### PR TITLE
Use partial interface Location

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1238,6 +1238,7 @@ that is exposed via <code>window.location.fragmentDirective</code> if the UA
 supports the feature.
 
 <pre class='idl'>
+  [Exposed=Window]
   interface FragmentDirective {
   };
 </pre>
@@ -1246,8 +1247,8 @@ We amend the {{Location}} interface to include a <code>fragmentDirective</code>
 property:
 
 <pre class='idl'>
-  interface Location {
-      readonly attribute FragmentDirective fragmentDirective;
+  partial interface Location {
+      [SameObject] readonly attribute FragmentDirective fragmentDirective;
   };
 </pre>
 


### PR DESCRIPTION
Fixes https://github.com/WICG/scroll-to-text-fragment/issues/106.

Drive-by: [Exposed=Window] and [SameObject]


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/ScrollToTextFragment/pull/111.html" title="Last updated on Jun 3, 2020, 1:10 PM UTC (f192109)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/111/8dcce57...foolip:f192109.html" title="Last updated on Jun 3, 2020, 1:10 PM UTC (f192109)">Diff</a>