### PR TITLE
Update the repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Text Fragments
 
-[Draft Spec](https://wicg.github.io/ScrollToTextFragment)  
+[Draft Spec](https://wicg.github.io/scroll-to-text-fragment/)  
 [Web Platform Tests](https://wpt.fyi/results/scroll-to-text-fragment?label=experimental&label=master&aligned)  
 [ChromeStatus entry](https://chromestatus.com/feature/4733392803332096)  
 
@@ -23,7 +23,7 @@ parts of pages are addressable by named anchors or elements with ids.
 
 ### Current Status
 
-This feature, as currently [specified in this repo](https://wicg.github.io/ScrollToTextFragment),
+This feature, as currently [specified in this repo](https://wicg.github.io/scroll-to-text-fragment/),
 is shipping to stable channel in Chrome M80.
 
 We're currently adding the ability for authors to disable this feature on their

--- a/index.bs
+++ b/index.bs
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Status: CG-DRAFT
 Title: Text Fragments
-ED: https://wicg.github.io/ScrollToTextFragment/
+ED: https://wicg.github.io/scroll-to-text-fragment/
 Shortname: text-fragments
 Level: 1
 Editor: Nick Burris, Google https://www.google.com, nburris@chromium.org

--- a/index.html
+++ b/index.html
@@ -1476,7 +1476,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt>This version:
      <dd><a class="u-url" href="https://wicg.github.io/scroll-to-text-fragment/">https://wicg.github.io/scroll-to-text-fragment/</a>
      <dt>Issue Tracking:
-     <dd><a href="https://wicg.github.io/scroll-to-text-fragment/issues/">GitHub</a>
+     <dd><a href="https://github.com/wicg/scroll-to-text-fragment/issues/">GitHub</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:nburris@chromium.org">Nick Burris</a> (<a class="p-org org" href="https://www.google.com">Google</a>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:bokan@chromium.org">David Bokan</a> (<a class="p-org org" href="https://www.google.com">Google</a>)

--- a/index.html
+++ b/index.html
@@ -1223,7 +1223,7 @@ Possible extra rowspan handling
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 19c1873c, updated Thu Jun 4 14:44:17 2020 -0700" name="generator">
-  <link href="https://wicg.github.io/ScrollToTextFragment/" rel="canonical">
+  <link href="https://wicg.github.io/scroll-to-text-fragment/" rel="canonical">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1474,9 +1474,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://wicg.github.io/ScrollToTextFragment/">https://wicg.github.io/ScrollToTextFragment/</a>
+     <dd><a class="u-url" href="https://wicg.github.io/scroll-to-text-fragment/">https://wicg.github.io/scroll-to-text-fragment/</a>
      <dt>Issue Tracking:
-     <dd><a href="https://github.com/wicg/ScrollToTextFragment/issues/">GitHub</a>
+     <dd><a href="https://wicg.github.io/scroll-to-text-fragment/issues/">GitHub</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:nburris@chromium.org">Nick Burris</a> (<a class="p-org org" href="https://www.google.com">Google</a>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:bokan@chromium.org">David Bokan</a> (<a class="p-org org" href="https://www.google.com">Google</a>)


### PR DESCRIPTION
`s/ScrollToTextFragment/scroll-to-text-fragment/g`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tomayac/scroll-to-text-fragment/pull/124.html" title="Last updated on Jun 25, 2020, 1:56 PM UTC (46af308)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/124/1708d3f...tomayac:46af308.html" title="Last updated on Jun 25, 2020, 1:56 PM UTC (46af308)">Diff</a>