### PR TITLE
[README] Correct typo in `Directives and Delimiters` sub-section

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ believe this is a safe choice.
 
 #### Directives and Delimiters
 
-When appending the `:~: token to a URL, it must appear inside a fragment so a
+When appending the `:~:` token to a URL, it must appear inside a fragment so a
 `#` must also be added:
 
 `https://example.com` --> `https://example.com#:~:text=foo`


### PR DESCRIPTION
I noticed that a " ` " mark was missing, so I decided to add that. 😃 