### PR TITLE
Change window.fragmentDirective to document.fragmentDirective

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,29 @@ Note: the fragment directive behavior (stripping everything after and including
 the `:~:` delimiter from the fragment) can be implemented independently of the
 larger proposal.
 
+### Feature Detection and Future APIs
+
+An author may wish to detect whether a UA has implemented support for
+text-fragments. This can be used by pages that generate such links to avoid
+generating fragment-directives for non-implementing UAs. It can also be used by
+libraries or authors to strip the fragment-directive from user or author
+generated links.
+
+This proposal includes a new property on the `document` object:
+
+```
+document.fragmentDirective
+```
+
+Authors can check for the existence of this (currently empty) object to
+determine if a UA has implemented support for text-fragments.
+
+This also serves as an extension point for future APIs. For example, we'd like
+to expose information about the text-fragments included in the URL so that
+authors can build functionality on it. See
+[#128](https://github.com/WICG/scroll-to-text-fragment/issues/128) for more
+details.
+
 ### :target
 
 For element-id based fragments (e.g.

--- a/index.bs
+++ b/index.bs
@@ -1302,23 +1302,26 @@ persisted user state</a> steps by inserting a new step after 2:
 ## Feature Detectability ## {#feature-detectability}
 
 For feature detectability, we propose adding a new FragmentDirective interface
-that is exposed via <code>window.location.fragmentDirective</code> if the UA
-supports the feature.
+that is exposed via <code>document.fragmentDirective</code> if the UA supports
+the feature.
 
 <pre class='idl'>
-  [Exposed=Window]
+  [Exposed=Document]
   interface FragmentDirective {
   };
 </pre>
 
-We amend the {{Location}} interface to include a <code>fragmentDirective</code>
+We amend the {{Document}} interface to include a <code>fragmentDirective</code>
 property:
 
 <pre class='idl'>
-  partial interface Location {
+  partial interface Document {
       [SameObject] readonly attribute FragmentDirective fragmentDirective;
   };
 </pre>
+
+This object may be used to expose additional information about the text
+fragment or other fragment directives in the future.
 
 # Generating Text Fragment Directives # {#generating-text-fragment-directives}
 

--- a/index.html
+++ b/index.html
@@ -1470,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-08-12">12 August 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-08-13">13 August 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2651,17 +2651,19 @@ value of this policy in the child <a data-link-type="dfn" href="https://dom.spec
    </ol>
    <h3 class="heading settled" data-level="3.8" id="feature-detectability"><span class="secno">3.8. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
-that is exposed via <code>window.location.fragmentDirective</code> if the UA
-supports the feature.</p>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+that is exposed via <code>document.fragmentDirective</code> if the UA supports
+the feature.</p>
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Document</c->]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="fragmentdirective"><code><c- g>FragmentDirective</c-></code></dfn> {
 };
 </pre>
-   <p>We amend the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/history.html#location" id="ref-for-location">Location</a></code> interface to include a <code>fragmentDirective</code> property:</p>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/history.html#location" id="ref-for-location①"><c- g>Location</c-></a> {
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject" id="ref-for-SameObject"><c- g>SameObject</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Location" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-location-fragmentdirective"></a></dfn>;
+   <p>We amend the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> interface to include a <code>fragmentDirective</code> property:</p>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①"><c- g>Document</c-></a> {
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject" id="ref-for-SameObject"><c- g>SameObject</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-document-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-document-fragmentdirective"></a></dfn>;
 };
 </pre>
+   <p>This object may be used to expose additional information about the text
+fragment or other fragment directives in the future.</p>
    <h2 class="heading settled" data-level="4" id="generating-text-fragment-directives"><span class="secno">4. </span><span class="content">Generating Text Fragment Directives</span><a class="self-link" href="#generating-text-fragment-directives"></a></h2>
    <div class="note" role="note"> This section is non-normative. </div>
    <p>This section contains recommendations for UAs automatically generating URLs
@@ -2930,7 +2932,7 @@ match based on whether the element-id was scrolled.</p>
      <li><a href="#fragmentdirective">(interface)</a><span>, in §3.8</span>
      <li><a href="#fragmentdirectiveproduction">definition of</a><span>, in §3.3.2</span>
     </ul>
-   <li><a href="#dom-location-fragmentdirective">fragmentDirective</a><span>, in §3.8</span>
+   <li><a href="#dom-document-fragmentdirective">fragmentDirective</a><span>, in §3.8</span>
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §3.3.1</span>
    <li><a href="#get-boundary-point-at-index">get boundary point at index</a><span>, in §3.5.2</span>
    <li><a href="#has-block-level-display">has block-level display</a><span>, in §3.5.2</span>
@@ -3045,6 +3047,12 @@ match based on whether the element-id was scrolled.</p>
    <ul>
     <li><a href="#ref-for-scroll-an-element-into-view">3.5. Navigating to a Text Fragment</a>
     <li><a href="#ref-for-scroll-an-element-into-view①">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-an-element-into-view②">(2)</a> <a href="#ref-for-scroll-an-element-into-view③">(3)</a> <a href="#ref-for-scroll-an-element-into-view④">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-document">
+   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-document">3.8. Feature Detectability</a> <a href="#ref-for-document①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-text">
@@ -3294,12 +3302,6 @@ match based on whether the element-id was scrolled.</p>
    <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlvideoelement">3.5.2. Finding Ranges in a Document</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-location">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#location">https://html.spec.whatwg.org/multipage/history.html#location</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-location">3.8. Feature Detectability</a> <a href="#ref-for-location①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-being-rendered">
@@ -3562,6 +3564,7 @@ match based on whether the element-id was scrolled.</p>
    <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
+     <li><span class="dfn-paneled" id="term-for-document" style="color:initial">Document</span>
      <li><span class="dfn-paneled" id="term-for-text" style="color:initial">Text</span>
      <li><span class="dfn-paneled" id="term-for-concept-range-bp-after" style="color:initial">after</span>
      <li><span class="dfn-paneled" id="term-for-concept-range-bp" style="color:initial">boundary point</span>
@@ -3614,7 +3617,6 @@ match based on whether the element-id was scrolled.</p>
      <li><span class="dfn-paneled" id="term-for-htmlscriptelement" style="color:initial">HTMLScriptElement</span>
      <li><span class="dfn-paneled" id="term-for-htmlstyleelement" style="color:initial">HTMLStyleElement</span>
      <li><span class="dfn-paneled" id="term-for-htmlvideoelement" style="color:initial">HTMLVideoElement</span>
-     <li><span class="dfn-paneled" id="term-for-location" style="color:initial">Location</span>
      <li><span class="dfn-paneled" id="term-for-being-rendered" style="color:initial">being rendered</span>
      <li><span class="dfn-paneled" id="term-for-concept-document-bc" style="color:initial">browsing context</span>
      <li><span class="dfn-paneled" id="term-for-browsing-context-set" style="color:initial">browsing context set</span>
@@ -3705,12 +3707,12 @@ match based on whether the element-id was scrolled.</p>
    <dd>A. Phillips; M. Davis. <a href="https://tools.ietf.org/html/bcp47">Tags for Identifying Languages</a>. September 2009. IETF Best Current Practice. URL: <a href="https://tools.ietf.org/html/bcp47">https://tools.ietf.org/html/bcp47</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Document</c->]
 <c- b>interface</c-> <a href="#fragmentdirective"><code><c- g>FragmentDirective</c-></code></a> {
 };
 
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/history.html#location"><c- g>Location</c-></a> {
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject"><c- g>SameObject</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective"><c- n>FragmentDirective</c-></a> <a data-readonly data-type="FragmentDirective" href="#dom-location-fragmentdirective"><code><c- g>fragmentDirective</c-></code></a>;
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document"><c- g>Document</c-></a> {
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject"><c- g>SameObject</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#fragmentdirective"><c- n>FragmentDirective</c-></a> <a data-readonly data-type="FragmentDirective" href="#dom-document-fragmentdirective"><code><c- g>fragmentDirective</c-></code></a>;
 };
 
 </pre>


### PR DESCRIPTION
Fixes #130


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/ScrollToTextFragment/pull/134.html" title="Last updated on Aug 13, 2020, 9:27 PM UTC (2317c4f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/134/60f5f63...bokand:2317c4f.html" title="Last updated on Aug 13, 2020, 9:27 PM UTC (2317c4f)">Diff</a>