### PR TITLE
Relax word boundary requirement on prefix&suffix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -959,8 +959,9 @@ following steps:
     1. Let |potentialMatch| be null.
     1. If |parsedValues|'s [=ParsedTextDirective/prefix=] is not null:
         1. Let |prefixMatch| be the the result of running the [=find a string
-            in range=] steps given |parsedValues|'s [=ParsedTextDirective/prefix=] and
-            |searchRange|.
+            in range=] steps with |query| |parsedValues|'s
+            [=ParsedTextDirective/prefix=], |searchRange| |searchRange|,
+            |wordStartBounded| true and |wordEndBounded| false.
         1. If |prefixMatch| is null, return null.
         1. Set |searchRange|'s [=range/start=] to the first [=/boundary point=]
             [=boundary point/after=] |prefixMatch|'s [=range/start=]
@@ -979,9 +980,15 @@ following steps:
               |matchRange|'s [=range/start=] now points to the next
               non-whitespace text data following a matched prefix.
             </div>
+        1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
+            [=ParsedTextDirective/textEnd=] is non-null or
+            |parsedValues|'s [=ParsedTextDirective/suffix=] is null, false
+            otherwise.
         1. Set |potentialMatch| to the result of running the [=find a string in
-            range=] steps given |parsedValues|'s
-            [=ParsedTextDirective/textStart=] and |matchRange|.
+            range=] steps with |query| |parsedValues|'s
+            [=ParsedTextDirective/textStart=], |searchRange| |matchRange|,
+            |wordStartBounded| false, and |wordEndBounded|
+            |mustEndAtWordBoundary|.
         1. If |potentialMatch| is null, return null.
         1. If |potentialMatch|'s [=range/start=] is not |matchRange|'s
             [=range/start=], then [=iteration/continue=].
@@ -991,9 +998,15 @@ following steps:
               next instance of [=ParsedTextDirective/prefix=].
             </div>
     1. Otherwise:
+        1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
+            [=ParsedTextDirective/textEnd=] is non-null or
+            |parsedValues|'s [=ParsedTextDirective/suffix=] is null, false
+            otherwise.
         1. Set |potentialMatch| to the result of running the [=find a string in
-            range=] steps given |parsedValues|'s
-            [=ParsedTextDirective/textStart=] and |searchRange|.
+            range=] steps with |query| |parsedValues|'s
+            [=ParsedTextDirective/textStart=], |searchRange| |searchRange|,
+            |wordStartBounded| true, and |wordEndBounded|
+            |mustEndAtWordBoundary|.
         1. If |potentialMatch| is null, return null.
         1. Set |searchRange|'s [=range/start=] to the first [=/boundary point=]
             [=boundary point/after=] |potentialMatch|'s [=range/start=]
@@ -1002,9 +1015,13 @@ following steps:
         1. Let |textEndRange| be a [=range=] whose [=range/start=] is
             |potentialMatch|'s [=range/end=] and whose [=range/end=] is
             |searchRange|'s [=range/end=].
+        1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
+            [=ParsedTextDirective/suffix=] is null, false otherwise.
         1. Let |textEndMatch| be the result of running the [=find a string
-            in range=] steps given |parsedValues|'s
-            [=ParsedTextDirective/textEnd=] and |textEndRange|.
+            in range=] steps with |query| |parsedValues|'s
+            [=ParsedTextDirective/textEnd=], |searchRange| |textEndRange|,
+            |wordStartBounded| true, and |wordEndBounded|
+            |mustEndAtWordBoundary|.
         1. If |textEndMatch| is null then return null.
         1. Set |potentialMatch|'s [=range/end=] to |textEndMatch|'s
             [=range/end=].
@@ -1018,8 +1035,9 @@ following steps:
     1. Advance |suffixRange|'s [=range/start=] to the [=next non-whitespace
         position=].
     1. Let |suffixMatch| be result of running the [=find a string in range=]
-        steps given |parsedValues|'s [=ParsedTextDirective/suffix=] and
-        |suffixRange|.
+        steps with |query| |parsedValues|'s [=ParsedTextDirective/suffix=],
+        |searchRange| |suffixRange|, |wordStartBounded| false, and
+        |wordEndBounded| true.
     1. If |suffixMatch| is null then return null.
         <div class="note">
           If the suffix doesn't appear in the remaining text of the document,
@@ -1060,16 +1078,17 @@ non-whitespace position</dfn> follow the steps:
         1. Add 1 to |range|'s [=range/start offset=].
     1. If |range|'s [=range/start offset=] is equal to |node|'s
         [=Node/length=], set |range|'s [=range/start node=] to the next node in
-        [=shadow-including tree order=], and set its [=range/start offset=] to
-        0.
+        [=shadow-including tree order=], and set its [=range/start offset=] to 0.
 
-To <dfn>find a string in range</dfn> for a <a spec=infra>string</a> |query|
-in a given [=range=] |searchRange|, run these steps:
+To <dfn>find a string in range</dfn> given a <a spec=infra>string</a> |query|, a
+[=range=] |searchRange|, and booleans |wordStartBounded| and |wordEndBounded|,
+run these steps:
 
 <div class="note">
-  This algorithm will return a [=range=] that represents the first [=word
-  bounded=] instance of the |query| text that is fully contained within
-  |searchRange|. Returns null if none is found.
+  This algorithm will return a [=range=] that represents the first instance of
+  the |query| text that is fully contained within |searchRange|, optionally
+  restricting itself to matches that start and/or end at word boundaries (see
+  [[#word-boundaries]]). Returns null if none is found.
 </div>
 
 <div class="note">
@@ -1124,8 +1143,8 @@ in a given [=range=] |searchRange|, run these steps:
             |textNodeList|.
         1. Set |curNode| to the next node in [=shadow-including tree order=].
     1. Run the [=find a range from a node list=] steps given |query|,
-        |searchRange|, and |textNodeList|, as input. If the resulting [=range=]
-        is not null, then return it.
+        |searchRange|, |textNodeList|, |wordStartBounded| and |wordEndBounded|
+        as input. If the resulting [=range=] is not null, then return it.
     1. If |curNode| is null, then [=iteration/break=].
     1. [=/Assert=]: |curNode| [=tree/following|follows=] |searchRange|'s
         [=range/start node=].
@@ -1164,16 +1183,17 @@ To find the <dfn>nearest block ancestor</dfn> of a |node| follow the steps:
 1. Return |node|'s [=Node/node document=]'s [=document element=].
 
 To <dfn>find a range from a node list</dfn> given a search string |queryString|,
-a [=range=] |searchRange|, and a [=/list=] of {{Text}} nodes |nodes|, follow the
-steps:
+a [=range=] |searchRange|, a [=/list=] of {{Text}} nodes |nodes|, and booleans
+|wordStartBounded| and |wordEndBounded|, follow these steps:
 
 <div class="note">
-  This will only return a match if the matched text falls on word boundaries.
-  That is, the text match must begin and end on a word boundary. For example:
+  Optionally, this will only return a match if the matched text begins and/or
+  ends on a word boundary. For example:
 
   <div class="example">
-    “range” will match in “mountain range” but not in “color orange” nor
-    “forest ranger”.
+    The query string “range” will always match in “mountain range”, but
+    1. When requiring a word boundary at the beginning, it will not match in “color orange”.
+    2. When requiring a word boundary at the end, it will not match in “forest ranger”.
   </div>
 
   See [[#word-boundaries]] for details and more examples.
@@ -1205,10 +1225,13 @@ steps:
         index=] |matchIndex| run over |nodes| with |isEnd| false.
     1. Set |end| to the [=/boundary point=] result of [=get boundary point at
         index=] |endIx| run over |nodes| with |isEnd| true.
-    1. If the substring of |searchBuffer| starting at |matchIndex| and of length
-        |queryString|'s [=string/length=] is not [=word bounded=], given the <a
-        spec=html>language</a> from each of |start| and |end|'s [=boundary
-        point/nodes=] as the |startLocale| and |endLocale|:
+    1. If |wordStartBounded| is true and |matchIndex| is not a [=word start
+        boundary=] in |searchBuffer|, given the <a spec=html>language</a> from
+        |start|'s [=boundary point/node=] as the |locale|; or |wordEndBounded|
+        is true and |matchIndex| + |queryString|'s [=string/length=] &minus; 1
+        is not a [=word end boundary=] in |searchBuffer|, given the <a
+        spec=html>language</a> from |end|'s [=boundary point/node=] as the
+        |locale|:
         1. Set |searchStart| to |matchIndex| + 1.
         1. Set |matchIndex| to null.
 1. Let |endInset| be 0.
@@ -1282,21 +1305,14 @@ of {{Text}} nodes |nodes|, and a boolean |isEnd|, follow these steps:
   alphabet as valid, one-letter words.
 </p>
 
-To determine if a substring of a larger string is <dfn>word bounded</dfn>,
-given a <a spec=infra>string</a> |text|, an integer |startPosition|, number
-|count|, and locales |startLocale| and |endLocale|, follow these steps:
+A <dfn>locale</dfn> is a <a spec=infra>string</a> containing a valid [[BCP47]]
+language tag, or the empty string. An empty string indicates that the primary
+language is unknown.
 
-|startLocale| and |endLocale| must be a valid [[BCP47]] language tag, or the empty
-string. An empty string indicates that the primary language is unknown.
-
-<div class="note">
-  |startPosition| and |count| represent a substring in |text|. |startLocale|
-  and |endLocale| specifying the language of the string at each end of the
-  match.
-
-  |startPosition| and |count| are assumed to be valid in that they represent a
-  substring within the bounds of |text|.
-</div>
+A substring is <dfn>word bounded</dfn> in a <a spec=infra>string</a> |text|,
+given [=locales=] |startLocale| and |endLocale|, if both the position of its
+first code unit is a [=word start boundary=] given |startLocale|, and the
+position of its last code unit is a [=word end boundary=] given |endLocale|.
 
 <div class="note">
   Intuitively, a substring is word bounded if it neither begins nor ends in the
@@ -1311,20 +1327,37 @@ string. An empty string indicates that the primary language is unknown.
   determine what a valid word in the given locale is.
 </div>
 
-1. Using locale |startLocale|, let |left bound| be the last word boundary in
-    |text| that precedes |startPosition|th [=code point=] of |text|.
+To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
+<dfn>word start boundary</dfn>, given a [=locale=] |locale|, follow these steps:
+
+<div class="note">
+  |text| is assumed to be non-empty, and |position| to be within its bounds.
+</div>
+
+1. Using |locale|, let |left bound| be the last word boundary in |text| that
+    precedes |position|th [=code point=] of |text|.
     <div class="note">
-      A string will always contain at least 2 word boundaries: before the first
-      code point and after the last code point of the string.
+      There will always be at least one such boundary: at the start of |text|.
     </div>
-1. If the first [=code point=] of |text| following |left bound| is not at
-    position |startPosition| return false.
-1. Let |endPosition| be (|startPosition| + |count| &minus; 1).
-1. Using locale |endLocale|, let |right bound| be the first word boundary in
-    |text| after the |endPosition|th [=code point=].
-1. If the first [=code point=] of |text| preceding |right bound| is not at
-    position |endPosition| return false.
-1. Return true.
+1. If the first [=code point=] of |text| following |left bound| is at
+    |position| return true.
+1. Return false.
+
+To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
+<dfn>word end boundary</dfn>, given a [=locale=] |locale|, follow these steps:
+
+<div class="note">
+  |text| is assumed to be non-empty, and |position| to be within its bounds.
+</div>
+
+1. Using |locale|, let |right bound| be the first word boundary in |text| after
+    the |position|th [=code point=].
+    <div class="note">
+      There will always be at least one such boundary: at the end of |text|.
+    </div>
+1. If the first [=code point=] of |text| preceding |right bound| is at
+    |position| return true.
+1. Return false.
 
 <div class="example">
   The substring "mountain range" is word bounded within the string "An impressive

--- a/index.bs
+++ b/index.bs
@@ -1228,8 +1228,8 @@ a [=range=] |searchRange|, a [=/list=] of {{Text}} nodes |nodes|, and booleans
     1. If |wordStartBounded| is true and |matchIndex| is not a [=word start
         boundary=] in |searchBuffer|, given the <a spec=html>language</a> from
         |start|'s [=boundary point/node=] as the |locale|; or |wordEndBounded|
-        is true and |matchIndex| + |queryString|'s [=string/length=] &minus; 1
-        is not a [=word end boundary=] in |searchBuffer|, given the <a
+        is true and |matchIndex| + |queryString|'s [=string/length=] is not a
+        [=word end boundary=] in |searchBuffer|, given the <a
         spec=html>language</a> from |end|'s [=boundary point/node=] as the
         |locale|:
         1. Set |searchStart| to |matchIndex| + 1.
@@ -1311,8 +1311,8 @@ language is unknown.
 
 A substring is <dfn>word bounded</dfn> in a <a spec=infra>string</a> |text|,
 given [=locales=] |startLocale| and |endLocale|, if both the position of its
-first code unit is a [=word start boundary=] given |startLocale|, and the
-position of its last code unit is a [=word end boundary=] given |endLocale|.
+first character is a [=word start boundary=] given |startLocale|, and the
+position after its last character is a [=word end boundary=] given |endLocale|.
 
 <div class="note">
   Intuitively, a substring is word bounded if it neither begins nor ends in the
@@ -1331,32 +1331,32 @@ To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
 <dfn>word start boundary</dfn>, given a [=locale=] |locale|, follow these steps:
 
 <div class="note">
-  |text| is assumed to be non-empty, and |position| to be within its bounds.
+  |text| is assumed to be non-empty, and |position| to be a non-negative integer
+  less than or equal to its length.
 </div>
 
-1. Using |locale|, let |left bound| be the last word boundary in |text| that
-    precedes |position|th [=code point=] of |text|.
+1. Using |locale|, let |bound| be the last word boundary in |text| either before
+    or at |position|.
     <div class="note">
       There will always be at least one such boundary: at the start of |text|.
     </div>
-1. If the first [=code point=] of |text| following |left bound| is at
-    |position| return true.
+1. If |bound| is at |position| return true.
 1. Return false.
 
 To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
 <dfn>word end boundary</dfn>, given a [=locale=] |locale|, follow these steps:
 
 <div class="note">
-  |text| is assumed to be non-empty, and |position| to be within its bounds.
+  |text| is assumed to be non-empty, and |position| to be a non-negative integer
+  less than or equal to its length.
 </div>
 
-1. Using |locale|, let |right bound| be the first word boundary in |text| after
-    the |position|th [=code point=].
+1. Using |locale|, let |bound| be the first word boundary in |text| either at or
+    after |position|.
     <div class="note">
       There will always be at least one such boundary: at the end of |text|.
     </div>
-1. If the first [=code point=] of |text| preceding |right bound| is at
-    |position| return true.
+1. If |bound| is at |position| return true.
 1. Return false.
 
 <div class="example">

--- a/index.bs
+++ b/index.bs
@@ -1317,7 +1317,7 @@ after its last character [=is at a word boundary=] given |endLocale|.
 A number |position| <dfn>is at a word boundary</dfn> in a <a spec=infra>string</a>
 |text|, given a [=locale=] |locale|, if, using |locale|, either a [=word
 boundary=] immediately precedes the |position|th code unit, or |text|'s length
-equals |position| and |text| ends with a [=word boundary=].
+is more than 0 and |position| equals either 0 or |text|'s length.
 
 <div class="note">
   Intuitively, a substring is word bounded if it neither begins nor ends in the

--- a/index.bs
+++ b/index.bs
@@ -1188,7 +1188,7 @@ a [=range=] |searchRange|, a [=/list=] of {{Text}} nodes |nodes|, and booleans
 
 <div class="note">
   Optionally, this will only return a match if the matched text begins and/or
-  ends on a word boundary. For example:
+  ends on a [=word boundary=]. For example:
 
   <div class="example">
     The query string “range” will always match in “mountain range”, but
@@ -1291,10 +1291,10 @@ of {{Text}} nodes |nodes|, and a boolean |isEnd|, follow these steps:
 </div>
 
 <p>
-  A word boundary is defined in [[!UAX29]] in [[UAX29#Word_Boundaries]].
-  [[UAX29#Default_Word_Boundaries]] defines a default set of what constitutes a
-  word boundary, but as the specification mentions, a more sophisticated
-  algorithm should be used based on the locale.
+  A <dfn>word boundary</dfn> is defined in [[!UAX29]] in
+  [[UAX29#Word_Boundaries]]. [[UAX29#Default_Word_Boundaries]] defines a
+  default set of what constitutes a word boundary, but as the specification
+  mentions, a more sophisticated algorithm should be used based on the locale.
 </p>
 <p>
   Dictionary-based word bounding should take specific care in locales without a
@@ -1327,6 +1327,27 @@ position after its last character is a [=word end boundary=] given |endLocale|.
   determine what a valid word in the given locale is.
 </div>
 
+<div class="example">
+  <p>
+    Text fragments are restricted such that match terms, when combined with
+    their adjacent context terms, must be word bounded. For example, in a range
+    search like <code>prefix,textStart,textEnd,suffix</code>, both
+    <code>"prefix+textStart"</code> and <code>"textEnd+suffix"</code> must be
+    word bounded. In an exact search like <code>prefix,textStart,suffix</code>,
+    <code>"prefix+textStart+suffix"</code> must be word bounded.
+  </p>
+
+  <p>
+    The goal is that a third-party must already know the full tokens they are
+    matching against. A range match like <code>textStart,textEnd</code> must be
+    word bounded on the inside of the two terms; otherwise a third party could
+    use this repeatedly to try and reveal a token (e.g. on a page with
+    <code>"Balance: 123,456 $"</code>, a third-party could set
+    <code>prefix="Balance: ", textEnd="$"</code> and vary <code>textStart</code>
+    to try and guess the numeric token.
+  </p>
+</div>
+
 To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
 <dfn>word start boundary</dfn>, given a [=locale=] |locale|, follow these steps:
 
@@ -1335,8 +1356,12 @@ To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
   less than or equal to its length.
 </div>
 
-1. Using |locale|, let |bound| be the last word boundary in |text| either before
-    or at |position|.
+<div class="note">
+  |position| is a word start boundary if it is the first code unit of a word.
+</div>
+
+1. Using |locale|, let |bound| be the last [=word boundary=] in |text| either
+    before or at |position|.
     <div class="note">
       There will always be at least one such boundary: at the start of |text|.
     </div>
@@ -1351,8 +1376,12 @@ To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
   less than or equal to its length.
 </div>
 
-1. Using |locale|, let |bound| be the first word boundary in |text| either at or
-    after |position|.
+<div class="note">
+  |position| is a word end boundary if it is the final code unit of a word.
+</div>
+
+1. Using |locale|, let |bound| be the first [=word boundary=] in |text| either
+    at or after |position|.
     <div class="note">
       There will always be at least one such boundary: at the end of |text|.
     </div>

--- a/index.bs
+++ b/index.bs
@@ -1225,13 +1225,13 @@ a [=range=] |searchRange|, a [=/list=] of {{Text}} nodes |nodes|, and booleans
         index=] |matchIndex| run over |nodes| with |isEnd| false.
     1. Set |end| to the [=/boundary point=] result of [=get boundary point at
         index=] |endIx| run over |nodes| with |isEnd| true.
-    1. If |wordStartBounded| is true and |matchIndex| is not a [=word start
-        boundary=] in |searchBuffer|, given the <a spec=html>language</a> from
-        |start|'s [=boundary point/node=] as the |locale|; or |wordEndBounded|
-        is true and |matchIndex| + |queryString|'s [=string/length=] is not a
-        [=word end boundary=] in |searchBuffer|, given the <a
-        spec=html>language</a> from |end|'s [=boundary point/node=] as the
-        |locale|:
+    1. If |wordStartBounded| is true and |matchIndex| [=is at a word boundary|is
+        not at a word boundary=] in |searchBuffer|, given the <a
+        spec=html>language</a> from |start|'s [=boundary point/node=] as the
+        |locale|; or |wordEndBounded| is true and |matchIndex| + |queryString|'s
+        [=string/length=] [=is at a word boundary|is not at a word boundary=] in
+        |searchBuffer|, given the <a spec=html>language</a> from |end|'s
+        [=boundary point/node=] as the |locale|:
         1. Set |searchStart| to |matchIndex| + 1.
         1. Set |matchIndex| to null.
 1. Let |endInset| be 0.
@@ -1311,8 +1311,13 @@ language is unknown.
 
 A substring is <dfn>word bounded</dfn> in a <a spec=infra>string</a> |text|,
 given [=locales=] |startLocale| and |endLocale|, if both the position of its
-first character is a [=word start boundary=] given |startLocale|, and the
-position after its last character is a [=word end boundary=] given |endLocale|.
+first character [=is at a word boundary=] given |startLocale|, and the position
+after its last character [=is at a word boundary=] given |endLocale|.
+
+A number |position| <dfn>is at a word boundary</dfn> in a <a spec=infra>string</a>
+|text|, given a [=locale=] |locale|, if, using |locale|, either a [=word
+boundary=] immediately precedes the |position|th code unit, or |text|'s length
+equals |position| and |text| ends with a [=word boundary=].
 
 <div class="note">
   Intuitively, a substring is word bounded if it neither begins nor ends in the
@@ -1352,41 +1357,6 @@ position after its last character is a [=word end boundary=] given |endLocale|.
     For more details, refer to the [Security Review Doc](https://docs.google.com/document/d/1YHcl1-vE_ZnZ0kL2almeikAj2gkwCq8_5xwIae7PVik/edit#heading=h.78iny7nejmx2)
   </p>
 </div>
-
-A [=word boundary=] is at position N if it immediately precedes the code unit at
-position N, or is at the end of a non-empty string of length N.
-
-To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
-<dfn>word start boundary</dfn>, given a [=locale=] |locale|, follow these steps:
-
-<div class="note">
-  |text| is assumed to be non-empty, and |position| to be a non-negative integer
-  less than or equal to its length.
-</div>
-
-1. Using |locale|, let |bound| be the last [=word boundary=] in |text| either
-    before or at |position|.
-    <div class="note">
-      There will always be at least one such boundary: at the start of |text|.
-    </div>
-1. If |bound| is at |position| return true.
-1. Return false.
-
-To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
-<dfn>word end boundary</dfn>, given a [=locale=] |locale|, follow these steps:
-
-<div class="note">
-  |text| is assumed to be non-empty, and |position| to be a non-negative integer
-  less than or equal to its length.
-</div>
-
-1. Using |locale|, let |bound| be the first [=word boundary=] in |text| either
-    at or after |position|.
-    <div class="note">
-      There will always be at least one such boundary: at the end of |text|.
-    </div>
-1. If |bound| is at |position| return true.
-1. Return false.
 
 <div class="example">
   The substring "mountain range" is word bounded within the string "An impressive

--- a/index.bs
+++ b/index.bs
@@ -1330,11 +1330,12 @@ position after its last character is a [=word end boundary=] given |endLocale|.
 <div class="example">
   <p>
     Text fragments are restricted such that match terms, when combined with
-    their adjacent context terms, must be word bounded. For example, in a range
-    search like <code>prefix,textStart,textEnd,suffix</code>, both
+    their adjacent context terms, must be word bounded. For example, in an
+    exact search like <code>prefix,textStart,suffix</code>,
+    <code>"prefix+textStart+suffix"</code> must be word bounded. However, in a
+    range search like <code>prefix,textStart,textEnd,suffix</code>, both
     <code>"prefix+textStart"</code> and <code>"textEnd+suffix"</code> must be
-    word bounded. In an exact search like <code>prefix,textStart,suffix</code>,
-    <code>"prefix+textStart+suffix"</code> must be word bounded.
+    word bounded.
   </p>
 
   <p>
@@ -1344,9 +1345,16 @@ position after its last character is a [=word end boundary=] given |endLocale|.
     use this repeatedly to try and reveal a token (e.g. on a page with
     <code>"Balance: 123,456 $"</code>, a third-party could set
     <code>prefix="Balance: ", textEnd="$"</code> and vary <code>textStart</code>
-    to try and guess the numeric token.
+    to try and guess the numeric token one digit at a time).
+  </p>
+  
+  <p>
+    For more details, refer to the [Security Review Doc](https://docs.google.com/document/d/1YHcl1-vE_ZnZ0kL2almeikAj2gkwCq8_5xwIae7PVik/edit#heading=h.78iny7nejmx2)
   </p>
 </div>
+
+A [=word boundary=] is at position N if it immediately precedes the code unit at
+position N.
 
 To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
 <dfn>word start boundary</dfn>, given a [=locale=] |locale|, follow these steps:
@@ -1354,10 +1362,6 @@ To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
 <div class="note">
   |text| is assumed to be non-empty, and |position| to be a non-negative integer
   less than or equal to its length.
-</div>
-
-<div class="note">
-  |position| is a word start boundary if it is the first code unit of a word.
 </div>
 
 1. Using |locale|, let |bound| be the last [=word boundary=] in |text| either
@@ -1374,10 +1378,6 @@ To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
 <div class="note">
   |text| is assumed to be non-empty, and |position| to be a non-negative integer
   less than or equal to its length.
-</div>
-
-<div class="note">
-  |position| is a word end boundary if it is the final code unit of a word.
 </div>
 
 1. Using |locale|, let |bound| be the first [=word boundary=] in |text| either

--- a/index.bs
+++ b/index.bs
@@ -1347,14 +1347,14 @@ position after its last character is a [=word end boundary=] given |endLocale|.
     <code>prefix="Balance: ", textEnd="$"</code> and vary <code>textStart</code>
     to try and guess the numeric token one digit at a time).
   </p>
-  
+
   <p>
     For more details, refer to the [Security Review Doc](https://docs.google.com/document/d/1YHcl1-vE_ZnZ0kL2almeikAj2gkwCq8_5xwIae7PVik/edit#heading=h.78iny7nejmx2)
   </p>
 </div>
 
 A [=word boundary=] is at position N if it immediately precedes the code unit at
-position N.
+position N, or is at the end of a non-empty string of length N.
 
 To determine if an integer |position| in a <a spec=infra>string</a> |text| is a
 <dfn>word start boundary</dfn>, given a [=locale=] |locale|, follow these steps:


### PR DESCRIPTION
As discussed in issue #137, there is no need to require the prefix to end at a word boundary, or the suffix to start at a boundary. This PR therefore removes this requirement.

I initially intended to also refactor the algorithms as mentioned in #137: separating the word boundary check from the search, running it only after a match has been found as an ‘acceptability check’ that could then be made optional for pages without inform. However that would be quite an effort (it would require access to the concatenated text nodes again), so instead I added arguments `wordStartBounded` and `wordEndBounded` that are passed down with the appropriate values for every piece that is being searched.

Feel free to tweak any parts. In the process I made a couple of changes that may require extra attention and reconsideration:
- I tentatively turned the description of ‘locale’ into a definition because it is being used as a parameter type; but I don’t know if that is desirable. (perhaps it could better be called a ‘language tag’, while linking to ‘[language][]’ in the WHATWG HTML spec?)
- I noticed that the current spec for determining whether a substring is word bounded handles the difference between code points and code units rather confusingly. I included a commit with a suggested improvement. To simplify things it treats word boundaries as having a numerical position, much like the offset of a BoundaryPoint.
- Relatedly, I am not sure whether making a difference between a word start boundary and a word end boundary is even needed, and perhaps we could just go with a single definition instead. The existing definition tests whether the first boundary before/after the code point at _position_ is followed/preceded by the code point at _position_; couldn’t it just ask whether there is a word boundary at _position_? I did not simplify it that far as it was not clear to me why the current approach was written the way it is, and hence I might be overlooking some relevant concerns.
- I kept a definition in place for a substring being word bounded; it is however not referred to, so I suppose it could just as well be omitted. Some notes and examples could also be revisited if the concept of being word bounded is replaced by being start-bounded and end-bounded.
- I used the terms start-bounded and end-bounded, instead of left-bounded and right-bounded, to avoid assuming a specific writing direction. It sounds a bit less natural though.

I tested the changes by updating the polyfill I made, see the word-boundaries [branch][], or try it out [here][].

[language]: https://html.spec.whatwg.org/multipage/dom.html#language
[branch]: https://code.treora.com/gerben/text-fragments-ts/src/branch/word-boundaries
[here]: https://temp.treora.com/text-fragments-ts-word-boundaries/demo.html#:~:text=poi-,i,-nt


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Treora/scroll-to-text-fragment/pull/148.html" title="Last updated on Oct 22, 2020, 10:50 AM UTC (9060c8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/148/2475249...Treora:9060c8c.html" title="Last updated on Oct 22, 2020, 10:50 AM UTC (9060c8c)">Diff</a>