### PR TITLE
Spec: Improve fragment stripping

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -16,13 +16,14 @@ WPT Display: inline
 </pre>
 
 <pre class='link-defaults'>
-spec:html; type:dfn; for:/; text:origin
 spec:css-display-3; type:value; for:display; text:flex
 spec:css-display-3; type:value; for:display; text:grid
 spec:dom; type:dfn; for:/; text:element
 spec:html; type:element; text:link
+spec:html; type:dfn; for:/; text:origin
 spec:html; type:element; text:script
 spec:html; type:element; text:style
+spec:url; type:dfn; text:fragment
 </pre>
 
 <pre class="biblio">
@@ -173,27 +174,7 @@ example" in "here is an example text".
 
 To avoid compatibility issues with usage of existing URL fragments, this spec
 introduces the [=fragment directive=]. The [=fragment directive=] is a portion
-of the URL fragment delimited by the code sequence <code>:~:</code>. It is
-reserved for UA instructions, such as text=, and is stripped from the URL
-during loading so that author scripts can't directly interact with it.
-
-The [=fragment directive=] is a mechanism for URLs to specify instructions meant
-for the UA rather than the document. It's meant to avoid direct interaction with
-author script so that future UA instructions can be added without fear of
-introducing breaking changes to existing content. Potential examples could be:
-translation-hints or enabling accessibility features.
-
-### Parsing the fragment directive ### {#parsing-the-fragment-directive}
-
-To the definition of [=Document=], add:
-
->   <strong>Monkeypatching [[HTML]]:</strong>
->
->   <em>
->     Each document has an associated <dfn>fragment directive</dfn> which is
->     either null or an ASCII string holding data used by the UA to process the
->     resource. It is initially null.
->   </em>
+of the URL [=url/fragment=] that follows the [=fragment directive delimiter=].
 
 The <dfn>fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).
@@ -208,40 +189,56 @@ three consecutive code points U+003A (:), U+007E (~), U+003A (:).
   must first be appended to the URL: https://example.com#:~:text=foo.
 </div>
 
+The fragment directive is meant to carry instructions, such as
+<code>text=</code>, for the UA rather than for the document.
 
-Amend the
-<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">
-create and initialize a Document object</a> steps to parse and remove the
-[=fragment directive=] from the Document's [=Document/URL=].
+To prevent impacting page operation, it is stripped from a [=Document=]'s
+[=Document/URL=] so that author scripts can't directly interact with it. This
+also ensures future directives could be added without introducing breaking
+changes to existing content.  Potential examples could be: image-fragments,
+translation-hints.
 
-Replace steps 7 and 8 of this algorithm with:
+
+### Processing the fragment directive ### {#processing-the-fragment-directive}
+
+The fragment directive is processed and removed from the fragment whenever the
+UA sets the [=Document/URL=] on a [=Document=]. This is defined with the
+following additions and changes.
+
+To the definition of [=Document=], add:
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   7. Let |url| be null
->   8. If |request| is non-null, then set |document|'s [=Document/URL=] to
->       |request|'s [=request/current URL=].
->   9. Otherwise, set |url| to <var ignore=''>response</var>'s [=response/URL=].
->   10. Let |raw fragment| be equal to |url|'s [=url/fragment=].
->   11. If |raw fragment| is non-null:
->       1. Let |fragmentDirectivePosition| be an integer initialized to 0.
->       2. While the substring of |raw fragment| starting at position
->           |fragmentDirectivePosition| does not begin with the [=fragment directive
->           delimiter=] and |fragmentDirectivePosition| does not point past the end
->           of |raw fragment|:
->           1. Increment |fragmentDirectivePosition| by 1.
->       3. If |fragmentDirectivePosition| does not point past the end of |raw
->           fragment|:
->           1. Let |fragment| be the substring of |raw fragment| starting at 0 of
->               count |fragmentDirectivePosition|.
->           1. Advance |fragmentDirectivePosition| by the length of [=fragment
->               directive delimiter=].
->           1. Let |fragment directive| be the substring of |raw fragment| starting
->               at |fragmentDirectivePosition|.
->           1. Set |url|'s [=url/fragment=] to |fragment|.
->           1. Set |document|'s [=fragment directive=] to |fragment directive|.
->               (Note: this is stored on the document but not web-exposed)
->   12. Set |document|'s [=Document/URL=] to be |url|.
+>   <em>
+>     Each document has an associated <dfn>fragment directive</dfn> which is
+>     either null or an ASCII string holding data used by the UA to process the
+>     resource. It is initially null.
+>   </em>
+
+Whenever the fragment directive is stripped from the URL, it is set to the
+Document's [=fragment directive=].
+
+Add a series of steps that will process a fragment directive on a [=Document/URL=]:
+
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   To <dfn>process and consume fragment directive</dfn> from a [=/URL=]
+>   |url| and [=Document=] |document|, run these steps:
+>   1. Let |raw fragment| be equal to |url|'s [=url/fragment=].
+>   1. If |raw fragment| is non-null and contains the [=fragment directive
+>       delimiter=] as a substring:
+>       1. Let |fragmentDirectivePosition| be the index of the first instance
+>           of the [=fragment directive delimiter=] in |raw fragment|.
+>       1. Let |fragment| be the substring of |raw fragment| starting at 0 of
+>           count |fragmentDirectivePosition|.
+>       1. Advance |fragmentDirectivePosition| by the length of [=fragment
+>           directive delimiter=].
+>       1. Let |fragment directive| be the substring of |raw fragment| starting
+>           at |fragmentDirectivePosition|.
+>       1. Set |url|'s [=url/fragment=] to |fragment|.
+>       1. Set |document|'s [=fragment directive=] to |fragment directive|.
+>           <div class="note">This is stored on the document but currently not
+>           web-exposed</div>
 
 <div class="note">
   These changes make a URL's fragment end at the [=fragment directive
@@ -254,6 +251,145 @@ Replace steps 7 and 8 of this algorithm with:
 the fragment is the string "test" and the [=fragment directive=] is the string
 "text=foo".
 </div>
+
+
+Amend the
+<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">
+create and initialize a Document object</a> steps to parse and remove the
+[=fragment directive=] by inserting the following steps right before the
+setting |document|'s [=Document/URL=]
+(<a href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#initialise-the-document-object">currently</a>
+step 9):
+
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   9. Run the [=process and consume fragment directive=] steps on
+>     |creationURL| and |document|.
+>   10. Set |document|'s [=Document/URL=] to be |creationURL|.
+
+Amend the
+<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history">
+traverse the history</a> steps to process the [=fragment directive=]
+during a history navigation by inserting steps before setting the |newDocument|'s URL (<a
+href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#traverse-the-history">currently</a>
+step 6).
+
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   6. Let |processedURL| be a copy of <var ignore="">entry</var>'s URL.
+>   7. Run the [=process and consume fragment directive=] steps on
+>       |processedURL| and |document|.
+>   8. Set |newDocument|'s URL to |processedURL|.
+
+<div class="note">
+  <p>
+    The changes in this section imply that a URL is only stripped of its fragment
+    directive when it is set on a Document. Notably, since a window's
+    {{Location}} object is a representation of the [=/URL=] of the [=active
+    document=], all getters on it will show a fragment-directive-stripped
+    version of the URL.
+  </p>
+
+  <p>
+    Some examples should help clarify various edge cases.
+  </p>
+</div>
+
+<div class="example">
+  ```
+  window.location = 'https://example.com#foo:~:bar';
+  ```
+
+  The page loads and when the document's URL is set the fragment directive is
+  stripped out during the "create and initialize a Document object" steps.
+
+  ```
+  console.log(window.location.href); // 'https://example.com#foo'
+  console.log(window.location.hash); // '#foo'
+  ```
+
+  Since same document navigations are made by adding a new session history
+  entry and using the "traverse the history" steps, the the fragment directive
+  will be stripped here as well.
+
+  ```
+  window.location.hash = 'fizz:~:buzz';
+  console.log(window.location.href); // 'https://example.com#fizz'
+  console.log(window.location.hash); // '#fizz'
+  ```
+
+  The hashchange event is dispatched when only the fragment directive changes
+  because the comparison for it is done on the URLs in the session history
+  entries, where the fragment directive hasn't been removed.
+
+  ```
+  onhashchange = () => {console.log('HASHCHANGE');};
+  window.location.hash = 'fizz:~:zillch'; // 'HASHCHANGE'
+  console.log(window.location.href); // 'https://example.com#fizz'
+  console.log(window.location.hash); // '#fizz'
+  ```
+</div>
+
+<div class="example">
+  In other cases where a Document's URL is not set by the UA, there is no
+  fragment directive stripping.
+
+  For URL objects:
+
+  ```
+  let url = new URL('https://example.com#foo:~:bar');
+  console.log(url.href); // 'https://example.com#foo:~:bar'
+  console.log(url.hash); // '#foo:~:bar'
+
+  document.url = url;
+  console.log(document.url.href); // 'https://example.com#foo:~:bar'
+  console.log(document.url.hash); // '#foo:~:bar'
+
+  ```
+
+  The `<a>` or `<area>` elements:
+
+  ```
+  <a id='anchor' href="https://example.com#foo:~:bar">Anchor</a>
+  <script>
+    console.log(anchor.href); // 'https://example.com#foo:~:bar'
+    console.log(anchor.hash); // '#foo:~:bar'
+  </script>
+  ```
+</div>
+
+<div class="example">
+  History pushState will create a session history entry where the URL's
+  fragment directive isn't stripped. However, traversing to the entry will
+  cause it to set its URL on the document which will process the fragment
+  directive before setting it on the Document (but the fragment directive
+  remains on the entry).
+
+
+  ```
+  history.pushState({}, 'title', 'index.html#foo:~:bar');
+  window.location = 'newpage.html';
+  // on newpage.html
+  history.back();
+  ```
+
+  Results in the current document having "bar" as the fragment directive.
+</div>
+
+
+### Parsing the fragment directive ### {#parsing-the-fragment-directive}
+
+A <dfn>ParsedTextDirective</dfn> is a <a spec=infra>struct</a> that consists of
+four strings: <dfn for="ParsedTextDirective">textStart</dfn>,
+<dfn for="ParsedTextDirective">textEnd</dfn>,
+<dfn for="ParsedTextDirective">prefix</dfn>, and
+<dfn for="ParsedTextDirective">suffix</dfn>. [=ParsedTextDirective/textStart=]
+is required to be non-null. The other three items may be set to null,
+indicating they weren't provided. The empty string is not a valid value for any
+of these items.
+
+See [[#syntax]] for the what each of these components means and how they're
+used.
 
 <div algorithm="parse a text directive">
 
@@ -312,18 +448,6 @@ directive input|, run these steps:
     1. Return |retVal|.
   </ol>
 </div>
-
-A <dfn>ParsedTextDirective</dfn> is a <a spec=infra>struct</a> that consists of
-four strings: <dfn for="ParsedTextDirective">textStart</dfn>,
-<dfn for="ParsedTextDirective">textEnd</dfn>,
-<dfn for="ParsedTextDirective">prefix</dfn>, and
-<dfn for="ParsedTextDirective">suffix</dfn>. [=ParsedTextDirective/textStart=]
-is required to be non-null. The other three items may be set to null,
-indicating they weren't provided. The empty string is not a valid value for any
-of these items.
-
-See [[#syntax]] for the what each of these components means and how they're
-used.
 
 ### Fragment directive grammar ### {#fragment-directive-grammar}
 

--- a/index.html
+++ b/index.html
@@ -1867,8 +1867,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>
        <a href="#the-fragment-directive"><span class="secno">3.3</span> <span class="content">The Fragment Directive</span></a>
        <ol class="toc">
-        <li><a href="#parsing-the-fragment-directive"><span class="secno">3.3.1</span> <span class="content">Parsing the fragment directive</span></a>
-        <li><a href="#fragment-directive-grammar"><span class="secno">3.3.2</span> <span class="content">Fragment directive grammar</span></a>
+        <li><a href="#processing-the-fragment-directive"><span class="secno">3.3.1</span> <span class="content">Processing the fragment directive</span></a>
+        <li><a href="#parsing-the-fragment-directive"><span class="secno">3.3.2</span> <span class="content">Parsing the fragment directive</span></a>
+        <li><a href="#fragment-directive-grammar"><span class="secno">3.3.3</span> <span class="content">Fragment directive grammar</span></a>
        </ol>
       <li>
        <a href="#security-and-privacy"><span class="secno">3.4</span> <span class="content">Security and Privacy</span></a>
@@ -2003,84 +2004,165 @@ example" in "here is an example text". </div>
    <h3 class="heading settled" data-level="3.3" id="the-fragment-directive"><span class="secno">3.3. </span><span class="content">The Fragment Directive</span><a class="self-link" href="#the-fragment-directive"></a></h3>
    <p>To avoid compatibility issues with usage of existing URL fragments, this spec
 introduces the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①">fragment directive</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive②">fragment directive</a> is a portion
-of the URL fragment delimited by the code sequence <code>:~:</code>. It is
-reserved for UA instructions, such as text=, and is stripped from the URL
-during loading so that author scripts can’t directly interact with it.</p>
-   <p>The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive③">fragment directive</a> is a mechanism for URLs to specify instructions meant
-for the UA rather than the document. It’s meant to avoid direct interaction with
-author script so that future UA instructions can be added without fear of
-introducing breaking changes to existing content. Potential examples could be:
-translation-hints or enabling accessibility features.</p>
-   <h4 class="heading settled" data-level="3.3.1" id="parsing-the-fragment-directive"><span class="secno">3.3.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
-   <p>To the definition of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>, add:</p>
+of the URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment">fragment</a> that follows the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive delimiter</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-delimiter">fragment directive delimiter</dfn> is the string ":~:", that is the
+three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
+   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive③">fragment directive</a> is part of the URL fragment. This means it must
+  always appear after a U+0023 (#) code point in a URL. </div>
+   <div class="example" id="example-aa58e32d"><a class="self-link" href="#example-aa58e32d"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> to a URL like https://example.com, a fragment
+  must first be appended to the URL: https://example.com#:~:text=foo. </div>
+   <p>The fragment directive is meant to carry instructions, such as <code>text=</code>, for the UA rather than for the document.</p>
+   <p>To prevent impacting page operation, it is stripped from a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url">URL</a> so that author scripts can’t directly interact with it. This
+also ensures future directives could be added without introducing breaking
+changes to existing content.  Potential examples could be: image-fragments,
+translation-hints.</p>
+   <h4 class="heading settled" data-level="3.3.1" id="processing-the-fragment-directive"><span class="secno">3.3.1. </span><span class="content">Processing the fragment directive</span><a class="self-link" href="#processing-the-fragment-directive"></a></h4>
+   <p>The fragment directive is processed and removed from the fragment whenever the
+UA sets the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url①">URL</a> on a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">Document</a>. This is defined with the
+following additions and changes.</p>
+   <p>To the definition of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a>, add:</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
     <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is
     either null or an ASCII string holding data used by the UA to process the
     resource. It is initially null. </em></p>
    </blockquote>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-delimiter">fragment directive delimiter</dfn> is the string ":~:", that is the
-three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
-   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> is part of the URL fragment. This means it must
-  always appear after a U+0023 (#) code point in a URL. </div>
-   <div class="example" id="example-aa58e32d"><a class="self-link" href="#example-aa58e32d"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a> to a URL like https://example.com, a fragment
-  must first be appended to the URL: https://example.com#:~:text=foo. </div>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to parse and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> from the Document’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url">URL</a>.</p>
-   <p>Replace steps 7 and 8 of this algorithm with:</p>
+   <p>Whenever the fragment directive is stripped from the URL, it is set to the
+Document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a>.</p>
+   <p>Add a series of steps that will process a fragment directive on a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url②">URL</a>:</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
-    <ol start="7">
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-and-consume-fragment-directive">process and consume fragment directive</dfn> from a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">URL</a> <var>url</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a> <var>document</var>, run these steps:</p>
+    <ol>
      <li data-md>
-      <p>Let <var>url</var> be null</p>
+      <p>Let <var>raw fragment</var> be equal to <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment①">fragment</a>.</p>
      <li data-md>
-      <p>If <var>request</var> is non-null, then set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url①">URL</a> to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a>.</p>
-     <li data-md>
-      <p>Otherwise, set <var>url</var> to <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">URL</a>.</p>
-     <li data-md>
-      <p>Let <var>raw fragment</var> be equal to <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment">fragment</a>.</p>
-     <li data-md>
-      <p>If <var>raw fragment</var> is non-null:</p>
+      <p>If <var>raw fragment</var> is non-null and contains the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive
+  delimiter</a> as a substring:</p>
       <ol>
        <li data-md>
-        <p>Let <var>fragmentDirectivePosition</var> be an integer initialized to 0.</p>
+        <p>Let <var>fragmentDirectivePosition</var> be the index of the first instance
+  of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive delimiter</a> in <var>raw fragment</var>.</p>
        <li data-md>
-        <p>While the substring of <var>raw fragment</var> starting at position <var>fragmentDirectivePosition</var> does not begin with the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive
-  delimiter</a> and <var>fragmentDirectivePosition</var> does not point past the end
-  of <var>raw fragment</var>:</p>
-        <ol>
-         <li data-md>
-          <p>Increment <var>fragmentDirectivePosition</var> by 1.</p>
-        </ol>
-       <li data-md>
-        <p>If <var>fragmentDirectivePosition</var> does not point past the end of <var>raw
-  fragment</var>:</p>
-        <ol>
-         <li data-md>
-          <p>Let <var>fragment</var> be the substring of <var>raw fragment</var> starting at 0 of
+        <p>Let <var>fragment</var> be the substring of <var>raw fragment</var> starting at 0 of
   count <var>fragmentDirectivePosition</var>.</p>
-         <li data-md>
-          <p>Advance <var>fragmentDirectivePosition</var> by the length of <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment
+       <li data-md>
+        <p>Advance <var>fragmentDirectivePosition</var> by the length of <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter③">fragment
   directive delimiter</a>.</p>
-         <li data-md>
-          <p>Let <var>fragment directive</var> be the substring of <var>raw fragment</var> starting
+       <li data-md>
+        <p>Let <var>fragment directive</var> be the substring of <var>raw fragment</var> starting
   at <var>fragmentDirectivePosition</var>.</p>
-         <li data-md>
-          <p>Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment①">fragment</a> to <var>fragment</var>.</p>
-         <li data-md>
-          <p>Set <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> to <var>fragment directive</var>.
-  (Note: this is stored on the document but not web-exposed)</p>
-        </ol>
+       <li data-md>
+        <p>Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment②">fragment</a> to <var>fragment</var>.</p>
+       <li data-md>
+        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> to <var>fragment directive</var>.</p>
+        <div class="note" role="note">This is stored on the document but currently not
+  web-exposed</div>
       </ol>
-     <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url②">URL</a> to be <var>url</var>.</p>
     </ol>
    </blockquote>
-   <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive
-  delimiter</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> includes all characters that follow,
+   <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter④">fragment directive
+  delimiter</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> includes all characters that follow,
   but not including, the delimiter. </div>
    <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
-the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> is the string
+the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> is the string
 "text=foo". </div>
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to parse and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> by inserting the following steps right before the
+setting <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url③">URL</a> (<a href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#initialise-the-document-object">currently</a> step 9):</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <ol start="9">
+     <li data-md>
+      <p>Run the <a data-link-type="dfn" href="#process-and-consume-fragment-directive" id="ref-for-process-and-consume-fragment-directive">process and consume fragment directive</a> steps on <var>creationURL</var> and <var>document</var>.</p>
+     <li data-md>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url④">URL</a> to be <var>creationURL</var>.</p>
+    </ol>
+   </blockquote>
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history"> traverse the history</a> steps to process the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a> during a history navigation by inserting steps before setting the <var>newDocument</var>’s URL (<a href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#traverse-the-history">currently</a> step 6).</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <ol start="6">
+     <li data-md>
+      <p>Let <var>processedURL</var> be a copy of <var>entry</var>’s URL.</p>
+     <li data-md>
+      <p>Run the <a data-link-type="dfn" href="#process-and-consume-fragment-directive" id="ref-for-process-and-consume-fragment-directive①">process and consume fragment directive</a> steps on <var>processedURL</var> and <var>document</var>.</p>
+     <li data-md>
+      <p>Set <var>newDocument</var>’s URL to <var>processedURL</var>.</p>
+    </ol>
+   </blockquote>
+   <div class="note" role="note">
+    <p> The changes in this section imply that a URL is only stripped of its fragment
+    directive when it is set on a Document. Notably, since a window’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/history.html#location" id="ref-for-location">Location</a></code> object is a representation of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①">URL</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active
+    document</a>, all getters on it will show a fragment-directive-stripped
+    version of the URL. </p>
+    <p> Some examples should help clarify various edge cases. </p>
+   </div>
+   <div class="example" id="example-609a3312">
+    <a class="self-link" href="#example-609a3312"></a> 
+<pre>  window.location = 'https://example.com#foo:~:bar';
+</pre>
+    <p>The page loads and when the document’s URL is set the fragment directive is
+  stripped out during the "create and initialize a Document object" steps.</p>
+<pre>  console.log(window.location.href); // 'https://example.com#foo'
+  console.log(window.location.hash); // '#foo'
+</pre>
+    <p>Since same document navigations are made by adding a new session history
+  entry and using the "traverse the history" steps, the the fragment directive
+  will be stripped here as well.</p>
+<pre>  window.location.hash = 'fizz:~:buzz';
+  console.log(window.location.href); // 'https://example.com#fizz'
+  console.log(window.location.hash); // '#fizz'
+</pre>
+    <p>The hashchange event is dispatched when only the fragment directive changes
+  because the comparison for it is done on the URLs in the session history
+  entries, where the fragment directive hasn’t been removed.</p>
+<pre>  onhashchange = () => {console.log('HASHCHANGE');};
+  window.location.hash = 'fizz:~:zillch'; // 'HASHCHANGE'
+  console.log(window.location.href); // 'https://example.com#fizz'
+  console.log(window.location.hash); // '#fizz'
+</pre>
+   </div>
+   <div class="example" id="example-42953739">
+    <a class="self-link" href="#example-42953739"></a> In other cases where a Document’s URL is not set by the UA, there is no
+  fragment directive stripping. 
+    <p>For URL objects:</p>
+<pre>  let url = new URL('https://example.com#foo:~:bar');
+  console.log(url.href); // 'https://example.com#foo:~:bar'
+  console.log(url.hash); // '#foo:~:bar'
+
+  document.url = url;
+  console.log(document.url.href); // 'https://example.com#foo:~:bar'
+  console.log(document.url.hash); // '#foo:~:bar'
+
+</pre>
+    <p>The <code>&lt;a></code> or <code>&lt;area></code> elements:</p>
+<pre>  &lt;a id='anchor' href="https://example.com#foo:~:bar">Anchor&lt;/a>
+  &lt;script>
+    console.log(anchor.href); // 'https://example.com#foo:~:bar'
+    console.log(anchor.hash); // '#foo:~:bar'
+  &lt;/script>
+</pre>
+   </div>
+   <div class="example" id="example-c1edb88d">
+    <a class="self-link" href="#example-c1edb88d"></a> History pushState will create a session history entry where the URL’s
+  fragment directive isn’t stripped. However, traversing to the entry will
+  cause it to set its URL on the document which will process the fragment
+  directive before setting it on the Document (but the fragment directive
+  remains on the entry). 
+<pre>  history.pushState({}, 'title', 'index.html#foo:~:bar');
+  window.location = 'newpage.html';
+  // on newpage.html
+  history.back();
+</pre>
+    <p>Results in the current document having "bar" as the fragment directive.</p>
+   </div>
+   <h4 class="heading settled" data-level="3.3.2" id="parsing-the-fragment-directive"><span class="secno">3.3.2. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parsedtextdirective">ParsedTextDirective</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct">struct</a> that consists of
+four strings: <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-textstart">textStart</dfn>, <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-textend">textEnd</dfn>, <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-prefix">prefix</dfn>, and <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-suffix">suffix</dfn>. <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart">textStart</a> is required to be non-null. The other three items may be set to null,
+indicating they weren’t provided. The empty string is not a valid value for any
+of these items.</p>
+   <p>See <a href="#syntax">§ 3.2 Syntax</a> for the what each of these components means and how they’re
+used.</p>
    <div class="algorithm" data-algorithm="parse a text directive">
     <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parse-a-text-directive">parse a text directive</dfn>, on a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a> <var>text
 directive input</var>, run these steps:</p>
@@ -2137,22 +2219,16 @@ first character from <var>potential suffix</var>.</p>
       <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> not equal to 1 nor 2 then
 return null.</p>
      <li data-md>
-      <p>Set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart">textStart</a> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode②">percent-decoding</a> of the first item of <var>tokens</var>.</p>
+      <p>Set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart①">textStart</a> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode②">percent-decoding</a> of the first item of <var>tokens</var>.</p>
      <li data-md>
       <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size①">size</a> 2, then set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend">textEnd</a> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode③">percent-decoding</a> of the last item of <var>tokens</var>.</p>
      <li data-md>
       <p>Return <var>retVal</var>.</p>
     </ol>
    </div>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parsedtextdirective">ParsedTextDirective</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct">struct</a> that consists of
-four strings: <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-textstart">textStart</dfn>, <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-textend">textEnd</dfn>, <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-prefix">prefix</dfn>, and <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-suffix">suffix</dfn>. <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart①">textStart</a> is required to be non-null. The other three items may be set to null,
-indicating they weren’t provided. The empty string is not a valid value for any
-of these items.</p>
-   <p>See <a href="#syntax">§ 3.2 Syntax</a> for the what each of these components means and how they’re
-used.</p>
-   <h4 class="heading settled" data-level="3.3.2" id="fragment-directive-grammar"><span class="secno">3.3.2. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
+   <h4 class="heading settled" data-level="3.3.3" id="fragment-directive-grammar"><span class="secno">3.3.3. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive</dfn> is a sequence of characters that appears
-in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a> that matches the production:</p>
+in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> that matches the production:</p>
    <dl>
      <code> <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirectiveproduction">FragmentDirective</dfn> ::= </dt> <dd> (<a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a> | <a data-link-type="dfn" href="#unknowndirective" id="ref-for-unknowndirective">UnknownDirective</a>) ("&amp;" <a data-link-type="dfn" href="#fragmentdirectiveproduction" id="ref-for-fragmentdirectiveproduction">FragmentDirective</a>)? </dd> </code> <code> <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="unknowndirective">UnknownDirective</dfn> ::= </dt> <dd> <a data-link-type="dfn" href="#characterstring" id="ref-for-characterstring">CharacterString</a> </dd> </code> <code> <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="characterstring">CharacterString</dfn> ::= </dt> <dd> (<a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar">ExplicitChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+ </dd> </code> <code> <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="explicitchar">ExplicitChar</dfn> ::= </dt> <dd> [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
       ";" | "=" | "?" | "@" | "_" | "~" | "&amp;" | "," | "-" </dd> </code> 
@@ -2163,7 +2239,7 @@ in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-d
   multiple indicated strings in the page, but this also allows for future
   directive types to be added and combined. For extensibility, we do not fail to
   parse if an unknown directive is in the &amp;-separated list of directives. </div>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> that
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-fragment-directive">text fragment directive</dfn> is one such <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a> that
 enables specifying a piece of text on the page, that matches the production:</p>
    <dl>
      <code> <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective">TextDirective</dfn> ::=</dt> <dd>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></dd> </code> 
@@ -2266,7 +2342,7 @@ multiple solutions with differing tradeoffs. For example, a UA <em>may</em> cont
 text directive</a>.  Alternatively, it <em>may</em> schedule an asynchronous task
 to find and set the indicated part of the document.</p>
    <h4 class="heading settled" data-level="3.4.4" id="restricting-the-text-fragment"><span class="secno">3.4.4. </span><span class="content">Restricting the Text Fragment</span><a class="self-link" href="#restricting-the-text-fragment"></a></h4>
-   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">Document</a> to include a new
+   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a> to include a new
 field for the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken">textFragmentToken</a>:</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>:</strong></p>
@@ -2274,17 +2350,17 @@ field for the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref
    </blockquote>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
-    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-textfragmenttoken">textFragmentToken</dfn> flag that is
+    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-textfragmenttoken">textFragmentToken</dfn> flag that is
   consumed in order to allow a single activation of a text fragment. This flag is
   generated only during loading if the navigation occurs as a result of a user
   activation.</p>
-    <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①">textFragmentToken</a> isn’t consumed to activate
-  a text fragment, it may be consumed to set the <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken">textFragmentToken</a> flag of a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>. In this way, a <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken②">textFragmentToken</a> can be propagated from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a> to another across a navigation.</p>
-    <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken③">textFragmentToken</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken①">textFragmentToken</a> must always consume the value,
+    <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①">textFragmentToken</a> isn’t consumed to activate
+  a text fragment, it may be consumed to set the <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken">textFragmentToken</a> flag of a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>. In this way, a <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken②">textFragmentToken</a> can be propagated from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a> to another across a navigation.</p>
+    <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken③">textFragmentToken</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken①">textFragmentToken</a> must always consume the value,
   such that the token cannot be cloned.</p>
    </blockquote>
    <div class="note" role="note">
-    <p> A <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken④">textFragmentToken</a> is generated when a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> is loaded
+    <p> A <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken④">textFragmentToken</a> is generated when a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a> is loaded
     as a result of a user gesture. It grants its holder permission (in terms of
     user activation) to activate a single text fragment. Alternatively, it may be
     propagated through a navigation to allow a future document to activate a text
@@ -2315,7 +2391,7 @@ field for the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref
    </div>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
-    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allowtextfragmentdirective">allowTextFragmentDirective</dfn> flag that is used to determine whether a text fragment directive should be
+    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allowtextfragmentdirective">allowTextFragmentDirective</dfn> flag that is used to determine whether a text fragment directive should be
   allowed to activate. If this flag is false, the text fragment must not
   cause any observable effects.</p>
    </blockquote>
@@ -2358,7 +2434,7 @@ and initialize a Document object</a> steps by adding the following steps before 
   following these sub-steps:</p>
       <ol>
        <li data-md>
-        <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective②">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
+        <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective②">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
        <li data-md>
         <p>Let <var>textFragmentToken</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑨">textFragmentToken</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①⓪">textFragmentToken</a> to false.</p>
        <li data-md>
@@ -2382,7 +2458,7 @@ and initialize a Document object</a> steps by adding the following steps before 
        <li data-md>
         <p>If <var>textFragmentToken</var> is false, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective④">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
        <li data-md>
-        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">document</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#latest-entry" id="ref-for-latest-entry">latest entry</a> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#session-history" id="ref-for-session-history">session history</a> is
+        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">document</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#latest-entry" id="ref-for-latest-entry">latest entry</a> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#session-history" id="ref-for-session-history">session history</a> is
   equal to <var>document</var>, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑤">allowTextFragmentDirective</a> to false
   and abort these sub-steps.</p>
         <div class="note" role="note"> i.e. Forbidden on a same-document navigation. </div>
@@ -2401,7 +2477,7 @@ and initialize a Document object</a> steps by adding the following steps before 
       </ol>
     </ol>
    </blockquote>
-   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken③">textFragmentToken</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①①">textFragmentToken</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a>'s value to
+   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken③">textFragmentToken</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①①">textFragmentToken</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a>'s value to
 false.</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
@@ -2455,7 +2531,7 @@ the following:</p>
     <ol start="3">
      <li data-md>
       <p><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
-  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>. If the result is true, abort these steps.</p>
+  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①②">Document</a>. If the result is true, abort these steps.</p>
      <li data-md>
       <p>If <em>range</em> is non-null:</p>
       <ol>
@@ -2479,7 +2555,7 @@ the following:</p>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
     <ol>
      <li data-md>
-      <p>Let <var>fragment directive string</var> be the document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a>.</p>
+      <p>Let <var>fragment directive string</var> be the document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment directive</a>.</p>
      <li data-md>
       <p>If the document’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①①">allowTextFragmentDirective</a> flag is true then:</p>
       <ol>
@@ -2608,7 +2684,7 @@ text=bar,baz
   list.</p>
    </div>
    <div class="algorithm" data-algorithm="process a fragment directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> <var>document</var>, run these steps: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a> <var>document</var>, run these steps: 
     <div class="note" role="note"> This algorithm takes as input a the <var>fragment directive input</var>, that is the
   raw text of the fragment directive and the <var>document</var> over which it operates.
   It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑨">ranges</a> that are to be visually
@@ -2643,7 +2719,7 @@ directive</a> steps on <var>directive</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="find a range from a text directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#parsedtextdirective" id="ref-for-parsedtextdirective②">ParsedTextDirective</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">Document</a> <var>document</var>, run the
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#parsedtextdirective" id="ref-for-parsedtextdirective②">ParsedTextDirective</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①④">Document</a> <var>document</var>, run the
 following steps: 
     <div class="note" role="note">
       This algorithm takes as input a successfully parsed text directive and a
@@ -3143,11 +3219,11 @@ persisted state</a> steps by inserting a new step after 2:</p>
    <ol start="3">
     <li data-md>
      <p><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
-the document policy value</a> of the "force-load-at-top" feature for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①②">Document</a>. If
+the document policy value</a> of the "force-load-at-top" feature for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑤">Document</a>. If
 the result is true, then the user agent should not restore the scroll
-position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a> or any of its scrollable regions. Scroll
+position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑥">Document</a> or any of its scrollable regions. Scroll
 positions for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#child-browsing-context" id="ref-for-child-browsing-context">child browsing contexts</a> should be restored based on the
-value of this policy in the child <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①④">Document</a>.</p>
+value of this policy in the child <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑦">Document</a>.</p>
    </ol>
    <h3 class="heading settled" data-level="3.8" id="feature-detectability"><span class="secno">3.8. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
@@ -3315,8 +3391,8 @@ match based on whether the element-id was scrolled.</p>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
    <li><a href="#document-allowtextfragmentdirective">allowTextFragmentDirective</a><span>, in §3.4.4</span>
-   <li><a href="#characterstring">CharacterString</a><span>, in §3.3.2</span>
-   <li><a href="#explicitchar">ExplicitChar</a><span>, in §3.3.2</span>
+   <li><a href="#characterstring">CharacterString</a><span>, in §3.3.3</span>
+   <li><a href="#explicitchar">ExplicitChar</a><span>, in §3.3.3</span>
    <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in §3.5.2</span>
    <li><a href="#find-a-range-from-a-text-directive">find a range from a text directive</a><span>, in §3.5.2</span>
    <li><a href="#find-a-string-in-range">find a string in range</a><span>, in §3.5.2</span>
@@ -3326,10 +3402,10 @@ match based on whether the element-id was scrolled.</p>
     FragmentDirective
     <ul>
      <li><a href="#fragmentdirective">(interface)</a><span>, in §3.8</span>
-     <li><a href="#fragmentdirectiveproduction">definition of</a><span>, in §3.3.2</span>
+     <li><a href="#fragmentdirectiveproduction">definition of</a><span>, in §3.3.3</span>
     </ul>
    <li><a href="#dom-document-fragmentdirective">fragmentDirective</a><span>, in §3.8</span>
-   <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §3.3.1</span>
+   <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §3.3</span>
    <li><a href="#get-boundary-point-at-index">get boundary point at index</a><span>, in §3.5.2</span>
    <li><a href="#has-block-level-display">has block-level display</a><span>, in §3.5.2</span>
    <li><a href="#is-at-a-word-boundary">is at a word boundary</a><span>, in §3.5.3</span>
@@ -3337,33 +3413,34 @@ match based on whether the element-id was scrolled.</p>
    <li><a href="#nearest-block-ancestor">nearest block ancestor</a><span>, in §3.5.2</span>
    <li><a href="#next-non-whitespace-position">next non-whitespace position</a><span>, in §3.5.2</span>
    <li><a href="#non-searchable-subtree">non-searchable subtree</a><span>, in §3.5.2</span>
-   <li><a href="#parse-a-text-directive">parse a text directive</a><span>, in §3.3.1</span>
-   <li><a href="#parsedtextdirective">ParsedTextDirective</a><span>, in §3.3.1</span>
-   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §3.3.2</span>
-   <li><a href="#parsedtextdirective-prefix">prefix</a><span>, in §3.3.1</span>
+   <li><a href="#parse-a-text-directive">parse a text directive</a><span>, in §3.3.2</span>
+   <li><a href="#parsedtextdirective">ParsedTextDirective</a><span>, in §3.3.2</span>
+   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §3.3.3</span>
+   <li><a href="#parsedtextdirective-prefix">prefix</a><span>, in §3.3.2</span>
    <li><a href="#process-a-fragment-directive">process a fragment directive</a><span>, in §3.5.2</span>
+   <li><a href="#process-and-consume-fragment-directive">process and consume fragment directive</a><span>, in §3.3.1</span>
    <li><a href="#scroll-a-domrect-into-view">scroll a DOMRect into view</a><span>, in §3.5.1</span>
    <li><a href="#scroll-a-range-into-view">scroll a Range into view</a><span>, in §3.5.1</span>
    <li><a href="#search-invisible">search invisible</a><span>, in §3.5.2</span>
    <li><a href="#shadow-including-parent">shadow-including parent</a><span>, in §3.5</span>
-   <li><a href="#parsedtextdirective-suffix">suffix</a><span>, in §3.3.1</span>
-   <li><a href="#textdirective">TextDirective</a><span>, in §3.3.2</span>
-   <li><a href="#textdirectiveexplicitchar">TextDirectiveExplicitChar</a><span>, in §3.3.2</span>
-   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §3.3.2</span>
-   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §3.3.2</span>
-   <li><a href="#textdirectivestring">TextDirectiveString</a><span>, in §3.3.2</span>
-   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §3.3.2</span>
-   <li><a href="#parsedtextdirective-textend">textEnd</a><span>, in §3.3.1</span>
-   <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §3.3.2</span>
+   <li><a href="#parsedtextdirective-suffix">suffix</a><span>, in §3.3.2</span>
+   <li><a href="#textdirective">TextDirective</a><span>, in §3.3.3</span>
+   <li><a href="#textdirectiveexplicitchar">TextDirectiveExplicitChar</a><span>, in §3.3.3</span>
+   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §3.3.3</span>
+   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §3.3.3</span>
+   <li><a href="#textdirectivestring">TextDirectiveString</a><span>, in §3.3.3</span>
+   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §3.3.3</span>
+   <li><a href="#parsedtextdirective-textend">textEnd</a><span>, in §3.3.2</span>
+   <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §3.3.3</span>
    <li>
     textFragmentToken
     <ul>
      <li><a href="#document-textfragmenttoken">dfn for document</a><span>, in §3.4.4</span>
      <li><a href="#request-textfragmenttoken">dfn for request</a><span>, in §3.4.4</span>
     </ul>
-   <li><a href="#parsedtextdirective-textstart">textStart</a><span>, in §3.3.1</span>
-   <li><a href="#unknowndirective">UnknownDirective</a><span>, in §3.3.2</span>
-   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §3.3.2</span>
+   <li><a href="#parsedtextdirective-textstart">textStart</a><span>, in §3.3.2</span>
+   <li><a href="#unknowndirective">UnknownDirective</a><span>, in §3.3.3</span>
+   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §3.3.3</span>
    <li><a href="#visible-text-node">visible text node</a><span>, in §3.5.2</span>
    <li><a href="#word-boundary">word boundary</a><span>, in §3.5.3</span>
    <li><a href="#word-bounded">word bounded</a><span>, in §3.5.3</span>
@@ -3499,11 +3576,12 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-concept-document">
    <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document">3.3.1. Parsing the fragment directive</a>
-    <li><a href="#ref-for-concept-document①">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a> <a href="#ref-for-concept-document④">(4)</a> <a href="#ref-for-concept-document⑤">(5)</a> <a href="#ref-for-concept-document⑥">(6)</a> <a href="#ref-for-concept-document⑦">(7)</a> <a href="#ref-for-concept-document⑧">(8)</a>
-    <li><a href="#ref-for-concept-document⑨">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-concept-document①⓪">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-document①①">(2)</a>
-    <li><a href="#ref-for-concept-document①②">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①③">(2)</a> <a href="#ref-for-concept-document①④">(3)</a>
+    <li><a href="#ref-for-concept-document">3.3. The Fragment Directive</a>
+    <li><a href="#ref-for-concept-document①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a>
+    <li><a href="#ref-for-concept-document④">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document⑤">(2)</a> <a href="#ref-for-concept-document⑥">(3)</a> <a href="#ref-for-concept-document⑦">(4)</a> <a href="#ref-for-concept-document⑧">(5)</a> <a href="#ref-for-concept-document⑨">(6)</a> <a href="#ref-for-concept-document①⓪">(7)</a> <a href="#ref-for-concept-document①①">(8)</a>
+    <li><a href="#ref-for-concept-document①②">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-document①③">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-document①④">(2)</a>
+    <li><a href="#ref-for-concept-document①⑤">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①⑥">(2)</a> <a href="#ref-for-concept-document①⑦">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document-element">
@@ -3648,25 +3726,14 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-concept-document-url">
    <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document-url">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-concept-document-url①">(2)</a> <a href="#ref-for-concept-document-url②">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-request-current-url">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-concept-document-url">3.3. The Fragment Directive</a>
+    <li><a href="#ref-for-concept-document-url①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-document-url②">(2)</a> <a href="#ref-for-concept-document-url③">(3)</a> <a href="#ref-for-concept-document-url④">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-request">
    <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a> <a href="#ref-for-concept-request③">(4)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-concept-response-url">3.3.1. Parsing the fragment directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-domrect">
@@ -3729,10 +3796,17 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-htmlvideoelement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-location">
+   <a href="https://html.spec.whatwg.org/multipage/history.html#location">https://html.spec.whatwg.org/multipage/history.html#location</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-location">3.3.1. Processing the fragment directive</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-active-document">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-active-document">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-active-document①">(2)</a>
+    <li><a href="#ref-for-active-document">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-active-document①">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-active-document②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-being-rendered">
@@ -3843,7 +3917,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-assert">
    <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-assert">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-assert">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-assert①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-assert②">(2)</a> <a href="#ref-for-assert③">(3)</a> <a href="#ref-for-assert④">(4)</a>
    </ul>
   </aside>
@@ -3886,7 +3960,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-list">
    <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-list">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-list①">3.5. Navigating to a Text Fragment</a>
     <li><a href="#ref-for-list②">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-list③">(2)</a> <a href="#ref-for-list④">(3)</a> <a href="#ref-for-list⑤">(4)</a> <a href="#ref-for-list⑥">(5)</a> <a href="#ref-for-list⑦">(6)</a> <a href="#ref-for-list⑧">(7)</a> <a href="#ref-for-list⑨">(8)</a>
    </ul>
@@ -3894,19 +3968,19 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-list-remove">
    <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-remove">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-list-remove①">(2)</a>
+    <li><a href="#ref-for-list-remove">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-list-remove①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-size">
    <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-size">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-list-size①">(2)</a>
+    <li><a href="#ref-for-list-size">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-split-on-commas">
    <a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-split-on-commas">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-split-on-commas">3.3.2. Parsing the fragment directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-strictly-split">
@@ -3918,7 +3992,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-string">
    <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-string">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-string①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a> <a href="#ref-for-string④">(4)</a>
     <li><a href="#ref-for-string⑤">3.5.3. Word Boundaries</a> <a href="#ref-for-string⑥">(2)</a> <a href="#ref-for-string⑦">(3)</a>
    </ul>
@@ -3926,25 +4000,32 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-struct">
    <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-struct">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-struct">3.3.2. Parsing the fragment directive</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
    <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url-fragment">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-concept-url-fragment①">(2)</a>
+    <li><a href="#ref-for-concept-url-fragment">3.3. The Fragment Directive</a>
+    <li><a href="#ref-for-concept-url-fragment①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-url-fragment②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-string-percent-decode">
    <a href="https://url.spec.whatwg.org/#string-percent-decode">https://url.spec.whatwg.org/#string-percent-decode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string-percent-decode">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-string-percent-decode①">(2)</a> <a href="#ref-for-string-percent-decode②">(3)</a> <a href="#ref-for-string-percent-decode③">(4)</a>
+    <li><a href="#ref-for-string-percent-decode">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-string-percent-decode①">(2)</a> <a href="#ref-for-string-percent-decode②">(3)</a> <a href="#ref-for-string-percent-decode③">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-url">
+   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-url">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-url①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-url-code-points">
    <a href="https://url.spec.whatwg.org/#url-code-points">https://url.spec.whatwg.org/#url-code-points</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-url-code-points">3.3.2. Fragment directive grammar</a> <a href="#ref-for-url-code-points①">(2)</a>
+    <li><a href="#ref-for-url-code-points">3.3.3. Fragment directive grammar</a> <a href="#ref-for-url-code-points①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Exposed">
@@ -4029,9 +4110,7 @@ match based on whether the element-id was scrolled.</p>
    <li>
     <a data-link-type="biblio">[FETCH]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-concept-request-current-url">current url</span>
      <li><span class="dfn-paneled" id="term-for-concept-request">request</span>
-     <li><span class="dfn-paneled" id="term-for-concept-response-url">url</span>
     </ul>
    <li>
     <a data-link-type="biblio">[geometry-1]</a> defines the following terms:
@@ -4050,6 +4129,7 @@ match based on whether the element-id was scrolled.</p>
      <li><span class="dfn-paneled" id="term-for-htmlscriptelement">HTMLScriptElement</span>
      <li><span class="dfn-paneled" id="term-for-htmlstyleelement">HTMLStyleElement</span>
      <li><span class="dfn-paneled" id="term-for-htmlvideoelement">HTMLVideoElement</span>
+     <li><span class="dfn-paneled" id="term-for-location">Location</span>
      <li><span class="dfn-paneled" id="term-for-active-document">active document</span>
      <li><span class="dfn-paneled" id="term-for-being-rendered">being rendered</span>
      <li><span class="dfn-paneled" id="term-for-concept-document-bc">browsing context</span>
@@ -4092,6 +4172,7 @@ match based on whether the element-id was scrolled.</p>
     <ul>
      <li><span class="dfn-paneled" id="term-for-concept-url-fragment">fragment</span>
      <li><span class="dfn-paneled" id="term-for-string-percent-decode">percent-decode</span>
+     <li><span class="dfn-paneled" id="term-for-concept-url">url</span>
      <li><span class="dfn-paneled" id="term-for-url-code-points">url code point</span>
     </ul>
    <li>
@@ -4152,62 +4233,69 @@ match based on whether the element-id was scrolled.</p>
 };
 
 </pre>
+  <aside class="dfn-panel" data-for="fragment-directive-delimiter">
+   <b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fragment-directive-delimiter">3.3. The Fragment Directive</a>
+    <li><a href="#ref-for-fragment-directive-delimiter①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter②">(2)</a> <a href="#ref-for-fragment-directive-delimiter③">(3)</a> <a href="#ref-for-fragment-directive-delimiter④">(4)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="fragment-directive">
    <b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-directive">3.2. Syntax</a>
-    <li><a href="#ref-for-fragment-directive①">3.3. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a>
-    <li><a href="#ref-for-fragment-directive④">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive⑤">(2)</a> <a href="#ref-for-fragment-directive⑥">(3)</a> <a href="#ref-for-fragment-directive⑦">(4)</a> <a href="#ref-for-fragment-directive⑧">(5)</a> <a href="#ref-for-fragment-directive⑨">(6)</a>
-    <li><a href="#ref-for-fragment-directive①⓪">3.3.2. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①①">(2)</a>
-    <li><a href="#ref-for-fragment-directive①②">3.4.4. Restricting the Text Fragment</a>
-    <li><a href="#ref-for-fragment-directive①③">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-fragment-directive①">3.3. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a> <a href="#ref-for-fragment-directive④">(4)</a>
+    <li><a href="#ref-for-fragment-directive⑤">3.3.1. Processing the fragment directive</a> <a href="#ref-for-fragment-directive⑥">(2)</a> <a href="#ref-for-fragment-directive⑦">(3)</a> <a href="#ref-for-fragment-directive⑧">(4)</a> <a href="#ref-for-fragment-directive⑨">(5)</a> <a href="#ref-for-fragment-directive①⓪">(6)</a>
+    <li><a href="#ref-for-fragment-directive①①">3.3.3. Fragment directive grammar</a> <a href="#ref-for-fragment-directive①②">(2)</a>
+    <li><a href="#ref-for-fragment-directive①③">3.4.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-fragment-directive①④">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragment-directive-delimiter">
-   <b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="process-and-consume-fragment-directive">
+   <b><a href="#process-and-consume-fragment-directive">#process-and-consume-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragment-directive-delimiter">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter①">(2)</a> <a href="#ref-for-fragment-directive-delimiter②">(3)</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="parse-a-text-directive">
-   <b><a href="#parse-a-text-directive">#parse-a-text-directive</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-parse-a-text-directive">3.5.2. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-process-and-consume-fragment-directive">3.3.1. Processing the fragment directive</a> <a href="#ref-for-process-and-consume-fragment-directive①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="parsedtextdirective">
    <b><a href="#parsedtextdirective">#parsedtextdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parsedtextdirective">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-parsedtextdirective①">(2)</a>
+    <li><a href="#ref-for-parsedtextdirective">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-parsedtextdirective①">(2)</a>
     <li><a href="#ref-for-parsedtextdirective②">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="parsedtextdirective-textstart">
    <b><a href="#parsedtextdirective-textstart">#parsedtextdirective-textstart</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parsedtextdirective-textstart">3.3.1. Parsing the fragment directive</a> <a href="#ref-for-parsedtextdirective-textstart①">(2)</a>
+    <li><a href="#ref-for-parsedtextdirective-textstart">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-parsedtextdirective-textstart①">(2)</a>
     <li><a href="#ref-for-parsedtextdirective-textstart②">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-textstart③">(2)</a> <a href="#ref-for-parsedtextdirective-textstart④">(3)</a> <a href="#ref-for-parsedtextdirective-textstart⑤">(4)</a> <a href="#ref-for-parsedtextdirective-textstart⑥">(5)</a> <a href="#ref-for-parsedtextdirective-textstart⑦">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="parsedtextdirective-textend">
    <b><a href="#parsedtextdirective-textend">#parsedtextdirective-textend</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parsedtextdirective-textend">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-parsedtextdirective-textend">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-parsedtextdirective-textend①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-textend②">(2)</a> <a href="#ref-for-parsedtextdirective-textend③">(3)</a> <a href="#ref-for-parsedtextdirective-textend④">(4)</a> <a href="#ref-for-parsedtextdirective-textend⑤">(5)</a> <a href="#ref-for-parsedtextdirective-textend⑥">(6)</a> <a href="#ref-for-parsedtextdirective-textend⑦">(7)</a> <a href="#ref-for-parsedtextdirective-textend⑧">(8)</a> <a href="#ref-for-parsedtextdirective-textend⑨">(9)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="parsedtextdirective-prefix">
    <b><a href="#parsedtextdirective-prefix">#parsedtextdirective-prefix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parsedtextdirective-prefix">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-parsedtextdirective-prefix">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-parsedtextdirective-prefix①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-prefix②">(2)</a> <a href="#ref-for-parsedtextdirective-prefix③">(3)</a> <a href="#ref-for-parsedtextdirective-prefix④">(4)</a> <a href="#ref-for-parsedtextdirective-prefix⑤">(5)</a> <a href="#ref-for-parsedtextdirective-prefix⑥">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="parsedtextdirective-suffix">
    <b><a href="#parsedtextdirective-suffix">#parsedtextdirective-suffix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parsedtextdirective-suffix">3.3.1. Parsing the fragment directive</a>
+    <li><a href="#ref-for-parsedtextdirective-suffix">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-parsedtextdirective-suffix①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-suffix②">(2)</a> <a href="#ref-for-parsedtextdirective-suffix③">(3)</a> <a href="#ref-for-parsedtextdirective-suffix④">(4)</a> <a href="#ref-for-parsedtextdirective-suffix⑤">(5)</a> <a href="#ref-for-parsedtextdirective-suffix⑥">(6)</a> <a href="#ref-for-parsedtextdirective-suffix⑦">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="parse-a-text-directive">
+   <b><a href="#parse-a-text-directive">#parse-a-text-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-parse-a-text-directive">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="valid-fragment-directive">
@@ -4219,25 +4307,25 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="fragmentdirectiveproduction">
    <b><a href="#fragmentdirectiveproduction">#fragmentdirectiveproduction</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragmentdirectiveproduction">3.3.2. Fragment directive grammar</a> <a href="#ref-for-fragmentdirectiveproduction①">(2)</a>
+    <li><a href="#ref-for-fragmentdirectiveproduction">3.3.3. Fragment directive grammar</a> <a href="#ref-for-fragmentdirectiveproduction①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="unknowndirective">
    <b><a href="#unknowndirective">#unknowndirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-unknowndirective">3.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-unknowndirective">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="characterstring">
    <b><a href="#characterstring">#characterstring</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-characterstring">3.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-characterstring">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="explicitchar">
    <b><a href="#explicitchar">#explicitchar</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-explicitchar">3.3.2. Fragment directive grammar</a> <a href="#ref-for-explicitchar①">(2)</a>
+    <li><a href="#ref-for-explicitchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-explicitchar①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="text-fragment-directive">
@@ -4255,45 +4343,45 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="textdirective">
    <b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirective">3.3.1. Parsing the fragment directive</a>
-    <li><a href="#ref-for-textdirective①">3.3.2. Fragment directive grammar</a> <a href="#ref-for-textdirective②">(2)</a>
+    <li><a href="#ref-for-textdirective">3.3.2. Parsing the fragment directive</a>
+    <li><a href="#ref-for-textdirective①">3.3.3. Fragment directive grammar</a> <a href="#ref-for-textdirective②">(2)</a>
     <li><a href="#ref-for-textdirective③">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveparameters">
    <b><a href="#textdirectiveparameters">#textdirectiveparameters</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectiveparameters">3.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-textdirectiveparameters">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveprefix">
    <b><a href="#textdirectiveprefix">#textdirectiveprefix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectiveprefix">3.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-textdirectiveprefix">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectivesuffix">
    <b><a href="#textdirectivesuffix">#textdirectivesuffix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectivesuffix">3.3.2. Fragment directive grammar</a>
+    <li><a href="#ref-for-textdirectivesuffix">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectivestring">
    <b><a href="#textdirectivestring">#textdirectivestring</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectivestring">3.3.2. Fragment directive grammar</a> <a href="#ref-for-textdirectivestring①">(2)</a> <a href="#ref-for-textdirectivestring②">(3)</a> <a href="#ref-for-textdirectivestring③">(4)</a>
+    <li><a href="#ref-for-textdirectivestring">3.3.3. Fragment directive grammar</a> <a href="#ref-for-textdirectivestring①">(2)</a> <a href="#ref-for-textdirectivestring②">(3)</a> <a href="#ref-for-textdirectivestring③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="textdirectiveexplicitchar">
    <b><a href="#textdirectiveexplicitchar">#textdirectiveexplicitchar</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-textdirectiveexplicitchar">3.3.2. Fragment directive grammar</a> <a href="#ref-for-textdirectiveexplicitchar①">(2)</a>
+    <li><a href="#ref-for-textdirectiveexplicitchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-textdirectiveexplicitchar①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="percentencodedchar">
    <b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-percentencodedchar">3.3.2. Fragment directive grammar</a> <a href="#ref-for-percentencodedchar①">(2)</a>
+    <li><a href="#ref-for-percentencodedchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-percentencodedchar①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="request-textfragmenttoken">


### PR DESCRIPTION
This PR elaborates and improves the description around how the fragment directive is processed and stripped from the URL. This was meant mainly to clarify what happens in various edge cases like scripting URL objects so this adds lots of non-normative examples.

However, I also noticed the current spec text was insufficient for same document navigations since those don't use the [create and initialize a document object](https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object) steps like a normal navigation does. [Fragment navigations](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid) instead create a new session history entry and use the [traverse the history](https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history) steps instead so I also updated this path to accurately reflect what we currently do in Chrome.

Aside from the content improvements, I made some editorial changes to improve readability by adding monkeypatch and algorithm sections.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/ScrollToTextFragment/pull/152.html" title="Last updated on Nov 13, 2020, 4:17 PM UTC (4519705)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/152/0ac04a9...bokand:4519705.html" title="Last updated on Nov 13, 2020, 4:17 PM UTC (4519705)">Diff</a>