### PR TITLE
Editorialize: add algorithm/monkeypatch sections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -187,11 +187,13 @@ translation-hints or enabling accessibility features.
 
 To the definition of [=Document=], add:
 
-<em>
-  Each document has an associated <dfn>fragment directive</dfn> which is either
-  null or an ASCII string holding data used by the UA to process the resource. It
-  is initially null.
-</em>
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   <em>
+>     Each document has an associated <dfn>fragment directive</dfn> which is
+>     either null or an ASCII string holding data used by the UA to process the
+>     resource. It is initially null.
+>   </em>
 
 The <dfn>fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).
@@ -206,6 +208,7 @@ three consecutive code points U+003A (:), U+007E (~), U+003A (:).
   must first be appended to the URL: https://example.com#:~:text=foo.
 </div>
 
+
 Amend the
 <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">
 create and initialize a Document object</a> steps to parse and remove the
@@ -213,30 +216,32 @@ create and initialize a Document object</a> steps to parse and remove the
 
 Replace steps 7 and 8 of this algorithm with:
 
-7. Let |url| be null
-8. If |request| is non-null, then set |document|'s [=Document/URL=] to
-    |request|'s [=request/current URL=].
-9. Otherwise, set |url| to <var ignore=''>response</var>'s [=response/URL=].
-10. Let |raw fragment| be equal to |url|'s [=url/fragment=].
-11. If |raw fragment| is non-null:
-    1. Let |fragmentDirectivePosition| be an integer initialized to 0.
-    2. While the substring of |raw fragment| starting at position
-        |fragmentDirectivePosition| does not begin with the [=fragment directive
-        delimiter=] and |fragmentDirectivePosition| does not point past the end
-        of |raw fragment|:
-        1. Increment |fragmentDirectivePosition| by 1.
-    3. If |fragmentDirectivePosition| does not point past the end of |raw
-        fragment|:
-        1. Let |fragment| be the substring of |raw fragment| starting at 0 of
-            count |fragmentDirectivePosition|.
-        1. Advance |fragmentDirectivePosition| by the length of [=fragment
-            directive delimiter=].
-        1. Let |fragment directive| be the substring of |raw fragment| starting
-            at |fragmentDirectivePosition|.
-        1. Set |url|'s [=url/fragment=] to |fragment|.
-        1. Set |document|'s [=fragment directive=] to |fragment directive|.
-            (Note: this is stored on the document but not web-exposed)
-12. Set |document|'s [=Document/URL=] to be |url|.
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   7. Let |url| be null
+>   8. If |request| is non-null, then set |document|'s [=Document/URL=] to
+>       |request|'s [=request/current URL=].
+>   9. Otherwise, set |url| to <var ignore=''>response</var>'s [=response/URL=].
+>   10. Let |raw fragment| be equal to |url|'s [=url/fragment=].
+>   11. If |raw fragment| is non-null:
+>       1. Let |fragmentDirectivePosition| be an integer initialized to 0.
+>       2. While the substring of |raw fragment| starting at position
+>           |fragmentDirectivePosition| does not begin with the [=fragment directive
+>           delimiter=] and |fragmentDirectivePosition| does not point past the end
+>           of |raw fragment|:
+>           1. Increment |fragmentDirectivePosition| by 1.
+>       3. If |fragmentDirectivePosition| does not point past the end of |raw
+>           fragment|:
+>           1. Let |fragment| be the substring of |raw fragment| starting at 0 of
+>               count |fragmentDirectivePosition|.
+>           1. Advance |fragmentDirectivePosition| by the length of [=fragment
+>               directive delimiter=].
+>           1. Let |fragment directive| be the substring of |raw fragment| starting
+>               at |fragmentDirectivePosition|.
+>           1. Set |url|'s [=url/fragment=] to |fragment|.
+>           1. Set |document|'s [=fragment directive=] to |fragment directive|.
+>               (Note: this is stored on the document but not web-exposed)
+>   12. Set |document|'s [=Document/URL=] to be |url|.
 
 <div class="note">
   These changes make a URL's fragment end at the [=fragment directive
@@ -249,6 +254,8 @@ Replace steps 7 and 8 of this algorithm with:
 the fragment is the string "test" and the [=fragment directive=] is the string
 "text=foo".
 </div>
+
+<div algorithm="parse a text directive">
 
 To <dfn>parse a text directive</dfn>, on a <a spec="infra">string</a> |text
 directive input|, run these steps:
@@ -267,39 +274,44 @@ directive input|, run these steps:
   </p>
 </div>
 
-1. [=/Assert=]: |text directive input| matches the production [=TextDirective=].
-1. Let |textDirectiveString| be the substring of |text directive
-    input| starting at index 5.
-    <div class="note">
-      This is the remainder of the |text directive input| following,
-      but not including, the "text=" prefix.
-    </div>
-1. Let |tokens| be a <a for=/>list</a> of strings that is the result of
-    <a lt="split on commas">splitting |textDirectiveString| on commas</a>.
-1. If |tokens| has size less than 1 or greater than 4, return null.
-1. If any of |tokens|'s items are the empty string, return null.
-1. Let |retVal| be a [=ParsedTextDirective=] with each of its items initialized
-    to null.
-1. Let |potential prefix| be the first item of |tokens|.
-1. If the last character of |potential prefix| is U+002D (-), then:
-    1. Set |retVal|'s [=ParsedTextDirective/prefix=] to the [=string/percent-decode|percent-decoding=] of
-        the result of removing the last character from |potential prefix|.
-    1. <a spec=infra for=list>Remove</a> the first item of the list |tokens|.
-1. Let |potential suffix| be the last item of |tokens|, if one exists, null
-    otherwise.
-1. If |potential suffix| is non-null and its first character is U+002D (-),
-    then:
-    1. Set |retVal|'s [=ParsedTextDirective/suffix=] to the [=string/percent-decode|percent-decoding=] of
-        the result of removing the first character from |potential suffix|.
-    1. <a spec=infra for=list>Remove</a> the last item of the list |tokens|.
-1. If |tokens| has <a spec=infra for=list>size</a> not equal to 1 nor 2 then
-    return null.
-1. Set |retVal|'s [=ParsedTextDirective/textStart=] be the [=string/percent-decode|percent-decoding=] of
-    the first item of |tokens|.
-1. If |tokens| has <a spec=infra for=list>size</a> 2, then set |retVal|'s
-    [=ParsedTextDirective/textEnd=] be the [=string/percent-decode|percent-decoding=] of the last item of
-    |tokens|.
-1. Return |retVal|.
+  <ol class="algorithm">
+    1. [=/Assert=]: |text directive input| matches the production [=TextDirective=].
+    1. Let |textDirectiveString| be the substring of |text directive
+        input| starting at index 5.
+        <div class="note">
+          This is the remainder of the |text directive input| following,
+          but not including, the "text=" prefix.
+        </div>
+    1. Let |tokens| be a <a for=/>list</a> of strings that is the result of
+        <a lt="split on commas">splitting |textDirectiveString| on commas</a>.
+    1. If |tokens| has size less than 1 or greater than 4, return null.
+    1. If any of |tokens|'s items are the empty string, return null.
+    1. Let |retVal| be a [=ParsedTextDirective=] with each of its items initialized
+        to null.
+    1. Let |potential prefix| be the first item of |tokens|.
+    1. If the last character of |potential prefix| is U+002D (-), then:
+        1. Set |retVal|'s [=ParsedTextDirective/prefix=] to the
+            [=string/percent-decode|percent-decoding=] of the result of removing the
+            last character from |potential prefix|.
+        1. <a spec=infra for=list>Remove</a> the first item of the list |tokens|.
+    1. Let |potential suffix| be the last item of |tokens|, if one exists, null
+        otherwise.
+    1. If |potential suffix| is non-null and its first character is U+002D (-),
+        then:
+        1. Set |retVal|'s [=ParsedTextDirective/suffix=] to the
+            [=string/percent-decode|percent-decoding=] of the result of removing the
+            first character from |potential suffix|.
+        1. <a spec=infra for=list>Remove</a> the last item of the list |tokens|.
+    1. If |tokens| has <a spec=infra for=list>size</a> not equal to 1 nor 2 then
+        return null.
+    1. Set |retVal|'s [=ParsedTextDirective/textStart=] be the
+        [=string/percent-decode|percent-decoding=] of the first item of |tokens|.
+    1. If |tokens| has <a spec=infra for=list>size</a> 2, then set |retVal|'s
+        [=ParsedTextDirective/textEnd=] be the
+        [=string/percent-decode|percent-decoding=] of the last item of |tokens|.
+    1. Return |retVal|.
+  </ol>
+</div>
 
 A <dfn>ParsedTextDirective</dfn> is a <a spec=infra>struct</a> that consists of
 four strings: <dfn for="ParsedTextDirective">textStart</dfn>,
@@ -534,20 +546,28 @@ to find and set the indicated part of the document.
 
 ### Restricting the Text Fragment ### {#restricting-the-text-fragment}
 
-A [=Document=] has a <dfn for="document">textFragmentToken</dfn> flag that is
-consumed in order to allow a single activation of a text fragment. This flag is
-generated only during loading if the navigation occurs as a result of a user
-activation.
+Amend the definition of a [=/request=] and of a [=Document=] to include a new
+field for the [=document/textFragmentToken=]:
 
-If the [=Document=]'s [=document/textFragmentToken=] isn't consumed to activate
-a text fragment, it may be consumed to set the <dfn for="request">
-textFragmentToken</dfn> flag of a [=/request=]. In this way, a
-textFragmentToken can be propagated from one [=Document=] to another across a
-navigation.
+>   <strong>Monkeypatching [[FETCH]]:</strong>
+>
+>   A [=/request=] has an associated <dfn for="request">textFragmentToken</dfn> flag
 
-Reading either the [=Document=]'s [=document/textFragmentToken=] or the
-[=/request=]'s [=request/textFragmentToken=] must always consume the value,
-such that the token cannot be cloned.
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   A [=Document=] has a <dfn for="document">textFragmentToken</dfn> flag that is
+>   consumed in order to allow a single activation of a text fragment. This flag is
+>   generated only during loading if the navigation occurs as a result of a user
+>   activation.
+>
+>   If the [=Document=]'s [=document/textFragmentToken=] isn't consumed to activate
+>   a text fragment, it may be consumed to set the [=request/textFragmentToken=]
+>   flag of a navigation [=/request=]. In this way, a [=document/textFragmentToken=]
+>   can be propagated from one [=Document=] to another across a navigation.
+>
+>   Reading either the [=Document=]'s [=document/textFragmentToken=] or the
+>   [=/request=]'s [=request/textFragmentToken=] must always consume the value,
+>   such that the token cannot be cloned.
 
 <div class="note">
   <p>
@@ -587,10 +607,12 @@ such that the token cannot be cloned.
   </p>
 </div>
 
-A [=Document=] has an <dfn for="document">allowTextFragmentDirective</dfn> flag
-that is used to determine whether a text fragment directive should be allowed
-to activate. If this flag is false, the text fragment must not cause any
-observable effects.
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   A [=Document=] has an <dfn for="document">allowTextFragmentDirective</dfn>
+>   flag that is used to determine whether a text fragment directive should be
+>   allowed to activate. If this flag is false, the text fragment must not
+>   cause any observable effects.
 
 <div class="note">
   <p>
@@ -618,91 +640,91 @@ Amend the <a
 href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">create
 and initialize a Document object</a> steps by adding the following steps before returning |document|:
 
-15. Set the [=document/textFragmentToken=] flag on |document|:
-    1. Let |is user activated| be true if the current navigation was initiated from
-        a window that had a <a spec="html">transient activation</a> at the time the
-        navigation was initiated, or the UA has reason to believe it comes from a
-        direct user gesture (e.g. user typed into the address bar).
-        <div class="note">
-          TODO: it'd be better to refer to the userActivationFlag on the
-          |request|. See
-          <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a>.
-        </div>
-    1. If <var ignore=''>browsing context</var> is a top-level browsing context and if either of |is
-        user activated| or the [=request/textFragmentToken=] flag of
-        |navigationParam|'s
-        <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
-        object is true, set the |document|'s [=document/textFragmentToken=]
-        flag to true. Otherwise, set it to false.
-        <div class="note">
-          It's important that the token not be copyable so that at most one token
-          is created per user-activated navigation.
-        </div>
-16. Set the [=document/allowTextFragmentDirective=] flag on |document| by
-    following these sub-steps:
-    1. If |document|'s [=fragment directive=] field is null or empty, set
-        [=document/allowTextFragmentDirective=] to false and abort these sub-steps.
-    1. Let |textFragmentToken| be the value of |document|'s
-        [=document/textFragmentToken=] and set |document|'s
-        [=document/textFragmentToken=] to false.
-    1. If the |navigationParam|'s
-        <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
-        has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
-        header and its value is `"none"` set
-        [=document/allowTextFragmentDirective=] to true and abort these
-        sub-steps.
-        <div class="note">
-          <p>
-            If a navigation originates from browser UI, it's always ok to allow it
-            since it'll be user triggered and the page/script isn't providing the
-            text snippet.
-          </p>
-          <p>
-            Note: Depending on the UA, there may be cases where the <var
-            ignore=''>incumbentNavigationOrigin</var> parameter is null but
-            it's not clear that the navigation should be considered as
-            initiated from browser UI. E.g. an "open in new window" context
-            menu item when right clicking on a link.  The intent in this item
-            is to distinguish cases where the app/page is able to set the URL
-            from those that are fully under the user's control.  In the former
-            we want to prevent activation of the text fragment unless the
-            destination is loaded in a separate browsing context group (so that
-            the source cannot both control the text snippet and observe
-            side-effects in the navigation).
-          </p>
-          <p>
-            See <a
-            href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a>
-            for a more detailed discussion of how this should apply.
-          </p>
-        </div>
-    1. If |textFragmentToken| is false, set
-        [=document/allowTextFragmentDirective=] to false and abort these sub-steps.
-    1. If the [=document=] of the <a spec=HTML>latest entry</a> in
-        |document|'s [=Document/browsing context=]'s <a spec=HTML>session history</a> is
-        equal to |document|, set [=document/allowTextFragmentDirective=] to false
-        and abort these sub-steps.
-        <div class="note">
-          i.e. Forbidden on a same-document navigation.
-        </div>
-    1. If the |navigationParam|'s
-        <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
-        has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
-        header and its value is `"same-site"` set
-        [=document/allowTextFragmentDirective=] to true and abort these
-        sub-steps.
-    1. If |document|'s [=Document/browsing context=] is a [=top-level browsing
-        context=] and its
-        <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>'s
-        <a spec=HTML>browsing context set</a> has length 1, set
-        [=document/allowTextFragmentDirective=] to true and abort these sub-steps.
-        <div class="note">
-          i.e. Only allow navigation from a cross-process element/script if the
-          document is loaded in a noopener context. That is, a new top level
-          browsing context group to which the navigator does not have script access
-          and which may be placed into a separate process.
-        </div>
-    1. Otherwise, set [=document/allowTextFragmentDirective=] to false.
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   15. Set the [=document/textFragmentToken=] flag on |document|:
+>       1. Let |is user activated| be true if the current navigation was initiated from
+>           a window that had a <a spec="html">transient activation</a> at the time the
+>           navigation was initiated, or the UA has reason to believe it comes from a
+>           direct user gesture (e.g. user typed into the address bar).
+>           <div class="note">
+>             TODO: it'd be better to refer to the userActivationFlag on the
+>             |request|. See
+>             <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a> in [[FETCH-METADATA]].
+>           </div>
+>       1. If <var ignore=''>browsing context</var> is a top-level browsing context and if either of |is
+>           user activated| or the [=request/textFragmentToken=] flag of
+>           |navigationParam|'s
+>           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
+>           object is true, set the |document|'s [=document/textFragmentToken=]
+>           flag to true. Otherwise, set it to false.
+>           <div class="note">
+>             It's important that the token not be copyable so that at most one token
+>             is created per user-activated navigation.
+>           </div>
+>   16. Set the [=document/allowTextFragmentDirective=] flag on |document| by
+>       following these sub-steps:
+>       1. If |document|'s [=fragment directive=] field is null or empty, set
+>           [=document/allowTextFragmentDirective=] to false and abort these sub-steps.
+>       1. Let |textFragmentToken| be the value of |document|'s
+>           [=document/textFragmentToken=] and set |document|'s
+>           [=document/textFragmentToken=] to false.
+>       1. If the |navigationParam|'s
+>           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
+>           has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
+>           header and its value is `"none"` set [=document/allowTextFragmentDirective=] to true and abort these sub-steps.
+>           <div class="note">
+>             <p>
+>               If a navigation originates from browser UI, it's always ok to allow it
+>               since it'll be user triggered and the page/script isn't providing the
+>               text snippet.
+>             </p>
+>             <p>
+>               Note: Depending on the UA, there may be cases where the <var
+>               ignore=''>incumbentNavigationOrigin</var> parameter is null but
+>               it's not clear that the navigation should be considered as
+>               initiated from browser UI. E.g. an "open in new window" context
+>               menu item when right clicking on a link.  The intent in this item
+>               is to distinguish cases where the app/page is able to set the URL
+>               from those that are fully under the user's control.  In the former
+>               we want to prevent activation of the text fragment unless the
+>               destination is loaded in a separate browsing context group (so that
+>               the source cannot both control the text snippet and observe
+>               side-effects in the navigation).
+>             </p>
+>             <p>
+>               See <a
+>               href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a>
+>               for a more detailed discussion of how this should apply.
+>             </p>
+>           </div>
+>       1. If |textFragmentToken| is false, set
+>           [=document/allowTextFragmentDirective=] to false and abort these sub-steps.
+>       1. If the [=document=] of the <a spec=HTML>latest entry</a> in
+>           |document|'s [=Document/browsing context=]'s <a spec=HTML>session history</a> is
+>           equal to |document|, set [=document/allowTextFragmentDirective=] to false
+>           and abort these sub-steps.
+>           <div class="note">
+>             i.e. Forbidden on a same-document navigation.
+>           </div>
+>       1. If the |navigationParam|'s
+>           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
+>           has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
+>           header and its value is `"same-site"` set
+>           [=document/allowTextFragmentDirective=] to true and abort these
+>           sub-steps.
+>       1. If |document|'s [=Document/browsing context=] is a [=top-level browsing
+>           context=] and its
+>           <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>'s
+>           <a spec=HTML>browsing context set</a> has length 1, set
+>           [=document/allowTextFragmentDirective=] to true and abort these sub-steps.
+>           <div class="note">
+>             i.e. Only allow navigation from a cross-process element/script if the
+>             document is loaded in a noopener context. That is, a new top level
+>             browsing context group to which the navigator does not have script access
+>             and which may be placed into a separate process.
+>           </div>
+>       1. Otherwise, set [=document/allowTextFragmentDirective=] to false.
 
 Amend step 2 of the
 <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch">
@@ -711,17 +733,31 @@ process a navigate fetch</a> steps to additionally set |request|'s
 [=document/textFragmentToken=] and set the [=active document=]'s value to
 false.
 
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   2. Set request's client to sourceBrowsingContext's active document's relevant
+>       settings object, destination to "document", mode to "navigate", credentials
+>       mode to "include", use-URL-credentials flag, redirect mode to "manual",
+>       replaces client id to browsingContext's active document's relevant settings
+>       object's id, and [=request/textFragmentToken=] to
+>       sourceBrowsingContext's active document's
+>       [=document/textFragmentToken=]. Set sourceBrowsingContext's active
+>       document's [=document/textFragmentToken=] to false.
+
+
 Amend the <a spec=HTML>try to scroll to the fragment</a> steps by replacing the
 steps of the task queued in step 2:
 
-1. If document has no parser, or its parser has stopped parsing, or the user
-    agent has reason to believe the user is no longer interested in scrolling to
-    the fragment, then clear <em>document</em>'s
-    [=allowTextFragmentDirective=] flag and abort these steps.
-2. Scroll to the fragment given in document's URL. If this does not find an
-    indicated part of the document, then try to scroll to the fragment for
-    document.
-3. Clear <em>document</em>'s [=allowTextFragmentDirective=] flag
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   1. If document has no parser, or its parser has stopped parsing, or the user
+>       agent has reason to believe the user is no longer interested in scrolling to
+>       the fragment, then clear <em>document</em>'s
+>       [=allowTextFragmentDirective=] flag and abort these steps.
+>   2. Scroll to the fragment given in document's URL. If this does not find an
+>       indicated part of the document, then try to scroll to the fragment for
+>       document.
+>   3. Clear <em>document</em>'s [=allowTextFragmentDirective=] flag
 
 
 ## Navigating to a Text Fragment ## {#navigating-to-text-fragment}
@@ -738,65 +774,79 @@ may be scrolled into view instead of the containing element.
 Replace step 3.1 of the <a spec=HTML>scroll to the fragment</a> algorithm with
 the following:
 
-1. Let <em>target, range</em> be the [=/element=] and [=range=] that is
-    <a spec=HTML>the indicated part of the document</a>.
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   1. Let <em>target, range</em> be the [=/element=] and [=range=] that is
+>       <a spec=HTML>the indicated part of the document</a>.
 
 Replace step 3.3 of the <a spec=HTML>scroll to the fragment</a> algorithm with
 the following:
 
-3. <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
-    the policy value</a> for `force-load-at-top` in the
-    [=Document=]. If the result is true, abort these steps.
-4. If <em>range</em> is non-null:
-    1. If the UA supports scrolling of text fragments on navigation, invoke
-        [=scroll a Range into view|Scroll range into view=], with range
-        <em>range</em>, containingElement <em>target</em>, <em>behavior</em> set
-        to "auto", <em>block</em> set to "center", and <em>inline</em> set to
-        "nearest".
-5. Otherwise:
-    1. <a spec=cssom-view lt="scroll an element into view">Scroll target
-        into view</a>, with <em>behavior</em> set to "auto", <em>block</em>
-        set to "start", and <em>inline</em> set to "nearest".
-        <div class="note">
-            This otherwise case is the same as the current step 3.3.
-        </div>
-
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   3. <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
+>       the policy value</a> for `force-load-at-top` in the
+>       [=Document=]. If the result is true, abort these steps.
+>   4. If <em>range</em> is non-null:
+>       1. If the UA supports scrolling of text fragments on navigation, invoke
+>           [=scroll a Range into view|Scroll range into view=], with range
+>           <em>range</em>, containingElement <em>target</em>, <em>behavior</em> set
+>           to "auto", <em>block</em> set to "center", and <em>inline</em> set to
+>           "nearest".
+>   5. Otherwise:
+>       1. <a spec=cssom-view lt="scroll an element into view">Scroll target
+>           into view</a>, with <em>behavior</em> set to "auto", <em>block</em>
+>           set to "start", and <em>inline</em> set to "nearest".
+>           <div class="note">
+>               This otherwise case is the same as the current step 3.3.
+>           </div>
 
 Add the following steps to the beginning of the processing model for
 <a spec=HTML>the indicated part of the document</a>:
 
-1. Let |fragment directive string| be the document's [=fragment directive=].
-1. If the document's [=allowTextFragmentDirective=] flag is true then:
-    1. Let |ranges| be a <a spec=infra>list</a> that is the result of running
-        the [=process a fragment directive=] steps with |fragment directive
-        string| and the document.
-    1. If |ranges| is non-empty, then:
-        1. Let |range| be the first item of |ranges|.
-            <div class="note">
-              The first [=range=] in |ranges| is specifically
-              scrolled into view. This [=range=], along with the
-              remaining |ranges| should be visually indicated in a way that
-              is not revealed to script, which is left as UA-defined behavior.
-            </div>
-        1. Let |node| be the [=first common ancestor=] of |range|'s
-            [=range/start node=] and [=range/end node=].
-        1. While |node| is non-null and is not an [=element=], set |node| to
-            |node|'s [=tree/parent=].
-        1. The indicated part of the document is |node| and |range|; return.
+>   <strong>Monkeypatching [[HTML]]:</strong>
+>
+>   1. Let |fragment directive string| be the document's [=fragment directive=].
+>   1. If the document's [=allowTextFragmentDirective=] flag is true then:
+>       1. Let |ranges| be a <a spec=infra>list</a> that is the result of running
+>           the [=process a fragment directive=] steps with |fragment directive
+>           string| and the document.
+>       1. If |ranges| is non-empty, then:
+>           1. Let |range| be the first item of |ranges|.
+>               <div class="note">
+>                 The first [=range=] in |ranges| is specifically
+>                 scrolled into view. This [=range=], along with the
+>                 remaining |ranges| should be visually indicated in a way that
+>                 is not revealed to script, which is left as UA-defined behavior.
+>               </div>
+>           1. Let |node| be the [=first common ancestor=] of |range|'s
+>               [=range/start node=] and [=range/end node=].
+>           1. While |node| is non-null and is not an [=element=], set |node| to
+>               |node|'s [=tree/parent=].
+>           1. The indicated part of the document is |node| and |range|; return.
 
+<div algorithm="first common ancestor">
 To find the <dfn>first common ancestor</dfn> of two nodes |nodeA| and |nodeB|,
 follow these steps:
 
-1. Let |commonAncestor| be |nodeA|.
-1. While |commonAncestor| is non-null and is not a [=shadow-including inclusive
-    ancestor=] of |nodeB|, let |commonAncestor| be |commonAncestor|’s
-    [=shadow-including parent=].
-1. Return |commonAncestor|.
 
+  <ol class="algorithm">
+    1. Let |commonAncestor| be |nodeA|.
+    1. While |commonAncestor| is non-null and is not a [=shadow-including inclusive
+        ancestor=] of |nodeB|, let |commonAncestor| be |commonAncestor|’s
+        [=shadow-including parent=].
+    1. Return |commonAncestor|.
+  </ol>
+</div>
+
+<div algorithm="shadow-including parent">
 To find the <dfn>shadow-including parent</dfn> of |node| follow these steps:
 
-1. If |node| is a [=/shadow root=], return |node|'s [=DocumentFragment/host=].
-1. Otherwise, return |node|'s [=tree/parent=].
+  <ol class="algorithm">
+    1. If |node| is a [=/shadow root=], return |node|'s [=DocumentFragment/host=].
+    1. Otherwise, return |node|'s [=tree/parent=].
+  </ol>
+</div>
 
 ### Scroll a DOMRect into view ### {#scroll-rect-into-view}
 <div class="note">
@@ -821,20 +871,53 @@ ignore=''>scrolling box</var>, in order of innermost to outermost scrolling box"
   |bounding box| is renamed from |element bounding border box|.
 </div>
 
+>   <strong>Monkeypatching [[CSSOM-VIEW]]:</strong>
+>
+>   To scroll a DOMRect into view given a {{DOMRect}} |bounding box|,
+>   a scroll behavior |behavior|,
+>   a block flow direction position |block|,
+>   and an inline base direction position |inline|,
+>   and [=element=] |startingElement|, means to run these steps for each ancestor element or viewport of |startingElement| that establishes
+>   a scrolling box <var ignore=''>scrolling box</var>, in order of innermost to outermost scrolling box:
+>
+>   <em>OMITTED</em>
+>
+>   <div class="note">
+>     TODO: There's more to do here since the |bounding box| needs to be
+>     transformed with each step to an ancestor element or viewport.
+>   </div>
+
+
 Replace steps 3-14 of the <a spec=cssom-view>scroll an element into view</a>
 algorithm with a call to [=scroll a DOMRect into view=]:
 
-3. Perform [=scroll a DOMRect into view=] given |element bounding border box|,
-    |options| and <var ignore=''>element</var>.
+>   <strong>Monkeypatching [[CSSOM-VIEW]]:</strong>
+>
+>   To scroll an element into view |element|,
+>   with a scroll behavior |behavior|,
+>   a block flow direction position |block|,
+>   and an inline base direction position |inline|,
+>   means to run these steps:
+>
+>   1. If the {{Document}} associated with |element| is not same origin with the {{Document}} associated with the element or viewport associated with <var ignore=''>box</var>, terminate these steps.
+>   1. Let |element bounding border box| be the box that the return value of invoking {{Element/getBoundingClientRect()}} on |element| represents.
+>   1. Perform [=scroll a DOMRect into view=] given |element bounding border box|,
+>       |options| and |element|.
 
-Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
-[=range=] |range|, [=element=] |containingElement|, and a
-{{ScrollIntoViewOptions}} dictionary |options|:
+Define a new algorithm for scrolling [=Range=] into view:
 
-1. Let |bounding rect| be the {{DOMRect}} that is the return value of
-    invoking {{Range/getBoundingClientRect()}} on |range|.
-2. Perform [=scroll a DOMRect into view=] given |bounding rect|, |options|, and
-    |containingElement|.
+>   <strong>Monkeypatching [[CSSOM-VIEW]]:</strong>
+>
+>   To <dfn>scroll a Range into view</dfn>, with input
+>   [=range=] |range|,
+>   scroll behavior |behavior|,
+>   a block flow direction position |block|,
+>   an inline base direction position |inline|,
+>   and an [=element=] |containingElement|:
+>   1. Let |bounding rect| be the {{DOMRect}} that is the return value of
+>       invoking {{Range/getBoundingClientRect()}} on |range|.
+>   2. Perform [=scroll a DOMRect into view=] given |bounding rect|, |behavior|, |block|, |inline|, and
+>       |containingElement|.
 
 ### Finding Ranges in a Document ### {#finding-ranges-in-a-document}
 
@@ -871,6 +954,7 @@ Define a new algorithm <dfn>scroll a Range into view</dfn>, with input
   list.
 </div>
 
+<div algorithm="process a fragment directive">
 To <dfn>process a fragment directive</dfn>, given as input a <a
 spec=infra>string</a> |fragment directive input| and a [=Document=]
 |document|, run these steps:
@@ -883,23 +967,27 @@ spec=infra>string</a> |fragment directive input| and a [=Document=]
   automatically).
 </div>
 
-1. If |fragment directive input| is not a [=valid fragment directive=], then
-    return an empty <a spec=infra>list</a>.
-2. Let |directives| be a <a spec=infra>list</a> of <a spec=infra>string</a>s
-    that is the result of [=strictly split a string|strictly splitting the
-    string=] |fragment directive input| on "&".
-3. Let |ranges| be a <a spec=infra>list</a> of [=ranges=], initially empty.
-4. For each <a spec=infra>string</a> |directive| of |directives|:
-    1. If |directive| does not match the production [=TextDirective=],
-        then [=iteration/continue=].
-    1. Let |parsedValues| be the result of running the [=parse a text
-        directive=] steps on |directive|.
-    1. If |parsedValues| is null then [=iteration/continue=].
-    1. If the result of running [=find a range from a text directive=] given
-        |parsedValues| and |document| is non-null, then [=list/append=] it to
-        |ranges|.
-5. Return |ranges|.
+  <ol class="algorithm">
+    1. If |fragment directive input| is not a [=valid fragment directive=], then
+        return an empty <a spec=infra>list</a>.
+    2. Let |directives| be a <a spec=infra>list</a> of <a spec=infra>string</a>s
+        that is the result of [=strictly split a string|strictly splitting the
+        string=] |fragment directive input| on "&".
+    3. Let |ranges| be a <a spec=infra>list</a> of [=ranges=], initially empty.
+    4. For each <a spec=infra>string</a> |directive| of |directives|:
+        1. If |directive| does not match the production [=TextDirective=],
+            then [=iteration/continue=].
+        1. Let |parsedValues| be the result of running the [=parse a text
+            directive=] steps on |directive|.
+        1. If |parsedValues| is null then [=iteration/continue=].
+        1. If the result of running [=find a range from a text directive=] given
+            |parsedValues| and |document| is non-null, then [=list/append=] it to
+            |ranges|.
+    5. Return |ranges|.
+  </ol>
+</div>
 
+<div algorithm="find a range from a text directive">
 To <dfn>find a range from a text directive</dfn>, given a
 [=ParsedTextDirective=] |parsedValues| and [=Document=] |document|, run the
 following steps:
@@ -953,138 +1041,146 @@ following steps:
 
   </div>
 </div>
-
-1. Let |searchRange| be a [=range=] with [=range/start=] (|document|, 0) and
-    [=range/end=] (|document|, |document|'s [=Node/length=])
-1. While |searchRange| is not [=range/collapsed=]:
-    1. Let |potentialMatch| be null.
-    1. If |parsedValues|'s [=ParsedTextDirective/prefix=] is not null:
-        1. Let |prefixMatch| be the the result of running the [=find a string
-            in range=] steps with |query| |parsedValues|'s
-            [=ParsedTextDirective/prefix=], |searchRange| |searchRange|,
-            |wordStartBounded| true and |wordEndBounded| false.
-        1. If |prefixMatch| is null, return null.
-        1. Set |searchRange|'s [=range/start=] to the first [=/boundary point=]
-            [=boundary point/after=] |prefixMatch|'s [=range/start=]
-        1. Let |matchRange| be a [=range=] whose [=range/start=] is
-            |prefixMatch|'s [=range/end=] and [=range/end=] is |searchRange|'s
-            [=range/end=].
-        1. Advance |matchRange|'s [=range/start=] to the
-            [=next non-whitespace position=].
-        1. If |matchRange| is [=range/collapsed=] return null.
-            <div class="note">
-              This can happen if |prefixMatch|'s [=range/end=] or its subsequent
-              non-whitespace position is at the end of the document.
-            </div>
-        1. [=/Assert=]: |matchRange|'s [=range/start node=] is a {{Text}} node.
-            <div class="note">
-              |matchRange|'s [=range/start=] now points to the next
-              non-whitespace text data following a matched prefix.
-            </div>
-        1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
-            [=ParsedTextDirective/textEnd=] is non-null or
-            |parsedValues|'s [=ParsedTextDirective/suffix=] is null, false
-            otherwise.
-        1. Set |potentialMatch| to the result of running the [=find a string in
-            range=] steps with |query| |parsedValues|'s
-            [=ParsedTextDirective/textStart=], |searchRange| |matchRange|,
-            |wordStartBounded| false, and |wordEndBounded|
-            |mustEndAtWordBoundary|.
-        1. If |potentialMatch| is null, return null.
-        1. If |potentialMatch|'s [=range/start=] is not |matchRange|'s
-            [=range/start=], then [=iteration/continue=].
-            <div class="note">
-              In this case, we found a prefix but it was followed by something
-              other than a matching text so we'll continue searching for the
-              next instance of [=ParsedTextDirective/prefix=].
-            </div>
-    1. Otherwise:
-        1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
-            [=ParsedTextDirective/textEnd=] is non-null or
-            |parsedValues|'s [=ParsedTextDirective/suffix=] is null, false
-            otherwise.
-        1. Set |potentialMatch| to the result of running the [=find a string in
-            range=] steps with |query| |parsedValues|'s
-            [=ParsedTextDirective/textStart=], |searchRange| |searchRange|,
-            |wordStartBounded| true, and |wordEndBounded|
-            |mustEndAtWordBoundary|.
-        1. If |potentialMatch| is null, return null.
-        1. Set |searchRange|'s [=range/start=] to the first [=/boundary point=]
-            [=boundary point/after=] |potentialMatch|'s [=range/start=]
-    1. If |parsedValues|'s [=ParsedTextDirective/textEnd=] item is
-        non-null, then:
-        1. Let |textEndRange| be a [=range=] whose [=range/start=] is
-            |potentialMatch|'s [=range/end=] and whose [=range/end=] is
+  <ol class="algorithm">
+    1. Let |searchRange| be a [=range=] with [=range/start=] (|document|, 0) and
+        [=range/end=] (|document|, |document|'s [=Node/length=])
+    1. While |searchRange| is not [=range/collapsed=]:
+        1. Let |potentialMatch| be null.
+        1. If |parsedValues|'s [=ParsedTextDirective/prefix=] is not null:
+            1. Let |prefixMatch| be the the result of running the [=find a string
+                in range=] steps with |query| |parsedValues|'s
+                [=ParsedTextDirective/prefix=], |searchRange| |searchRange|,
+                |wordStartBounded| true and |wordEndBounded| false.
+            1. If |prefixMatch| is null, return null.
+            1. Set |searchRange|'s [=range/start=] to the first [=/boundary point=]
+                [=boundary point/after=] |prefixMatch|'s [=range/start=]
+            1. Let |matchRange| be a [=range=] whose [=range/start=] is
+                |prefixMatch|'s [=range/end=] and [=range/end=] is |searchRange|'s
+                [=range/end=].
+            1. Advance |matchRange|'s [=range/start=] to the
+                [=next non-whitespace position=].
+            1. If |matchRange| is [=range/collapsed=] return null.
+                <div class="note">
+                  This can happen if |prefixMatch|'s [=range/end=] or its subsequent
+                  non-whitespace position is at the end of the document.
+                </div>
+            1. [=/Assert=]: |matchRange|'s [=range/start node=] is a {{Text}} node.
+                <div class="note">
+                  |matchRange|'s [=range/start=] now points to the next
+                  non-whitespace text data following a matched prefix.
+                </div>
+            1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
+                [=ParsedTextDirective/textEnd=] is non-null or
+                |parsedValues|'s [=ParsedTextDirective/suffix=] is null, false
+                otherwise.
+            1. Set |potentialMatch| to the result of running the [=find a string in
+                range=] steps with |query| |parsedValues|'s
+                [=ParsedTextDirective/textStart=], |searchRange| |matchRange|,
+                |wordStartBounded| false, and |wordEndBounded|
+                |mustEndAtWordBoundary|.
+            1. If |potentialMatch| is null, return null.
+            1. If |potentialMatch|'s [=range/start=] is not |matchRange|'s
+                [=range/start=], then [=iteration/continue=].
+                <div class="note">
+                  In this case, we found a prefix but it was followed by something
+                  other than a matching text so we'll continue searching for the
+                  next instance of [=ParsedTextDirective/prefix=].
+                </div>
+        1. Otherwise:
+            1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
+                [=ParsedTextDirective/textEnd=] is non-null or
+                |parsedValues|'s [=ParsedTextDirective/suffix=] is null, false
+                otherwise.
+            1. Set |potentialMatch| to the result of running the [=find a string in
+                range=] steps with |query| |parsedValues|'s
+                [=ParsedTextDirective/textStart=], |searchRange| |searchRange|,
+                |wordStartBounded| true, and |wordEndBounded|
+                |mustEndAtWordBoundary|.
+            1. If |potentialMatch| is null, return null.
+            1. Set |searchRange|'s [=range/start=] to the first [=/boundary point=]
+                [=boundary point/after=] |potentialMatch|'s [=range/start=]
+        1. If |parsedValues|'s [=ParsedTextDirective/textEnd=] item is
+            non-null, then:
+            1. Let |textEndRange| be a [=range=] whose [=range/start=] is
+                |potentialMatch|'s [=range/end=] and whose [=range/end=] is
+                |searchRange|'s [=range/end=].
+            1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
+                [=ParsedTextDirective/suffix=] is null, false otherwise.
+            1. Let |textEndMatch| be the result of running the [=find a string
+                in range=] steps with |query| |parsedValues|'s
+                [=ParsedTextDirective/textEnd=], |searchRange| |textEndRange|,
+                |wordStartBounded| true, and |wordEndBounded|
+                |mustEndAtWordBoundary|.
+            1. If |textEndMatch| is null then return null.
+            1. Set |potentialMatch|'s [=range/end=] to |textEndMatch|'s
+                [=range/end=].
+        1. [=/Assert=]: |potentialMatch| is non-null, not [=range/collapsed=] and
+            represents a range exactly containing an instance of matching text.
+        1. If |parsedValues|'s [=ParsedTextDirective/suffix=] is null, return
+            |potentialMatch|.
+        1. Let |suffixRange| be a [=range=] with [=range/start=] equal to
+            |potentialMatch|'s [=range/end=] and [=range/end=] equal to
             |searchRange|'s [=range/end=].
-        1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
-            [=ParsedTextDirective/suffix=] is null, false otherwise.
-        1. Let |textEndMatch| be the result of running the [=find a string
-            in range=] steps with |query| |parsedValues|'s
-            [=ParsedTextDirective/textEnd=], |searchRange| |textEndRange|,
-            |wordStartBounded| true, and |wordEndBounded|
-            |mustEndAtWordBoundary|.
-        1. If |textEndMatch| is null then return null.
-        1. Set |potentialMatch|'s [=range/end=] to |textEndMatch|'s
-            [=range/end=].
-    1. [=/Assert=]: |potentialMatch| is non-null, not [=range/collapsed=] and
-        represents a range exactly containing an instance of matching text.
-    1. If |parsedValues|'s [=ParsedTextDirective/suffix=] is null, return
-        |potentialMatch|.
-    1. Let |suffixRange| be a [=range=] with [=range/start=] equal to
-        |potentialMatch|'s [=range/end=] and [=range/end=] equal to
-        |searchRange|'s [=range/end=].
-    1. Advance |suffixRange|'s [=range/start=] to the [=next non-whitespace
-        position=].
-    1. Let |suffixMatch| be result of running the [=find a string in range=]
-        steps with |query| |parsedValues|'s [=ParsedTextDirective/suffix=],
-        |searchRange| |suffixRange|, |wordStartBounded| false, and
-        |wordEndBounded| true.
-    1. If |suffixMatch| is null then return null.
-        <div class="note">
-          If the suffix doesn't appear in the remaining text of the document,
-          there's no possible way to make a match.
-        </div>
-    1. If |suffixMatch|'s [=range/start=] is |suffixRange|'s [=range/start=],
-        return |potentialMatch|.
-1. Return null
+        1. Advance |suffixRange|'s [=range/start=] to the [=next non-whitespace
+            position=].
+        1. Let |suffixMatch| be result of running the [=find a string in range=]
+            steps with |query| |parsedValues|'s [=ParsedTextDirective/suffix=],
+            |searchRange| |suffixRange|, |wordStartBounded| false, and
+            |wordEndBounded| true.
+        1. If |suffixMatch| is null then return null.
+            <div class="note">
+              If the suffix doesn't appear in the remaining text of the document,
+              there's no possible way to make a match.
+            </div>
+        1. If |suffixMatch|'s [=range/start=] is |suffixRange|'s [=range/start=],
+            return |potentialMatch|.
+    1. Return null
+  </ol>
+
+</div>
 
 <wpt>
   /scroll-to-text-fragment/find-range-from-text-directive.html
 </wpt>
 
+<div algorithm="advance range start to next non-whitespace position">
 To advance a [=range=] |range|'s [=range/start=] to the <dfn>next
 non-whitespace position</dfn> follow the steps:
 
-1. While |range| is not collapsed:
-    1. Let |node| be |range|'s [=range/start node=].
-    1. Let |offset| be |range|'s [=range/start offset=].
-    1. If |node| is part of a [=non-searchable subtree=] then:
-        1. Set |range|'s [=range/start node=] to the next node, in
-            [=shadow-including tree order=], that isn't a [=shadow-including
-            descendant=] of |node|, and set its [=range/start offset=] to 0.
-        1. [=iteration/Continue=].
-    1. If |node| is not a [=visible text node=]:
-        1. Set |range|'s [=range/start node=] to the next node, in
-            [=shadow-including tree order=], and set its [=range/start offset=]
-            to 0.
-        1. [=iteration/Continue=].
-    1. If the [=Text/substring data=] of |node| at offset |offset|
-        and count 6 is equal to the string "&amp;nbsp;" then:
-        1. Add 6 to |range|'s [=range/start offset=].
-    1. Otherwise, if the [=Text/substring data=] of |node| at offset |offset|
-        and count 5 is equal to the string "&amp;nbsp" then:
-        1. Add 5 to |range|'s [=range/start offset=].
-    1. Otherwise:
-        1. Let |cp| be the [=code point=] at the |offset| index in |node|'s
-            [=CharacterData/data=].
-        1. If |cp| does not have the <a
-            href="http://www.unicode.org/reports/tr44/#White_Space">White_Space</a>
-            property set, return.
-        1. Add 1 to |range|'s [=range/start offset=].
-    1. If |range|'s [=range/start offset=] is equal to |node|'s
-        [=Node/length=], set |range|'s [=range/start node=] to the next node in
-        [=shadow-including tree order=], and set its [=range/start offset=] to 0.
+  <ol class="algorithm">
+    1. While |range| is not collapsed:
+        1. Let |node| be |range|'s [=range/start node=].
+        1. Let |offset| be |range|'s [=range/start offset=].
+        1. If |node| is part of a [=non-searchable subtree=] then:
+            1. Set |range|'s [=range/start node=] to the next node, in
+                [=shadow-including tree order=], that isn't a [=shadow-including
+                descendant=] of |node|, and set its [=range/start offset=] to 0.
+            1. [=iteration/Continue=].
+        1. If |node| is not a [=visible text node=]:
+            1. Set |range|'s [=range/start node=] to the next node, in
+                [=shadow-including tree order=], and set its [=range/start offset=]
+                to 0.
+            1. [=iteration/Continue=].
+        1. If the [=Text/substring data=] of |node| at offset |offset|
+            and count 6 is equal to the string "&amp;nbsp;" then:
+            1. Add 6 to |range|'s [=range/start offset=].
+        1. Otherwise, if the [=Text/substring data=] of |node| at offset |offset|
+            and count 5 is equal to the string "&amp;nbsp" then:
+            1. Add 5 to |range|'s [=range/start offset=].
+        1. Otherwise:
+            1. Let |cp| be the [=code point=] at the |offset| index in |node|'s
+                [=CharacterData/data=].
+            1. If |cp| does not have the <a
+                href="http://www.unicode.org/reports/tr44/#White_Space">White_Space</a>
+                property set, return.
+            1. Add 1 to |range|'s [=range/start offset=].
+        1. If |range|'s [=range/start offset=] is equal to |node|'s
+            [=Node/length=], set |range|'s [=range/start node=] to the next node in
+            [=shadow-including tree order=], and set its [=range/start offset=] to 0.
+  </ol>
+</div>
 
+<div algorithm="find a string in a range">
 To <dfn>find a string in range</dfn> given a <a spec=infra>string</a> |query|, a
 [=range=] |searchRange|, and booleans |wordStartBounded| and |wordEndBounded|,
 run these steps:
@@ -1120,42 +1216,45 @@ run these steps:
   a block-level container) within a single block-level container.
 </div>
 
-1. While |searchRange| is not [=range/collapsed=]:
-    1. Let |curNode| be |searchRange|'s [=range/start node=].
-    1. If |curNode| is part of a [=non-searchable subtree=]:
-        1. Set |searchRange|'s [=range/start node=] to the next node, in
-            [=shadow-including tree order=], that isn't a [=shadow-including
-            descendant=] of |curNode|.
-        1. [=iteration/Continue=].
-    1. If |curNode| is not a [=visible text node=]:
-        1. Set |searchRange|'s [=range/start node=] to the next node, in
-            [=shadow-including tree order=], that is not a [=doctype=], and
-            set its [=range/start offset=] to 0.
-        1. [=iteration/Continue=].
-    1. Let |blockAncestor| be the [=nearest block ancestor=] of |curNode|.
-    1. Let |textNodeList| be a <a spec=infra>list</a> of {{Text}} nodes,
-        initially empty.
-    1. While |curNode| is a [=shadow-including descendant=] of |blockAncestor|
-        and the position of the [=/boundary point=] (|curNode|, 0) is not
-        [=boundary point/after=] |searchRange|'s [=range/end=]:
-        1. If |curNode| [=has block-level display=] then [=iteration/break=].
-        1. If |curNode| is [=search invisible=]:
-            1. Set |curNode| to the next node, in [=shadow-including tree
-                order=], that isn't a [=shadow-including descendant=] of
-                |curNode|.
-            2. [=iteration/Continue=].
-        1. If |curNode| is a [=visible text node=] then append it to
-            |textNodeList|.
-        1. Set |curNode| to the next node in [=shadow-including tree order=].
-    1. Run the [=find a range from a node list=] steps given |query|,
-        |searchRange|, |textNodeList|, |wordStartBounded| and |wordEndBounded|
-        as input. If the resulting [=range=] is not null, then return it.
-    1. If |curNode| is null, then [=iteration/break=].
-    1. [=/Assert=]: |curNode| [=tree/following|follows=] |searchRange|'s
-        [=range/start node=].
-    1. Set |searchRange|'s [=range/start=] to the [=/boundary point=] (|curNode|,
-        0).
-1. Return null.
+  <ol class="algorithm">
+    1. While |searchRange| is not [=range/collapsed=]:
+        1. Let |curNode| be |searchRange|'s [=range/start node=].
+        1. If |curNode| is part of a [=non-searchable subtree=]:
+            1. Set |searchRange|'s [=range/start node=] to the next node, in
+                [=shadow-including tree order=], that isn't a [=shadow-including
+                descendant=] of |curNode|.
+            1. [=iteration/Continue=].
+        1. If |curNode| is not a [=visible text node=]:
+            1. Set |searchRange|'s [=range/start node=] to the next node, in
+                [=shadow-including tree order=], that is not a [=doctype=], and
+                set its [=range/start offset=] to 0.
+            1. [=iteration/Continue=].
+        1. Let |blockAncestor| be the [=nearest block ancestor=] of |curNode|.
+        1. Let |textNodeList| be a <a spec=infra>list</a> of {{Text}} nodes,
+            initially empty.
+        1. While |curNode| is a [=shadow-including descendant=] of |blockAncestor|
+            and the position of the [=/boundary point=] (|curNode|, 0) is not
+            [=boundary point/after=] |searchRange|'s [=range/end=]:
+            1. If |curNode| [=has block-level display=] then [=iteration/break=].
+            1. If |curNode| is [=search invisible=]:
+                1. Set |curNode| to the next node, in [=shadow-including tree
+                    order=], that isn't a [=shadow-including descendant=] of
+                    |curNode|.
+                2. [=iteration/Continue=].
+            1. If |curNode| is a [=visible text node=] then append it to
+                |textNodeList|.
+            1. Set |curNode| to the next node in [=shadow-including tree order=].
+        1. Run the [=find a range from a node list=] steps given |query|,
+            |searchRange|, |textNodeList|, |wordStartBounded| and |wordEndBounded|
+            as input. If the resulting [=range=] is not null, then return it.
+        1. If |curNode| is null, then [=iteration/break=].
+        1. [=/Assert=]: |curNode| [=tree/following|follows=] |searchRange|'s
+            [=range/start node=].
+        1. Set |searchRange|'s [=range/start=] to the [=/boundary point=] (|curNode|,
+            0).
+    1. Return null.
+  </ol>
+</div>
 
 A node is <dfn>search invisible</dfn> if it is an [=element=] in the [=HTML
 namespace=] and meets any of the following conditions:
@@ -1179,14 +1278,19 @@ A node <dfn>has block-level display</dfn> if it is an [=element=] and the [=comp
 ''display/flow-root'', ''display/grid'', ''display/flex'',
 ''display/list-item''.
 
+<div algorithm="nearest block ancestor">
 To find the <dfn>nearest block ancestor</dfn> of a |node| follow the steps:
-1. Let |curNode| be |node|.
-1. While |curNode| is non-null
-    1. If |curNode| is not a {{Text}} node and it [=has block-level display=] then
-        return |curNode|.
-    1. Otherwise, set |curNode| to |curNode|'s [=tree/parent=].
-1. Return |node|'s [=Node/node document=]'s [=document element=].
+  <ol class="algorithm">
+    1. Let |curNode| be |node|.
+    1. While |curNode| is non-null
+        1. If |curNode| is not a {{Text}} node and it [=has block-level display=] then
+            return |curNode|.
+        1. Otherwise, set |curNode| to |curNode|'s [=tree/parent=].
+    1. Return |node|'s [=Node/node document=]'s [=document element=].
+  </ol>
+</div>
 
+<div algorithm="range from node list">
 To <dfn>find a range from a node list</dfn> given a search string |queryString|,
 a [=range=] |searchRange|, a [=/list=] of {{Text}} nodes |nodes|, and booleans
 |wordStartBounded| and |wordEndBounded|, follow these steps:
@@ -1204,59 +1308,63 @@ a [=range=] |searchRange|, a [=/list=] of {{Text}} nodes |nodes|, and booleans
   See [[#word-boundaries]] for details and more examples.
 </div>
 
-1. Let |searchBuffer| be the [=string/concatenate|concatenation=] of the
-    [=CharacterData/data=] of each item in |nodes|.
-1. Let |searchStart| be 0.
-1. If the first item in |nodes| is |searchRange|'s [=range/start node=] then
-    set |searchStart| to |searchRange|'s [=range/start offset=].
-1. Let |start| and |end| be [=/boundary points=], initially null.
-1. Let |matchIndex| be null.
-1. While |matchIndex| is null
-    1. Set |matchIndex| to the index of the first instance of |queryString| in
-        |searchBuffer|, starting at |searchStart|. The string search must be
-        performed using a base character comparison, or the
-        <a href="http://www.unicode.org/reports/tr10/#Multi_Level_Comparison">primary
-        level</a>, as defined in [[!UTS10]].
+  <ol class="algorithm">
+    1. Let |searchBuffer| be the [=string/concatenate|concatenation=] of the
+        [=CharacterData/data=] of each item in |nodes|.
+    1. Let |searchStart| be 0.
+    1. If the first item in |nodes| is |searchRange|'s [=range/start node=] then
+        set |searchStart| to |searchRange|'s [=range/start offset=].
+    1. Let |start| and |end| be [=/boundary points=], initially null.
+    1. Let |matchIndex| be null.
+    1. While |matchIndex| is null
+        1. Set |matchIndex| to the index of the first instance of |queryString| in
+            |searchBuffer|, starting at |searchStart|. The string search must be
+            performed using a base character comparison, or the
+            <a href="http://www.unicode.org/reports/tr10/#Multi_Level_Comparison">primary
+            level</a>, as defined in [[!UTS10]].
+            <div class="note">
+              Intuitively, this is a case-insensitive search also ignoring accents
+              and other marks.
+            </div>
+        1. If |matchIndex| is null, return null.
+        1. Let |endIx| be |matchIndex| + |queryString|'s [=string/length=].
+            <div class="note">
+               |endIx| is the index of the last character in the match + 1.
+            </div>
+        1. Set |start| to the [=/boundary point=] result of [=get boundary point at
+            index=] |matchIndex| run over |nodes| with |isEnd| false.
+        1. Set |end| to the [=/boundary point=] result of [=get boundary point at
+            index=] |endIx| run over |nodes| with |isEnd| true.
+        1. If |wordStartBounded| is true and |matchIndex| [=is at a word boundary|is
+            not at a word boundary=] in |searchBuffer|, given the <a
+            spec=html>language</a> from |start|'s [=boundary point/node=] as the
+            |locale|; or |wordEndBounded| is true and |matchIndex| + |queryString|'s
+            [=string/length=] [=is at a word boundary|is not at a word boundary=] in
+            |searchBuffer|, given the <a spec=html>language</a> from |end|'s
+            [=boundary point/node=] as the |locale|:
+            1. Set |searchStart| to |matchIndex| + 1.
+            1. Set |matchIndex| to null.
+    1. Let |endInset| be 0.
+    1. If the last item in |nodes| is |searchRange|'s [=range/end node=] then set
+        |endInset| to (|searchRange|'s [=range/end node=]'s [=Node/length=] &minus;
+        |searchRange|'s [=range/end offset=])
         <div class="note">
-          Intuitively, this is a case-insensitive search also ignoring accents
-          and other marks.
+          |endInset| is the offset from the last position in the last node in the
+          reverse direction. Alternatively, it is the length of the node that's not
+          included in the range.
         </div>
-    1. If |matchIndex| is null, return null.
-    1. Let |endIx| be |matchIndex| + |queryString|'s [=string/length=].
+    1. If |matchIndex| + |queryString|'s [=string/length=] is greater than
+        |searchBuffer|'s length &minus; |endInset| return null.
         <div class="note">
-           |endIx| is the index of the last character in the match + 1.
+          If the match runs past the end of the search range, return null.
         </div>
-    1. Set |start| to the [=/boundary point=] result of [=get boundary point at
-        index=] |matchIndex| run over |nodes| with |isEnd| false.
-    1. Set |end| to the [=/boundary point=] result of [=get boundary point at
-        index=] |endIx| run over |nodes| with |isEnd| true.
-    1. If |wordStartBounded| is true and |matchIndex| [=is at a word boundary|is
-        not at a word boundary=] in |searchBuffer|, given the <a
-        spec=html>language</a> from |start|'s [=boundary point/node=] as the
-        |locale|; or |wordEndBounded| is true and |matchIndex| + |queryString|'s
-        [=string/length=] [=is at a word boundary|is not at a word boundary=] in
-        |searchBuffer|, given the <a spec=html>language</a> from |end|'s
-        [=boundary point/node=] as the |locale|:
-        1. Set |searchStart| to |matchIndex| + 1.
-        1. Set |matchIndex| to null.
-1. Let |endInset| be 0.
-1. If the last item in |nodes| is |searchRange|'s [=range/end node=] then set
-    |endInset| to (|searchRange|'s [=range/end node=]'s [=Node/length=] &minus;
-    |searchRange|'s [=range/end offset=])
-    <div class="note">
-      |endInset| is the offset from the last position in the last node in the
-      reverse direction. Alternatively, it is the length of the node that's not
-      included in the range.
-    </div>
-1. If |matchIndex| + |queryString|'s [=string/length=] is greater than
-    |searchBuffer|'s length &minus; |endInset| return null.
-    <div class="note">
-      If the match runs past the end of the search range, return null.
-    </div>
-1. [=/Assert=]: |start| and |end| are non-null, valid [=/boundary points=] in
-    |searchRange|.
-1. Return a [=range=] with [=range/start=] |start| and [=range/end=] |end|.
+    1. [=/Assert=]: |start| and |end| are non-null, valid [=/boundary points=] in
+        |searchRange|.
+    1. Return a [=range=] with [=range/start=] |start| and [=range/end=] |end|.
+  </ol>
+</div>
 
+<div algorithm="boundary point at index">
 To <dfn>get boundary point at index</dfn>, given an integer |index|, [=/list=]
 of {{Text}} nodes |nodes|, and a boolean |isEnd|, follow these steps:
 
@@ -1273,14 +1381,17 @@ of {{Text}} nodes |nodes|, and a boolean |isEnd|, follow these steps:
   </p>
 </div>
 
-1. Let |counted| be 0.
-1. For each |curNode| of |nodes|:
-    1. Let |nodeEnd| be |counted| + |curNode|'s [=Node/length=].
-    1. If |isEnd| is true, add 1 to |nodeEnd|.
-    1. If |nodeEnd| is greater than |index| then:
-        1. Return the [=/boundary point=] (|curNode|, |index| &minus; |counted|).
-    1. Increment |counted| by |curNode|'s [=Node/length=].
-1. Return null.
+  <ol class="algorithm">
+    1. Let |counted| be 0.
+    1. For each |curNode| of |nodes|:
+        1. Let |nodeEnd| be |counted| + |curNode|'s [=Node/length=].
+        1. If |isEnd| is true, add 1 to |nodeEnd|.
+        1. If |nodeEnd| is greater than |index| then:
+            1. Return the [=/boundary point=] (|curNode|, |index| &minus; |counted|).
+        1. Increment |counted| by |curNode|'s [=Node/length=].
+    1. Return null.
+  </ol>
+</div>
 
 ### Word Boundaries ### {#word-boundaries}
 <div class="note">
@@ -1325,8 +1436,8 @@ boundary=] immediately precedes the |position|th code unit, or |text|'s length
 is more than 0 and |position| equals either 0 or |text|'s length.
 
 <div class="note">
-  Intuitively, a substring is word bounded if it neither begins nor ends in the
-  middle of a word.
+  Intuitively, a substring is [=word bounded=] if it neither begins nor ends in
+  the middle of a word.
 
   In languages with a word separator (e.g. " " space) this is (mostly)
   straightforward; though there are details covered by the above technical

--- a/index.html
+++ b/index.html
@@ -1750,6 +1750,17 @@ c-[vg] { color: #0077aa } /* Name.Variable.Global */
 c-[vi] { color: #0077aa } /* Name.Variable.Instance */
 c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
+<style>/* style-var-click-highlighting */
+
+    var { cursor: pointer; }
+    var.selected0 { background-color: #F4D200; box-shadow: 0 0 0 2px #F4D200; }
+    var.selected1 { background-color: #FF87A2; box-shadow: 0 0 0 2px #FF87A2; }
+    var.selected2 { background-color: #96E885; box-shadow: 0 0 0 2px #96E885; }
+    var.selected3 { background-color: #3EEED2; box-shadow: 0 0 0 2px #3EEED2; }
+    var.selected4 { background-color: #EACFB6; box-shadow: 0 0 0 2px #EACFB6; }
+    var.selected5 { background-color: #82DDFF; box-shadow: 0 0 0 2px #82DDFF; }
+    var.selected6 { background-color: #FFBCF2; box-shadow: 0 0 0 2px #FFBCF2; }
+    </style>
 <style>/* style-wpt */
 
 :root {
@@ -2002,9 +2013,12 @@ introducing breaking changes to existing content. Potential examples could be:
 translation-hints or enabling accessibility features.</p>
    <h4 class="heading settled" data-level="3.3.1" id="parsing-the-fragment-directive"><span class="secno">3.3.1. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
    <p>To the definition of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>, add:</p>
-   <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is either
-  null or an ASCII string holding data used by the UA to process the resource. It
-  is initially null. </em></p>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is
+    either null or an ASCII string holding data used by the UA to process the
+    resource. It is initially null. </em></p>
+   </blockquote>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-delimiter">fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> is part of the URL fragment. This means it must
@@ -2013,119 +2027,123 @@ three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
   must first be appended to the URL: https://example.com#:~:text=foo. </div>
    <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to parse and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> from the Document’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url">URL</a>.</p>
    <p>Replace steps 7 and 8 of this algorithm with:</p>
-   <ol start="7">
-    <li data-md>
-     <p>Let <var>url</var> be null</p>
-    <li data-md>
-     <p>If <var>request</var> is non-null, then set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url①">URL</a> to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a>.</p>
-    <li data-md>
-     <p>Otherwise, set <var>url</var> to <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">URL</a>.</p>
-    <li data-md>
-     <p>Let <var>raw fragment</var> be equal to <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment">fragment</a>.</p>
-    <li data-md>
-     <p>If <var>raw fragment</var> is non-null:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>fragmentDirectivePosition</var> be an integer initialized to 0.</p>
-      <li data-md>
-       <p>While the substring of <var>raw fragment</var> starting at position <var>fragmentDirectivePosition</var> does not begin with the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive
-delimiter</a> and <var>fragmentDirectivePosition</var> does not point past the end
-of <var>raw fragment</var>:</p>
-       <ol>
-        <li data-md>
-         <p>Increment <var>fragmentDirectivePosition</var> by 1.</p>
-       </ol>
-      <li data-md>
-       <p>If <var>fragmentDirectivePosition</var> does not point past the end of <var>raw
-fragment</var>:</p>
-       <ol>
-        <li data-md>
-         <p>Let <var>fragment</var> be the substring of <var>raw fragment</var> starting at 0 of
-count <var>fragmentDirectivePosition</var>.</p>
-        <li data-md>
-         <p>Advance <var>fragmentDirectivePosition</var> by the length of <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment
-directive delimiter</a>.</p>
-        <li data-md>
-         <p>Let <var>fragment directive</var> be the substring of <var>raw fragment</var> starting
-at <var>fragmentDirectivePosition</var>.</p>
-        <li data-md>
-         <p>Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment①">fragment</a> to <var>fragment</var>.</p>
-        <li data-md>
-         <p>Set <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> to <var>fragment directive</var>.
-(Note: this is stored on the document but not web-exposed)</p>
-       </ol>
-     </ol>
-    <li data-md>
-     <p>Set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url②">URL</a> to be <var>url</var>.</p>
-   </ol>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <ol start="7">
+     <li data-md>
+      <p>Let <var>url</var> be null</p>
+     <li data-md>
+      <p>If <var>request</var> is non-null, then set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url①">URL</a> to <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current URL</a>.</p>
+     <li data-md>
+      <p>Otherwise, set <var>url</var> to <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">URL</a>.</p>
+     <li data-md>
+      <p>Let <var>raw fragment</var> be equal to <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment">fragment</a>.</p>
+     <li data-md>
+      <p>If <var>raw fragment</var> is non-null:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>fragmentDirectivePosition</var> be an integer initialized to 0.</p>
+       <li data-md>
+        <p>While the substring of <var>raw fragment</var> starting at position <var>fragmentDirectivePosition</var> does not begin with the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive
+  delimiter</a> and <var>fragmentDirectivePosition</var> does not point past the end
+  of <var>raw fragment</var>:</p>
+        <ol>
+         <li data-md>
+          <p>Increment <var>fragmentDirectivePosition</var> by 1.</p>
+        </ol>
+       <li data-md>
+        <p>If <var>fragmentDirectivePosition</var> does not point past the end of <var>raw
+  fragment</var>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>fragment</var> be the substring of <var>raw fragment</var> starting at 0 of
+  count <var>fragmentDirectivePosition</var>.</p>
+         <li data-md>
+          <p>Advance <var>fragmentDirectivePosition</var> by the length of <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment
+  directive delimiter</a>.</p>
+         <li data-md>
+          <p>Let <var>fragment directive</var> be the substring of <var>raw fragment</var> starting
+  at <var>fragmentDirectivePosition</var>.</p>
+         <li data-md>
+          <p>Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment①">fragment</a> to <var>fragment</var>.</p>
+         <li data-md>
+          <p>Set <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> to <var>fragment directive</var>.
+  (Note: this is stored on the document but not web-exposed)</p>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url②">URL</a> to be <var>url</var>.</p>
+    </ol>
+   </blockquote>
    <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive
   delimiter</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑧">fragment directive</a> includes all characters that follow,
   but not including, the delimiter. </div>
    <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
 the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> is the string
 "text=foo". </div>
-   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parse-a-text-directive">parse a text directive</dfn>, on a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a> <var>text
+   <div class="algorithm" data-algorithm="parse a text directive">
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parse-a-text-directive">parse a text directive</dfn>, on a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a> <var>text
 directive input</var>, run these steps:</p>
-   <div class="note" role="note">
-    <p> This algorithm takes a single text directive string as input (e.g.
+    <div class="note" role="note">
+     <p> This algorithm takes a single text directive string as input (e.g.
     "text=prefix-,foo,bar") and attempts to parse the string into the
     components of the directive (e.g. ("prefix", "foo", "bar", null)). See <a href="#syntax">§ 3.2 Syntax</a> for the what each of these components means and how they’re
     used. </p>
-    <p> Returns null if the input is invalid or fails to parse in any way.
+     <p> Returns null if the input is invalid or fails to parse in any way.
     Otherwise, returns a <a data-link-type="dfn" href="#parsedtextdirective" id="ref-for-parsedtextdirective">ParsedTextDirective</a>. </p>
-   </div>
-   <ol>
-    <li data-md>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>text directive input</var> matches the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a>.</p>
-    <li data-md>
-     <p>Let <var>textDirectiveString</var> be the substring of <var>text directive
+    </div>
+    <ol class="algorithm">
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>text directive input</var> matches the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a>.</p>
+     <li data-md>
+      <p>Let <var>textDirectiveString</var> be the substring of <var>text directive
 input</var> starting at index 5.</p>
-     <div class="note" role="note"> This is the remainder of the <var>text directive input</var> following,
+      <div class="note" role="note"> This is the remainder of the <var>text directive input</var> following,
   but not including, the "text=" prefix. </div>
-    <li data-md>
-     <p>Let <var>tokens</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of strings that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <var>textDirectiveString</var> on commas</a>.</p>
-    <li data-md>
-     <p>If <var>tokens</var> has size less than 1 or greater than 4, return null.</p>
-    <li data-md>
-     <p>If any of <var>tokens</var>’s items are the empty string, return null.</p>
-    <li data-md>
-     <p>Let <var>retVal</var> be a <a data-link-type="dfn" href="#parsedtextdirective" id="ref-for-parsedtextdirective①">ParsedTextDirective</a> with each of its items initialized
+     <li data-md>
+      <p>Let <var>tokens</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> of strings that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#split-on-commas" id="ref-for-split-on-commas">splitting <var>textDirectiveString</var> on commas</a>.</p>
+     <li data-md>
+      <p>If <var>tokens</var> has size less than 1 or greater than 4, return null.</p>
+     <li data-md>
+      <p>If any of <var>tokens</var>’s items are the empty string, return null.</p>
+     <li data-md>
+      <p>Let <var>retVal</var> be a <a data-link-type="dfn" href="#parsedtextdirective" id="ref-for-parsedtextdirective①">ParsedTextDirective</a> with each of its items initialized
 to null.</p>
-    <li data-md>
-     <p>Let <var>potential prefix</var> be the first item of <var>tokens</var>.</p>
-    <li data-md>
-     <p>If the last character of <var>potential prefix</var> is U+002D (-), then:</p>
-     <ol>
-      <li data-md>
-       <p>Set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix">prefix</a> to the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode">percent-decoding</a> of
-the result of removing the last character from <var>potential prefix</var>.</p>
-      <li data-md>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> the first item of the list <var>tokens</var>.</p>
-     </ol>
-    <li data-md>
-     <p>Let <var>potential suffix</var> be the last item of <var>tokens</var>, if one exists, null
+     <li data-md>
+      <p>Let <var>potential prefix</var> be the first item of <var>tokens</var>.</p>
+     <li data-md>
+      <p>If the last character of <var>potential prefix</var> is U+002D (-), then:</p>
+      <ol>
+       <li data-md>
+        <p>Set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix">prefix</a> to the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode">percent-decoding</a> of the result of removing the
+last character from <var>potential prefix</var>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> the first item of the list <var>tokens</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Let <var>potential suffix</var> be the last item of <var>tokens</var>, if one exists, null
 otherwise.</p>
-    <li data-md>
-     <p>If <var>potential suffix</var> is non-null and its first character is U+002D (-),
+     <li data-md>
+      <p>If <var>potential suffix</var> is non-null and its first character is U+002D (-),
 then:</p>
-     <ol>
-      <li data-md>
-       <p>Set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix">suffix</a> to the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode①">percent-decoding</a> of
-the result of removing the first character from <var>potential suffix</var>.</p>
-      <li data-md>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove①">Remove</a> the last item of the list <var>tokens</var>.</p>
-     </ol>
-    <li data-md>
-     <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> not equal to 1 nor 2 then
+      <ol>
+       <li data-md>
+        <p>Set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix">suffix</a> to the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode①">percent-decoding</a> of the result of removing the
+first character from <var>potential suffix</var>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove①">Remove</a> the last item of the list <var>tokens</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size">size</a> not equal to 1 nor 2 then
 return null.</p>
-    <li data-md>
-     <p>Set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart">textStart</a> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode②">percent-decoding</a> of
-the first item of <var>tokens</var>.</p>
-    <li data-md>
-     <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size①">size</a> 2, then set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend">textEnd</a> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode③">percent-decoding</a> of the last item of <var>tokens</var>.</p>
-    <li data-md>
-     <p>Return <var>retVal</var>.</p>
-   </ol>
+     <li data-md>
+      <p>Set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart">textStart</a> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode②">percent-decoding</a> of the first item of <var>tokens</var>.</p>
+     <li data-md>
+      <p>If <var>tokens</var> has <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-size" id="ref-for-list-size①">size</a> 2, then set <var>retVal</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend">textEnd</a> be the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#string-percent-decode" id="ref-for-string-percent-decode③">percent-decoding</a> of the last item of <var>tokens</var>.</p>
+     <li data-md>
+      <p>Return <var>retVal</var>.</p>
+    </ol>
+   </div>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parsedtextdirective">ParsedTextDirective</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct">struct</a> that consists of
 four strings: <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-textstart">textStart</dfn>, <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-textend">textEnd</dfn>, <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-prefix">prefix</dfn>, and <dfn class="dfn-paneled" data-dfn-for="ParsedTextDirective" data-dfn-type="dfn" data-noexport id="parsedtextdirective-suffix">suffix</dfn>. <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart①">textStart</a> is required to be non-null. The other three items may be set to null,
 indicating they weren’t provided. The empty string is not a valid value for any
@@ -2248,18 +2266,25 @@ multiple solutions with differing tradeoffs. For example, a UA <em>may</em> cont
 text directive</a>.  Alternatively, it <em>may</em> schedule an asynchronous task
 to find and set the indicated part of the document.</p>
    <h4 class="heading settled" data-level="3.4.4" id="restricting-the-text-fragment"><span class="secno">3.4.4. </span><span class="content">Restricting the Text Fragment</span><a class="self-link" href="#restricting-the-text-fragment"></a></h4>
-   <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-textfragmenttoken">textFragmentToken</dfn> flag that is
-consumed in order to allow a single activation of a text fragment. This flag is
-generated only during loading if the navigation occurs as a result of a user
-activation.</p>
-   <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken">textFragmentToken</a> isn’t consumed to activate
-a text fragment, it may be consumed to set the <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-lt="textFragmentToken" data-noexport id="request-textfragmenttoken"> textFragmentToken</dfn> flag of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a>. In this way, a
-textFragmentToken can be propagated from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a> to another across a
-navigation.</p>
-   <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①">textFragmentToken</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a>'s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken">textFragmentToken</a> must always consume the value,
-such that the token cannot be cloned.</p>
+   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">Document</a> to include a new
+field for the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken">textFragmentToken</a>:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>:</strong></p>
+    <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> has an associated <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport id="request-textfragmenttoken">textFragmentToken</dfn> flag</p>
+   </blockquote>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-textfragmenttoken">textFragmentToken</dfn> flag that is
+  consumed in order to allow a single activation of a text fragment. This flag is
+  generated only during loading if the navigation occurs as a result of a user
+  activation.</p>
+    <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①">textFragmentToken</a> isn’t consumed to activate
+  a text fragment, it may be consumed to set the <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken">textFragmentToken</a> flag of a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>. In this way, a <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken②">textFragmentToken</a> can be propagated from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a> to another across a navigation.</p>
+    <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken③">textFragmentToken</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken①">textFragmentToken</a> must always consume the value,
+  such that the token cannot be cloned.</p>
+   </blockquote>
    <div class="note" role="note">
-    <p> A <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken②">textFragmentToken</a> is generated when a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a> is loaded
+    <p> A <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken④">textFragmentToken</a> is generated when a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> is loaded
     as a result of a user gesture. It grants its holder permission (in terms of
     user activation) to activate a single text fragment. Alternatively, it may be
     propagated through a navigation to allow a future document to activate a text
@@ -2277,7 +2302,7 @@ such that the token cannot be cloned.</p>
      <tt>status 3xx</tt>
      ) redirects, these "client-side"
     redirects cannot propagate the fact that the navigation is the result of a
-    user gesture. The <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken③">textFragmentToken</a> mechanism allows passing
+    user gesture. The <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑤">textFragmentToken</a> mechanism allows passing
     through this specifically scoped user-activation through such navigations.
     This means a page can programmatically navigate to a text fragment, a
     single time, as if it has a user gesture. However, further navigations
@@ -2288,12 +2313,14 @@ such that the token cannot be cloned.</p>
      <img alt="Diagram showing how a text fragment token is created and used" src="https://raw.githubusercontent.com/WICG/scroll-to-text-fragment/master/text_fragment_token.png" style="margin-left:auto;margin-right:auto;display:block"> 
     <p> See <a href="redirects.md">redirects.md</a> for a more in-depth discussion. </p>
    </div>
-   <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allowtextfragmentdirective">allowTextFragmentDirective</dfn> flag
-that is used to determine whether a text fragment directive should be allowed
-to activate. If this flag is false, the text fragment must not cause any
-observable effects.</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allowtextfragmentdirective">allowTextFragmentDirective</dfn> flag that is used to determine whether a text fragment directive should be
+  allowed to activate. If this flag is false, the text fragment must not
+  cause any observable effects.</p>
+   </blockquote>
    <div class="note" role="note">
-    <p> <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken④">textFragmentToken</a> is analogous to a user-activation state
+    <p> <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑥">textFragmentToken</a> is analogous to a user-activation state
     while <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective">allowTextFragmentDirective</a> is more comprehensive, taking into
     account various pieces of information, one of which is the existence of a
     textFragmentToken. </p>
@@ -2308,86 +2335,104 @@ observable effects.</p>
   allowed in all cases. </div>
    <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">create
 and initialize a Document object</a> steps by adding the following steps before returning <var>document</var>:</p>
-   <ol start="15">
-    <li data-md>
-     <p>Set the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑤">textFragmentToken</a> flag on <var>document</var>:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>is user activated</var> be true if the current navigation was initiated from
-a window that had a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation" id="ref-for-transient-activation">transient activation</a> at the time the
-navigation was initiated, or the UA has reason to believe it comes from a
-direct user gesture (e.g. user typed into the address bar).</p>
-       <div class="note" role="note"> TODO: it’d be better to refer to the userActivationFlag on the <var>request</var>. See <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a>. </div>
-      <li data-md>
-       <p>If <var>browsing context</var> is a top-level browsing context and if either of <var>is
-user activated</var> or the <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken①">textFragmentToken</a> flag of <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> object is true, set the <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑥">textFragmentToken</a> flag to true. Otherwise, set it to false.</p>
-       <div class="note" role="note"> It’s important that the token not be copyable so that at most one token
-  is created per user-activated navigation. </div>
-     </ol>
-    <li data-md>
-     <p>Set the <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①">allowTextFragmentDirective</a> flag on <var>document</var> by
-following these sub-steps:</p>
-     <ol>
-      <li data-md>
-       <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective②">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
-      <li data-md>
-       <p>Let <var>textFragmentToken</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑦">textFragmentToken</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑧">textFragmentToken</a> to false.</p>
-      <li data-md>
-       <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective③">allowTextFragmentDirective</a> to true and abort these
-sub-steps.</p>
-       <div class="note" role="note">
-        <p> If a navigation originates from browser UI, it’s always ok to allow it
-    since it’ll be user triggered and the page/script isn’t providing the
-    text snippet. </p>
-        <p> Note: Depending on the UA, there may be cases where the <var>incumbentNavigationOrigin</var> parameter is null but
-    it’s not clear that the navigation should be considered as
-    initiated from browser UI. E.g. an "open in new window" context
-    menu item when right clicking on a link.  The intent in this item
-    is to distinguish cases where the app/page is able to set the URL
-    from those that are fully under the user’s control.  In the former
-    we want to prevent activation of the text fragment unless the
-    destination is loaded in a separate browsing context group (so that
-    the source cannot both control the text snippet and observe
-    side-effects in the navigation). </p>
-        <p> See <a href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a> for a more detailed discussion of how this should apply. </p>
-       </div>
-      <li data-md>
-       <p>If <var>textFragmentToken</var> is false, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective④">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
-      <li data-md>
-       <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">document</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#latest-entry" id="ref-for-latest-entry">latest entry</a> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#session-history" id="ref-for-session-history">session history</a> is
-equal to <var>document</var>, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑤">allowTextFragmentDirective</a> to false
-and abort these sub-steps.</p>
-       <div class="note" role="note"> i.e. Forbidden on a same-document navigation. </div>
-      <li data-md>
-       <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-site"</code> set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑥">allowTextFragmentDirective</a> to true and abort these
-sub-steps.</p>
-      <li data-md>
-       <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc①">browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing
-context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑦">allowTextFragmentDirective</a> to true and abort these sub-steps.</p>
-       <div class="note" role="note"> i.e. Only allow navigation from a cross-process element/script if the
-  document is loaded in a noopener context. That is, a new top level
-  browsing context group to which the navigator does not have script access
-  and which may be placed into a separate process. </div>
-      <li data-md>
-       <p>Otherwise, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑧">allowTextFragmentDirective</a> to false.</p>
-     </ol>
-   </ol>
-   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken②">textFragmentToken</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑨">textFragmentToken</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a>'s value to
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <ol start="15">
+     <li data-md>
+      <p>Set the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑦">textFragmentToken</a> flag on <var>document</var>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>is user activated</var> be true if the current navigation was initiated from
+  a window that had a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation" id="ref-for-transient-activation">transient activation</a> at the time the
+  navigation was initiated, or the UA has reason to believe it comes from a
+  direct user gesture (e.g. user typed into the address bar).</p>
+        <div class="note" role="note"> TODO: it’d be better to refer to the userActivationFlag on the <var>request</var>. See <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a> in <a data-link-type="biblio" href="#biblio-fetch-metadata">[FETCH-METADATA]</a>. </div>
+       <li data-md>
+        <p>If <var>browsing context</var> is a top-level browsing context and if either of <var>is
+  user activated</var> or the <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken②">textFragmentToken</a> flag of <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> object is true, set the <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑧">textFragmentToken</a> flag to true. Otherwise, set it to false.</p>
+        <div class="note" role="note"> It’s important that the token not be copyable so that at most one token
+    is created per user-activated navigation. </div>
+      </ol>
+     <li data-md>
+      <p>Set the <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①">allowTextFragmentDirective</a> flag on <var>document</var> by
+  following these sub-steps:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective②">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
+       <li data-md>
+        <p>Let <var>textFragmentToken</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑨">textFragmentToken</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①⓪">textFragmentToken</a> to false.</p>
+       <li data-md>
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective③">allowTextFragmentDirective</a> to true and abort these sub-steps.</p>
+        <div class="note" role="note">
+         <p> If a navigation originates from browser UI, it’s always ok to allow it
+      since it’ll be user triggered and the page/script isn’t providing the
+      text snippet. </p>
+         <p> Note: Depending on the UA, there may be cases where the <var>incumbentNavigationOrigin</var> parameter is null but
+      it’s not clear that the navigation should be considered as
+      initiated from browser UI. E.g. an "open in new window" context
+      menu item when right clicking on a link.  The intent in this item
+      is to distinguish cases where the app/page is able to set the URL
+      from those that are fully under the user’s control.  In the former
+      we want to prevent activation of the text fragment unless the
+      destination is loaded in a separate browsing context group (so that
+      the source cannot both control the text snippet and observe
+      side-effects in the navigation). </p>
+         <p> See <a href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a> for a more detailed discussion of how this should apply. </p>
+        </div>
+       <li data-md>
+        <p>If <var>textFragmentToken</var> is false, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective④">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
+       <li data-md>
+        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">document</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#latest-entry" id="ref-for-latest-entry">latest entry</a> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#session-history" id="ref-for-session-history">session history</a> is
+  equal to <var>document</var>, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑤">allowTextFragmentDirective</a> to false
+  and abort these sub-steps.</p>
+        <div class="note" role="note"> i.e. Forbidden on a same-document navigation. </div>
+       <li data-md>
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-site"</code> set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑥">allowTextFragmentDirective</a> to true and abort these
+  sub-steps.</p>
+       <li data-md>
+        <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc①">browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing
+  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑦">allowTextFragmentDirective</a> to true and abort these sub-steps.</p>
+        <div class="note" role="note"> i.e. Only allow navigation from a cross-process element/script if the
+    document is loaded in a noopener context. That is, a new top level
+    browsing context group to which the navigator does not have script access
+    and which may be placed into a separate process. </div>
+       <li data-md>
+        <p>Otherwise, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑧">allowTextFragmentDirective</a> to false.</p>
+      </ol>
+    </ol>
+   </blockquote>
+   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken③">textFragmentToken</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①①">textFragmentToken</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a>'s value to
 false.</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <ol start="2">
+     <li data-md>
+      <p>Set request’s client to sourceBrowsingContext’s active document’s relevant
+  settings object, destination to "document", mode to "navigate", credentials
+  mode to "include", use-URL-credentials flag, redirect mode to "manual",
+  replaces client id to browsingContext’s active document’s relevant settings
+  object’s id, and <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken④">textFragmentToken</a> to
+  sourceBrowsingContext’s active document’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①②">textFragmentToken</a>. Set sourceBrowsingContext’s active
+  document’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①③">textFragmentToken</a> to false.</p>
+    </ol>
+   </blockquote>
    <p>Amend the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment">try to scroll to the fragment</a> steps by replacing the
 steps of the task queued in step 2:</p>
-   <ol>
-    <li data-md>
-     <p>If document has no parser, or its parser has stopped parsing, or the user
-agent has reason to believe the user is no longer interested in scrolling to
-the fragment, then clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑨">allowTextFragmentDirective</a> flag and abort these steps.</p>
-    <li data-md>
-     <p>Scroll to the fragment given in document’s URL. If this does not find an
-indicated part of the document, then try to scroll to the fragment for
-document.</p>
-    <li data-md>
-     <p>Clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①⓪">allowTextFragmentDirective</a> flag</p>
-   </ol>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <ol>
+     <li data-md>
+      <p>If document has no parser, or its parser has stopped parsing, or the user
+  agent has reason to believe the user is no longer interested in scrolling to
+  the fragment, then clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑨">allowTextFragmentDirective</a> flag and abort these steps.</p>
+     <li data-md>
+      <p>Scroll to the fragment given in document’s URL. If this does not find an
+  indicated part of the document, then try to scroll to the fragment for
+  document.</p>
+     <li data-md>
+      <p>Clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①⓪">allowTextFragmentDirective</a> flag</p>
+    </ol>
+   </blockquote>
    <h3 class="heading settled" data-level="3.5" id="navigating-to-text-fragment"><span class="secno">3.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
    <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.10.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive④">text fragment directive</a> is
 present and a match is found in the page, the text fragment takes precedent over
@@ -2396,80 +2441,93 @@ indicated part of the document to optionally include a <a data-link-type="dfn" h
 may be scrolled into view instead of the containing element. </div>
    <p>Replace step 3.1 of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier①">scroll to the fragment</a> algorithm with
 the following:</p>
-   <ol>
-    <li data-md>
-     <p>Let <em>target, range</em> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element">element</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①">range</a> that is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document" id="ref-for-the-indicated-part-of-the-document">the indicated part of the document</a>.</p>
-   </ol>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <ol>
+     <li data-md>
+      <p>Let <em>target, range</em> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element">element</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①">range</a> that is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document" id="ref-for-the-indicated-part-of-the-document">the indicated part of the document</a>.</p>
+    </ol>
+   </blockquote>
    <p>Replace step 3.3 of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier②">scroll to the fragment</a> algorithm with
 the following:</p>
-   <ol start="3">
-    <li data-md>
-     <p><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
-the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a>. If the result is true, abort these steps.</p>
-    <li data-md>
-     <p>If <em>range</em> is non-null:</p>
-     <ol>
-      <li data-md>
-       <p>If the UA supports scrolling of text fragments on navigation, invoke <a data-link-type="dfn" href="#scroll-a-range-into-view" id="ref-for-scroll-a-range-into-view">Scroll range into view</a>, with range <em>range</em>, containingElement <em>target</em>, <em>behavior</em> set
-to "auto", <em>block</em> set to "center", and <em>inline</em> set to
-"nearest".</p>
-     </ol>
-    <li data-md>
-     <p>Otherwise:</p>
-     <ol>
-      <li data-md>
-       <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view">Scroll target
-into view</a>, with <em>behavior</em> set to "auto", <em>block</em> set to "start", and <em>inline</em> set to "nearest".</p>
-       <div class="note" role="note"> This otherwise case is the same as the current step 3.3. </div>
-     </ol>
-   </ol>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <ol start="3">
+     <li data-md>
+      <p><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
+  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>. If the result is true, abort these steps.</p>
+     <li data-md>
+      <p>If <em>range</em> is non-null:</p>
+      <ol>
+       <li data-md>
+        <p>If the UA supports scrolling of text fragments on navigation, invoke <a data-link-type="dfn" href="#scroll-a-range-into-view" id="ref-for-scroll-a-range-into-view">Scroll range into view</a>, with range <em>range</em>, containingElement <em>target</em>, <em>behavior</em> set
+  to "auto", <em>block</em> set to "center", and <em>inline</em> set to
+  "nearest".</p>
+      </ol>
+     <li data-md>
+      <p>Otherwise:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view">Scroll target
+  into view</a>, with <em>behavior</em> set to "auto", <em>block</em> set to "start", and <em>inline</em> set to "nearest".</p>
+        <div class="note" role="note"> This otherwise case is the same as the current step 3.3. </div>
+      </ol>
+    </ol>
+   </blockquote>
    <p>Add the following steps to the beginning of the processing model for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document" id="ref-for-the-indicated-part-of-the-document①">the indicated part of the document</a>:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>fragment directive string</var> be the document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a>.</p>
-    <li data-md>
-     <p>If the document’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①①">allowTextFragmentDirective</a> flag is true then:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
-the <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive">process a fragment directive</a> steps with <var>fragment directive
-string</var> and the document.</p>
-      <li data-md>
-       <p>If <var>ranges</var> is non-empty, then:</p>
-       <ol>
-        <li data-md>
-         <p>Let <var>range</var> be the first item of <var>ranges</var>.</p>
-         <div class="note" role="note"> The first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②">range</a> in <var>ranges</var> is specifically
-  scrolled into view. This <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range③">range</a>, along with the
-  remaining <var>ranges</var> should be visually indicated in a way that
-  is not revealed to script, which is left as UA-defined behavior. </div>
-        <li data-md>
-         <p>Let <var>node</var> be the <a data-link-type="dfn" href="#first-common-ancestor" id="ref-for-first-common-ancestor">first common ancestor</a> of <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node">start node</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node">end node</a>.</p>
-        <li data-md>
-         <p>While <var>node</var> is non-null and is not an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element①">element</a>, set <var>node</var> to <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent">parent</a>.</p>
-        <li data-md>
-         <p>The indicated part of the document is <var>node</var> and <var>range</var>; return.</p>
-       </ol>
-     </ol>
-   </ol>
-   <p>To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="first-common-ancestor">first common ancestor</dfn> of two nodes <var>nodeA</var> and <var>nodeB</var>,
-follow these steps:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>commonAncestor</var> be <var>nodeA</var>.</p>
-    <li data-md>
-     <p>While <var>commonAncestor</var> is non-null and is not a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor" id="ref-for-concept-shadow-including-inclusive-ancestor">shadow-including inclusive
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <ol>
+     <li data-md>
+      <p>Let <var>fragment directive string</var> be the document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a>.</p>
+     <li data-md>
+      <p>If the document’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①①">allowTextFragmentDirective</a> flag is true then:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
+  the <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive">process a fragment directive</a> steps with <var>fragment directive
+  string</var> and the document.</p>
+       <li data-md>
+        <p>If <var>ranges</var> is non-empty, then:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>range</var> be the first item of <var>ranges</var>.</p>
+          <div class="note" role="note"> The first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②">range</a> in <var>ranges</var> is specifically
+    scrolled into view. This <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range③">range</a>, along with the
+    remaining <var>ranges</var> should be visually indicated in a way that
+    is not revealed to script, which is left as UA-defined behavior. </div>
+         <li data-md>
+          <p>Let <var>node</var> be the <a data-link-type="dfn" href="#first-common-ancestor" id="ref-for-first-common-ancestor">first common ancestor</a> of <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node">start node</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node">end node</a>.</p>
+         <li data-md>
+          <p>While <var>node</var> is non-null and is not an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element①">element</a>, set <var>node</var> to <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent">parent</a>.</p>
+         <li data-md>
+          <p>The indicated part of the document is <var>node</var> and <var>range</var>; return.</p>
+        </ol>
+      </ol>
+    </ol>
+   </blockquote>
+   <div class="algorithm" data-algorithm="first common ancestor">
+     To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="first-common-ancestor">first common ancestor</dfn> of two nodes <var>nodeA</var> and <var>nodeB</var>,
+follow these steps: 
+    <ol class="algorithm">
+     <li data-md>
+      <p>Let <var>commonAncestor</var> be <var>nodeA</var>.</p>
+     <li data-md>
+      <p>While <var>commonAncestor</var> is non-null and is not a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor" id="ref-for-concept-shadow-including-inclusive-ancestor">shadow-including inclusive
 ancestor</a> of <var>nodeB</var>, let <var>commonAncestor</var> be <var>commonAncestor</var>’s <a data-link-type="dfn" href="#shadow-including-parent" id="ref-for-shadow-including-parent">shadow-including parent</a>.</p>
-    <li data-md>
-     <p>Return <var>commonAncestor</var>.</p>
-   </ol>
-   <p>To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shadow-including-parent">shadow-including parent</dfn> of <var>node</var> follow these steps:</p>
-   <ol>
-    <li data-md>
-     <p>If <var>node</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-root" id="ref-for-concept-shadow-root">shadow root</a>, return <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-documentfragment-host" id="ref-for-concept-documentfragment-host">host</a>.</p>
-    <li data-md>
-     <p>Otherwise, return <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent①">parent</a>.</p>
-   </ol>
+     <li data-md>
+      <p>Return <var>commonAncestor</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="shadow-including parent">
+     To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shadow-including-parent">shadow-including parent</dfn> of <var>node</var> follow these steps: 
+    <ol class="algorithm">
+     <li data-md>
+      <p>If <var>node</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-root" id="ref-for-concept-shadow-root">shadow root</a>, return <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-documentfragment-host" id="ref-for-concept-documentfragment-host">host</a>.</p>
+     <li data-md>
+      <p>Otherwise, return <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent①">parent</a>.</p>
+    </ol>
+   </div>
    <h4 class="heading settled" data-level="3.5.1" id="scroll-rect-into-view"><span class="secno">3.5.1. </span><span class="content">Scroll a DOMRect into view</span><a class="self-link" href="#scroll-rect-into-view"></a></h4>
    <div class="note" role="note"> This section describes a refactoring of the CSSOMVIEW’s <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view①">scroll an element into view</a> algorithm
   to separate the steps for scrolling a DOMRect into view, so it can be used to
@@ -2480,23 +2538,55 @@ ancestor</a> of <var>nodeB</var>, let <var>commonAncestor</var> be <var>commonAn
 DOMRect into view</a> algorithm: "run these steps for each ancestor element or
 viewport <b>of <var>startingElement</var></b> that establishes a scrolling box <var>scrolling box</var>, in order of innermost to outermost scrolling box".</p>
    <div class="note" role="note"> <var>bounding box</var> is renamed from <var>element bounding border box</var>. </div>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-cssom-view">[CSSOM-VIEW]</a>:</strong></p>
+    <p>To scroll a DOMRect into view given a <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrect" id="ref-for-domrect①">DOMRect</a></code> <var>bounding box</var>,
+  a scroll behavior <var>behavior</var>,
+  a block flow direction position <var>block</var>,
+  and an inline base direction position <var>inline</var>,
+  and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element③">element</a> <var>startingElement</var>, means to run these steps for each ancestor element or viewport of <var>startingElement</var> that establishes
+  a scrolling box <var>scrolling box</var>, in order of innermost to outermost scrolling box:</p>
+    <p><em>OMITTED</em></p>
+    <div class="note" role="note"> TODO: There’s more to do here since the <var>bounding box</var> needs to be
+    transformed with each step to an ancestor element or viewport. </div>
+   </blockquote>
    <p>Replace steps 3-14 of the <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view④">scroll an element into view</a> algorithm with a call to <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view①">scroll a DOMRect into view</a>:</p>
-   <ol start="3">
-    <li data-md>
-     <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view②">scroll a DOMRect into view</a> given <var>element bounding border box</var>, <var>options</var> and <var>element</var>.</p>
-   </ol>
-   <p>Define a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-range-into-view">scroll a Range into view</dfn>, with input <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range④">range</a> <var>range</var>, <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element③">element</a> <var>containingElement</var>, and a <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions" id="ref-for-dictdef-scrollintoviewoptions①">ScrollIntoViewOptions</a></code> dictionary <var>options</var>:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>bounding rect</var> be the <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrect" id="ref-for-domrect①">DOMRect</a></code> that is the return value of
-invoking <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect" id="ref-for-dom-range-getboundingclientrect">getBoundingClientRect()</a></code> on <var>range</var>.</p>
-    <li data-md>
-     <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view③">scroll a DOMRect into view</a> given <var>bounding rect</var>, <var>options</var>, and <var>containingElement</var>.</p>
-   </ol>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-cssom-view">[CSSOM-VIEW]</a>:</strong></p>
+    <p>To scroll an element into view <var>element</var>,
+  with a scroll behavior <var>behavior</var>,
+  a block flow direction position <var>block</var>,
+  and an inline base direction position <var>inline</var>,
+  means to run these steps:</p>
+    <ol>
+     <li data-md>
+      <p>If the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> associated with <var>element</var> is not same origin with the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> associated with the element or viewport associated with <var>box</var>, terminate these steps.</p>
+     <li data-md>
+      <p>Let <var>element bounding border box</var> be the box that the return value of invoking <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect" id="ref-for-dom-element-getboundingclientrect">getBoundingClientRect()</a></code> on <var>element</var> represents.</p>
+     <li data-md>
+      <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view②">scroll a DOMRect into view</a> given <var>element bounding border box</var>, <var>options</var> and <var>element</var>.</p>
+    </ol>
+   </blockquote>
+   <p>Define a new algorithm for scrolling <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range④">Range</a> into view:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-cssom-view">[CSSOM-VIEW]</a>:</strong></p>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-range-into-view">scroll a Range into view</dfn>, with input <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑤">range</a> <var>range</var>,
+  scroll behavior <var>behavior</var>,
+  a block flow direction position <var>block</var>,
+  an inline base direction position <var>inline</var>,
+  and an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element④">element</a> <var>containingElement</var>:</p>
+    <ol>
+     <li data-md>
+      <p>Let <var>bounding rect</var> be the <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrect" id="ref-for-domrect②">DOMRect</a></code> that is the return value of
+  invoking <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect" id="ref-for-dom-range-getboundingclientrect">getBoundingClientRect()</a></code> on <var>range</var>.</p>
+     <li data-md>
+      <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view③">scroll a DOMRect into view</a> given <var>bounding rect</var>, <var>behavior</var>, <var>block</var>, <var>inline</var>, and <var>containingElement</var>.</p>
+    </ol>
+   </blockquote>
    <h4 class="heading settled" data-level="3.5.2" id="finding-ranges-in-a-document"><span class="secno">3.5.2. </span><span class="content">Finding Ranges in a Document</span><a class="self-link" href="#finding-ranges-in-a-document"></a></h4>
    <div class="note" role="note">
      This section outlines several algorithms and definitions that specify how to
-  turn a full fragment directive string into a list of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑤">Ranges</a> in the
+  turn a full fragment directive string into a list of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑥">Ranges</a> in the
   document. 
     <p>At a high level, we take a fragment directive string that looks like this:</p>
 <pre>text=prefix-,foo&amp;unknown&amp;text=bar,baz
@@ -2509,319 +2599,327 @@ text=bar,baz
   instance of rendered text that matches the restrictions in the directive.
   Each search is independent of any others; that is, the result is the same
   regardless of how many other directives are provided or their match result.</p>
-    <p>If a directive successfully matches to text in the document, it returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑥">range</a> indicating that match in the document. The <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive①">process a fragment
+    <p>If a directive successfully matches to text in the document, it returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑦">range</a> indicating that match in the document. The <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive①">process a fragment
   directive</a> steps are the high level API provided by this section. These
-  return a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑦">ranges</a> that were matched by the
+  return a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑧">ranges</a> that were matched by the
   individual directive matching steps, in the order the directives were
   specified in the fragment directive string.</p>
     <p>If a directive was not matched, it does not add an item to the returned
   list.</p>
    </div>
-   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a> <var>document</var>, run these steps:</p>
-   <div class="note" role="note"> This algorithm takes as input a the <var>fragment directive input</var>, that is the
+   <div class="algorithm" data-algorithm="process a fragment directive">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> <var>document</var>, run these steps: 
+    <div class="note" role="note"> This algorithm takes as input a the <var>fragment directive input</var>, that is the
   raw text of the fragment directive and the <var>document</var> over which it operates.
-  It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑧">ranges</a> that are to be visually
+  It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑨">ranges</a> that are to be visually
   indicated, the first of which may be scrolled into view (if the UA scrolls
   automatically). </div>
-   <ol>
-    <li data-md>
-     <p>If <var>fragment directive input</var> is not a <a data-link-type="dfn" href="#valid-fragment-directive" id="ref-for-valid-fragment-directive">valid fragment directive</a>, then
+    <ol class="algorithm">
+     <li data-md>
+      <p>If <var>fragment directive input</var> is not a <a data-link-type="dfn" href="#valid-fragment-directive" id="ref-for-valid-fragment-directive">valid fragment directive</a>, then
 return an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list④">list</a>.</p>
-    <li data-md>
-     <p>Let <var>directives</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a>s
+     <li data-md>
+      <p>Let <var>directives</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a>s
 that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split">strictly splitting the
 string</a> <var>fragment directive input</var> on "&amp;".</p>
-    <li data-md>
-     <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑥">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑨">ranges</a>, initially empty.</p>
-    <li data-md>
-     <p>For each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> <var>directive</var> of <var>directives</var>:</p>
-     <ol>
-      <li data-md>
-       <p>If <var>directive</var> does not match the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective③">TextDirective</a>,
+     <li data-md>
+      <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑥">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⓪">ranges</a>, initially empty.</p>
+     <li data-md>
+      <p>For each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> <var>directive</var> of <var>directives</var>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>directive</var> does not match the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective③">TextDirective</a>,
 then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</p>
-      <li data-md>
-       <p>Let <var>parsedValues</var> be the result of running the <a data-link-type="dfn" href="#parse-a-text-directive" id="ref-for-parse-a-text-directive">parse a text
+       <li data-md>
+        <p>Let <var>parsedValues</var> be the result of running the <a data-link-type="dfn" href="#parse-a-text-directive" id="ref-for-parse-a-text-directive">parse a text
 directive</a> steps on <var>directive</var>.</p>
-      <li data-md>
-       <p>If <var>parsedValues</var> is null then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
-      <li data-md>
-       <p>If the result of running <a data-link-type="dfn" href="#find-a-range-from-a-text-directive" id="ref-for-find-a-range-from-a-text-directive①">find a range from a text directive</a> given <var>parsedValues</var> and <var>document</var> is non-null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> it to <var>ranges</var>.</p>
-     </ol>
-    <li data-md>
-     <p>Return <var>ranges</var>.</p>
-   </ol>
-   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#parsedtextdirective" id="ref-for-parsedtextdirective②">ParsedTextDirective</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> <var>document</var>, run the
-following steps:</p>
-   <div class="note" role="note">
-     This algorithm takes as input a successfully parsed text directive and a
-  document in which to search. It returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⓪">range</a> that points to the first
+       <li data-md>
+        <p>If <var>parsedValues</var> is null then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
+       <li data-md>
+        <p>If the result of running <a data-link-type="dfn" href="#find-a-range-from-a-text-directive" id="ref-for-find-a-range-from-a-text-directive①">find a range from a text directive</a> given <var>parsedValues</var> and <var>document</var> is non-null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> it to <var>ranges</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>ranges</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="find a range from a text directive">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#parsedtextdirective" id="ref-for-parsedtextdirective②">ParsedTextDirective</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">Document</a> <var>document</var>, run the
+following steps: 
+    <div class="note" role="note">
+      This algorithm takes as input a successfully parsed text directive and a
+  document in which to search. It returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①①">range</a> that points to the first
   text passage within the document that matches the searched-for text and
   satisfies the surrounding context. Returns null if no such passage exists. 
-    <p><a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend①">textEnd</a> may be null. If omitted, this is an "exact"
-  search and the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①①">range</a> must contain a string exactly matching <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart②">textStart</a>. If <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend②">textEnd</a> is
-  provided, this is a "range" search; the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①②">range</a> must start with <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart③">textStart</a> and end with <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend③">textEnd</a>. In the normative text below, we’ll call a
+     <p><a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend①">textEnd</a> may be null. If omitted, this is an "exact"
+  search and the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①②">range</a> must contain a string exactly matching <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart②">textStart</a>. If <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend②">textEnd</a> is
+  provided, this is a "range" search; the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①③">range</a> must start with <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart③">textStart</a> and end with <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend③">textEnd</a>. In the normative text below, we’ll call a
   text passage that matches the provided <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart④">textStart</a> and <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend④">textEnd</a>, regardless of which mode we’re in, the
   "matching text".</p>
-    <p>Either or both of <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix①">prefix</a> and <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix①">suffix</a> may be null, in which case context on that
+     <p>Either or both of <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix①">prefix</a> and <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix①">suffix</a> may be null, in which case context on that
   side of a match is not checked. E.g. If <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix②">prefix</a> is
   null, text is matched without any requirement on what text precedes it.</p>
-   </div>
-   <div class="note" role="note">
-     While the matching text and its prefix/suffix can span across
+    </div>
+    <div class="note" role="note">
+      While the matching text and its prefix/suffix can span across
   block-boundaries, the individual parameters to these steps cannot. That is,
   each of <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix③">prefix</a>, <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart⑤">textStart</a>, <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑤">textEnd</a>, and <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix②">suffix</a> will only
   match text within a single block. 
-    <div class="example" id="example-73638554">
-     <a class="self-link" href="#example-73638554"></a> 
+     <div class="example" id="example-73638554">
+      <a class="self-link" href="#example-73638554"></a> 
 <pre>:~:text=The quick,lazy dog</pre>
-      will fail to match in 
+       will fail to match in 
 <pre>    &lt;div>The&lt;div> &lt;/div>quick brown fox&lt;/div>
     &lt;div>jumped over the lazy dog&lt;/div>
 </pre>
-     <p>because the starting string "The quick" does not appear within a single,
+      <p>because the starting string "The quick" does not appear within a single,
     uninterrupted block. The instance of "The quick" in the document has a
     block element between "The" and "quick".</p>
-     <p>It does, however, match in this example:</p>
+      <p>It does, however, match in this example:</p>
 <pre>    &lt;div>The quick brown fox&lt;/div>
     &lt;div>jumped over the lazy dog&lt;/div>
 </pre>
+     </div>
     </div>
-   </div>
-   <ol>
-    <li data-md>
-     <p>Let <var>searchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①③">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start">start</a> (<var>document</var>, 0) and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end">end</a> (<var>document</var>, <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length">length</a>)</p>
-    <li data-md>
-     <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed">collapsed</a>:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>potentialMatch</var> be null.</p>
-      <li data-md>
-       <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix④">prefix</a> is not null:</p>
-       <ol>
-        <li data-md>
-         <p>Let <var>prefixMatch</var> be the the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range">find a string
+    <ol class="algorithm">
+     <li data-md>
+      <p>Let <var>searchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①④">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start">start</a> (<var>document</var>, 0) and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end">end</a> (<var>document</var>, <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length">length</a>)</p>
+     <li data-md>
+      <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed">collapsed</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>potentialMatch</var> be null.</p>
+       <li data-md>
+        <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix④">prefix</a> is not null:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>prefixMatch</var> be the the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range">find a string
 in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix⑤">prefix</a>, <var>searchRange</var> <var>searchRange</var>, <var>wordStartBounded</var> true and <var>wordEndBounded</var> false.</p>
-        <li data-md>
-         <p>If <var>prefixMatch</var> is null, return null.</p>
-        <li data-md>
-         <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after">after</a> <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start②">start</a></p>
-        <li data-md>
-         <p>Let <var>matchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①④">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start③">start</a> is <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end②">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end③">end</a>.</p>
-        <li data-md>
-         <p>Advance <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start④">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position">next non-whitespace position</a>.</p>
-        <li data-md>
-         <p>If <var>matchRange</var> is <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed①">collapsed</a> return null.</p>
-         <div class="note" role="note"> This can happen if <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end④">end</a> or its subsequent
+         <li data-md>
+          <p>If <var>prefixMatch</var> is null, return null.</p>
+         <li data-md>
+          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after">after</a> <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start②">start</a></p>
+         <li data-md>
+          <p>Let <var>matchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑤">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start③">start</a> is <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end②">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end③">end</a>.</p>
+         <li data-md>
+          <p>Advance <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start④">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position">next non-whitespace position</a>.</p>
+         <li data-md>
+          <p>If <var>matchRange</var> is <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed①">collapsed</a> return null.</p>
+          <div class="note" role="note"> This can happen if <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end④">end</a> or its subsequent
   non-whitespace position is at the end of the document. </div>
-        <li data-md>
-         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node①">start node</a> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text">Text</a></code> node.</p>
-         <div class="note" role="note"> <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑤">start</a> now points to the next
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node①">start node</a> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text">Text</a></code> node.</p>
+          <div class="note" role="note"> <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑤">start</a> now points to the next
   non-whitespace text data following a matched prefix. </div>
-        <li data-md>
-         <p>Let <var>mustEndAtWordBoundary</var> be true if <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑥">textEnd</a> is non-null or <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix③">suffix</a> is null, false
+         <li data-md>
+          <p>Let <var>mustEndAtWordBoundary</var> be true if <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑥">textEnd</a> is non-null or <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix③">suffix</a> is null, false
 otherwise.</p>
-        <li data-md>
-         <p>Set <var>potentialMatch</var> to the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range①">find a string in
+         <li data-md>
+          <p>Set <var>potentialMatch</var> to the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range①">find a string in
 range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart⑥">textStart</a>, <var>searchRange</var> <var>matchRange</var>, <var>wordStartBounded</var> false, and <var>wordEndBounded</var> <var>mustEndAtWordBoundary</var>.</p>
-        <li data-md>
-         <p>If <var>potentialMatch</var> is null, return null.</p>
-        <li data-md>
-         <p>If <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑥">start</a> is not <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑦">start</a>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">continue</a>.</p>
-         <div class="note" role="note"> In this case, we found a prefix but it was followed by something
+         <li data-md>
+          <p>If <var>potentialMatch</var> is null, return null.</p>
+         <li data-md>
+          <p>If <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑥">start</a> is not <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑦">start</a>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">continue</a>.</p>
+          <div class="note" role="note"> In this case, we found a prefix but it was followed by something
   other than a matching text so we’ll continue searching for the
   next instance of <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix⑥">prefix</a>. </div>
-       </ol>
-      <li data-md>
-       <p>Otherwise:</p>
-       <ol>
-        <li data-md>
-         <p>Let <var>mustEndAtWordBoundary</var> be true if <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑦">textEnd</a> is non-null or <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix④">suffix</a> is null, false
+        </ol>
+       <li data-md>
+        <p>Otherwise:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>mustEndAtWordBoundary</var> be true if <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑦">textEnd</a> is non-null or <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix④">suffix</a> is null, false
 otherwise.</p>
-        <li data-md>
-         <p>Set <var>potentialMatch</var> to the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range②">find a string in
+         <li data-md>
+          <p>Set <var>potentialMatch</var> to the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range②">find a string in
 range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart⑦">textStart</a>, <var>searchRange</var> <var>searchRange</var>, <var>wordStartBounded</var> true, and <var>wordEndBounded</var> <var>mustEndAtWordBoundary</var>.</p>
-        <li data-md>
-         <p>If <var>potentialMatch</var> is null, return null.</p>
-        <li data-md>
-         <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑧">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp①">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after①">after</a> <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑨">start</a></p>
-       </ol>
-      <li data-md>
-       <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑧">textEnd</a> item is
+         <li data-md>
+          <p>If <var>potentialMatch</var> is null, return null.</p>
+         <li data-md>
+          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑧">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp①">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after①">after</a> <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑨">start</a></p>
+        </ol>
+       <li data-md>
+        <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑧">textEnd</a> item is
 non-null, then:</p>
-       <ol>
-        <li data-md>
-         <p>Let <var>textEndRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑤">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⓪">start</a> is <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑤">end</a> and whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑥">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑦">end</a>.</p>
-        <li data-md>
-         <p>Let <var>mustEndAtWordBoundary</var> be true if <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑤">suffix</a> is null, false otherwise.</p>
-        <li data-md>
-         <p>Let <var>textEndMatch</var> be the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range③">find a string
+        <ol>
+         <li data-md>
+          <p>Let <var>textEndRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑥">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⓪">start</a> is <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑤">end</a> and whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑥">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑦">end</a>.</p>
+         <li data-md>
+          <p>Let <var>mustEndAtWordBoundary</var> be true if <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑤">suffix</a> is null, false otherwise.</p>
+         <li data-md>
+          <p>Let <var>textEndMatch</var> be the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range③">find a string
 in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑨">textEnd</a>, <var>searchRange</var> <var>textEndRange</var>, <var>wordStartBounded</var> true, and <var>wordEndBounded</var> <var>mustEndAtWordBoundary</var>.</p>
-        <li data-md>
-         <p>If <var>textEndMatch</var> is null then return null.</p>
-        <li data-md>
-         <p>Set <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑧">end</a> to <var>textEndMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑨">end</a>.</p>
-       </ol>
-      <li data-md>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">Assert</a>: <var>potentialMatch</var> is non-null, not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed②">collapsed</a> and
+         <li data-md>
+          <p>If <var>textEndMatch</var> is null then return null.</p>
+         <li data-md>
+          <p>Set <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑧">end</a> to <var>textEndMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑨">end</a>.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">Assert</a>: <var>potentialMatch</var> is non-null, not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed②">collapsed</a> and
 represents a range exactly containing an instance of matching text.</p>
-      <li data-md>
-       <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑥">suffix</a> is null, return <var>potentialMatch</var>.</p>
-      <li data-md>
-       <p>Let <var>suffixRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑥">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①①">start</a> equal to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⓪">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①①">end</a> equal to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①②">end</a>.</p>
-      <li data-md>
-       <p>Advance <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①②">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position①">next non-whitespace
+       <li data-md>
+        <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑥">suffix</a> is null, return <var>potentialMatch</var>.</p>
+       <li data-md>
+        <p>Let <var>suffixRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①①">start</a> equal to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⓪">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①①">end</a> equal to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①②">end</a>.</p>
+       <li data-md>
+        <p>Advance <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①②">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position①">next non-whitespace
 position</a>.</p>
-      <li data-md>
-       <p>Let <var>suffixMatch</var> be result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range④">find a string in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑦">suffix</a>, <var>searchRange</var> <var>suffixRange</var>, <var>wordStartBounded</var> false, and <var>wordEndBounded</var> true.</p>
-      <li data-md>
-       <p>If <var>suffixMatch</var> is null then return null.</p>
-       <div class="note" role="note"> If the suffix doesn’t appear in the remaining text of the document,
+       <li data-md>
+        <p>Let <var>suffixMatch</var> be result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range④">find a string in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑦">suffix</a>, <var>searchRange</var> <var>suffixRange</var>, <var>wordStartBounded</var> false, and <var>wordEndBounded</var> true.</p>
+       <li data-md>
+        <p>If <var>suffixMatch</var> is null then return null.</p>
+        <div class="note" role="note"> If the suffix doesn’t appear in the remaining text of the document,
   there’s no possible way to make a match. </div>
-      <li data-md>
-       <p>If <var>suffixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①③">start</a> is <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①④">start</a>,
+       <li data-md>
+        <p>If <var>suffixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①③">start</a> is <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①④">start</a>,
 return <var>potentialMatch</var>.</p>
-     </ol>
-    <li data-md>
-     <p>Return null</p>
-   </ol>
+      </ol>
+     <li data-md>
+      <p>Return null</p>
+    </ol>
+   </div>
    <ul class="wpt-tests-block">
     <li class="wpt-test"><a href="https://wpt.fyi/results/scroll-to-text-fragment/find-range-from-text-directive.html">find-range-from-text-directive.html</a> <a href="http://web-platform-tests.live/scroll-to-text-fragment/find-range-from-text-directive.html" title="scroll-to-text-fragment/find-range-from-text-directive.html"><small>(live test)</small></a> <a href="https://github.com/web-platform-tests/wpt/blob/master/scroll-to-text-fragment/find-range-from-text-directive.html"><small>(source)</small></a>
    </ul>
-   <p>To advance a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑤">start</a> to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="next non-whitespace position" data-noexport id="next-non-whitespace-position">next
-non-whitespace position</dfn> follow the steps:</p>
-   <ol>
-    <li data-md>
-     <p>While <var>range</var> is not collapsed:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>node</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node②">start node</a>.</p>
-      <li data-md>
-       <p>Let <var>offset</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset">start offset</a>.</p>
-      <li data-md>
-       <p>If <var>node</var> is part of a <a data-link-type="dfn" href="#non-searchable-subtree" id="ref-for-non-searchable-subtree">non-searchable subtree</a> then:</p>
-       <ol>
-        <li data-md>
-         <p>Set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node③">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order">shadow-including tree order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant">shadow-including
+   <div class="algorithm" data-algorithm="advance range start to next non-whitespace position">
+     To advance a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑧">range</a> <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑤">start</a> to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="next non-whitespace position" data-noexport id="next-non-whitespace-position">next
+non-whitespace position</dfn> follow the steps: 
+    <ol class="algorithm">
+     <li data-md>
+      <p>While <var>range</var> is not collapsed:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>node</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node②">start node</a>.</p>
+       <li data-md>
+        <p>Let <var>offset</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset">start offset</a>.</p>
+       <li data-md>
+        <p>If <var>node</var> is part of a <a data-link-type="dfn" href="#non-searchable-subtree" id="ref-for-non-searchable-subtree">non-searchable subtree</a> then:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node③">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order">shadow-including tree order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant">shadow-including
 descendant</a> of <var>node</var>, and set its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset①">start offset</a> to 0.</p>
-        <li data-md>
-         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue③">Continue</a>.</p>
-       </ol>
-      <li data-md>
-       <p>If <var>node</var> is not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node">visible text node</a>:</p>
-       <ol>
-        <li data-md>
-         <p>Set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node④">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order①">shadow-including tree order</a>, and set its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset②">start offset</a> to 0.</p>
-        <li data-md>
-         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue④">Continue</a>.</p>
-       </ol>
-      <li data-md>
-       <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-substring" id="ref-for-concept-cd-substring">substring data</a> of <var>node</var> at offset <var>offset</var> and count 6 is equal to the string "&amp;nbsp;" then:</p>
-       <ol>
-        <li data-md>
-         <p>Add 6 to <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset③">start offset</a>.</p>
-       </ol>
-      <li data-md>
-       <p>Otherwise, if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-substring" id="ref-for-concept-cd-substring①">substring data</a> of <var>node</var> at offset <var>offset</var> and count 5 is equal to the string "&amp;nbsp" then:</p>
-       <ol>
-        <li data-md>
-         <p>Add 5 to <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset④">start offset</a>.</p>
-       </ol>
-      <li data-md>
-       <p>Otherwise:</p>
-       <ol>
-        <li data-md>
-         <p>Let <var>cp</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point" id="ref-for-code-point">code point</a> at the <var>offset</var> index in <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data" id="ref-for-concept-cd-data">data</a>.</p>
-        <li data-md>
-         <p>If <var>cp</var> does not have the <a href="http://www.unicode.org/reports/tr44/#White_Space">White_Space</a> property set, return.</p>
-        <li data-md>
-         <p>Add 1 to <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑤">start offset</a>.</p>
-       </ol>
-      <li data-md>
-       <p>If <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑥">start offset</a> is equal to <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length①">length</a>, set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑤">start node</a> to the next node in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order②">shadow-including tree order</a>, and set its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑦">start offset</a> to 0.</p>
-     </ol>
-   </ol>
-   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-string-in-range">find a string in range</dfn> given a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> <var>query</var>, a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑧">range</a> <var>searchRange</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>,
-run these steps:</p>
-   <div class="note" role="note"> This algorithm will return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑨">range</a> that represents the first instance of
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue③">Continue</a>.</p>
+        </ol>
+       <li data-md>
+        <p>If <var>node</var> is not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node">visible text node</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node④">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order①">shadow-including tree order</a>, and set its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset②">start offset</a> to 0.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue④">Continue</a>.</p>
+        </ol>
+       <li data-md>
+        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-substring" id="ref-for-concept-cd-substring">substring data</a> of <var>node</var> at offset <var>offset</var> and count 6 is equal to the string "&amp;nbsp;" then:</p>
+        <ol>
+         <li data-md>
+          <p>Add 6 to <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset③">start offset</a>.</p>
+        </ol>
+       <li data-md>
+        <p>Otherwise, if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-substring" id="ref-for-concept-cd-substring①">substring data</a> of <var>node</var> at offset <var>offset</var> and count 5 is equal to the string "&amp;nbsp" then:</p>
+        <ol>
+         <li data-md>
+          <p>Add 5 to <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset④">start offset</a>.</p>
+        </ol>
+       <li data-md>
+        <p>Otherwise:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>cp</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point" id="ref-for-code-point">code point</a> at the <var>offset</var> index in <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data" id="ref-for-concept-cd-data">data</a>.</p>
+         <li data-md>
+          <p>If <var>cp</var> does not have the <a href="http://www.unicode.org/reports/tr44/#White_Space">White_Space</a> property set, return.</p>
+         <li data-md>
+          <p>Add 1 to <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑤">start offset</a>.</p>
+        </ol>
+       <li data-md>
+        <p>If <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑥">start offset</a> is equal to <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length①">length</a>, set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑤">start node</a> to the next node in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order②">shadow-including tree order</a>, and set its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑦">start offset</a> to 0.</p>
+      </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="find a string in a range">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-string-in-range">find a string in range</dfn> given a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> <var>query</var>, a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑨">range</a> <var>searchRange</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>,
+run these steps: 
+    <div class="note" role="note"> This algorithm will return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⓪">range</a> that represents the first instance of
   the <var>query</var> text that is fully contained within <var>searchRange</var>, optionally
   restricting itself to matches that start and/or end at word boundaries (see <a href="#word-boundaries">§ 3.5.3 Word Boundaries</a>). Returns null if none is found. </div>
-   <div class="note" role="note">
-    <p> The basic premise of this algorithm is to walk all searchable text nodes
+    <div class="note" role="note">
+     <p> The basic premise of this algorithm is to walk all searchable text nodes
     within a block, collecting them into a list. The list is then concatenated
     into a single string in which we can search, using the node list to
-    determine offsets with a node so we can return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⓪">range</a>. </p>
-    <p> Collection breaks when we hit a block node, e.g. searching over this tree: </p>
+    determine offsets with a node so we can return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②①">range</a>. </p>
+     <p> Collection breaks when we hit a block node, e.g. searching over this tree: </p>
 <pre>      &lt;div>
         a&lt;em>b&lt;/em>c&lt;div>d&lt;/div>e
       &lt;/div>
 </pre>
-    <p></p>
-    <p>Will perform a search on "abc", then on "d", then on "e".</p>
-    <p>Thus, <var>query</var> will only match text that is continuous (i.e. uninterrupted by
+     <p></p>
+     <p>Will perform a search on "abc", then on "d", then on "e".</p>
+     <p>Thus, <var>query</var> will only match text that is continuous (i.e. uninterrupted by
   a block-level container) within a single block-level container.</p>
-   </div>
-   <ol>
-    <li data-md>
-     <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed③">collapsed</a>:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>curNode</var> be <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑥">start node</a>.</p>
-      <li data-md>
-       <p>If <var>curNode</var> is part of a <a data-link-type="dfn" href="#non-searchable-subtree" id="ref-for-non-searchable-subtree①">non-searchable subtree</a>:</p>
-       <ol>
-        <li data-md>
-         <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑦">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order③">shadow-including tree order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant①">shadow-including
+    </div>
+    <ol class="algorithm">
+     <li data-md>
+      <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed③">collapsed</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>curNode</var> be <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑥">start node</a>.</p>
+       <li data-md>
+        <p>If <var>curNode</var> is part of a <a data-link-type="dfn" href="#non-searchable-subtree" id="ref-for-non-searchable-subtree①">non-searchable subtree</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑦">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order③">shadow-including tree order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant①">shadow-including
 descendant</a> of <var>curNode</var>.</p>
-        <li data-md>
-         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue⑤">Continue</a>.</p>
-       </ol>
-      <li data-md>
-       <p>If <var>curNode</var> is not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node①">visible text node</a>:</p>
-       <ol>
-        <li data-md>
-         <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑧">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order④">shadow-including tree order</a>, that is not a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-doctype" id="ref-for-concept-doctype">doctype</a>, and
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue⑤">Continue</a>.</p>
+        </ol>
+       <li data-md>
+        <p>If <var>curNode</var> is not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node①">visible text node</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑧">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order④">shadow-including tree order</a>, that is not a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-doctype" id="ref-for-concept-doctype">doctype</a>, and
 set its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑧">start offset</a> to 0.</p>
-        <li data-md>
-         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue⑥">Continue</a>.</p>
-       </ol>
-      <li data-md>
-       <p>Let <var>blockAncestor</var> be the <a data-link-type="dfn" href="#nearest-block-ancestor" id="ref-for-nearest-block-ancestor">nearest block ancestor</a> of <var>curNode</var>.</p>
-      <li data-md>
-       <p>Let <var>textNodeList</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑦">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text①">Text</a></code> nodes,
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue⑥">Continue</a>.</p>
+        </ol>
+       <li data-md>
+        <p>Let <var>blockAncestor</var> be the <a data-link-type="dfn" href="#nearest-block-ancestor" id="ref-for-nearest-block-ancestor">nearest block ancestor</a> of <var>curNode</var>.</p>
+       <li data-md>
+        <p>Let <var>textNodeList</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑦">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text①">Text</a></code> nodes,
 initially empty.</p>
-      <li data-md>
-       <p>While <var>curNode</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant②">shadow-including descendant</a> of <var>blockAncestor</var> and the position of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp②">boundary point</a> (<var>curNode</var>, 0) is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after②">after</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①③">end</a>:</p>
-       <ol>
-        <li data-md>
-         <p>If <var>curNode</var> <a data-link-type="dfn" href="#has-block-level-display" id="ref-for-has-block-level-display">has block-level display</a> then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break">break</a>.</p>
-        <li data-md>
-         <p>If <var>curNode</var> is <a data-link-type="dfn" href="#search-invisible" id="ref-for-search-invisible">search invisible</a>:</p>
-         <ol>
-          <li data-md>
-           <p>Set <var>curNode</var> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order⑤">shadow-including tree
+       <li data-md>
+        <p>While <var>curNode</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant②">shadow-including descendant</a> of <var>blockAncestor</var> and the position of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp②">boundary point</a> (<var>curNode</var>, 0) is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after②">after</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①③">end</a>:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>curNode</var> <a data-link-type="dfn" href="#has-block-level-display" id="ref-for-has-block-level-display">has block-level display</a> then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break">break</a>.</p>
+         <li data-md>
+          <p>If <var>curNode</var> is <a data-link-type="dfn" href="#search-invisible" id="ref-for-search-invisible">search invisible</a>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>curNode</var> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order⑤">shadow-including tree
 order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant③">shadow-including descendant</a> of <var>curNode</var>.</p>
-          <li data-md>
-           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue⑦">Continue</a>.</p>
-         </ol>
-        <li data-md>
-         <p>If <var>curNode</var> is a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node②">visible text node</a> then append it to <var>textNodeList</var>.</p>
-        <li data-md>
-         <p>Set <var>curNode</var> to the next node in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order⑥">shadow-including tree order</a>.</p>
-       </ol>
-      <li data-md>
-       <p>Run the <a data-link-type="dfn" href="#find-a-range-from-a-node-list" id="ref-for-find-a-range-from-a-node-list">find a range from a node list</a> steps given <var>query</var>, <var>searchRange</var>, <var>textNodeList</var>, <var>wordStartBounded</var> and <var>wordEndBounded</var> as input. If the resulting <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②①">range</a> is not null, then return it.</p>
-      <li data-md>
-       <p>If <var>curNode</var> is null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break①">break</a>.</p>
-      <li data-md>
-       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert③">Assert</a>: <var>curNode</var> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-following" id="ref-for-concept-tree-following">follows</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑨">start node</a>.</p>
-      <li data-md>
-       <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑥">start</a> to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp③">boundary point</a> (<var>curNode</var>,
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue⑦">Continue</a>.</p>
+          </ol>
+         <li data-md>
+          <p>If <var>curNode</var> is a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node②">visible text node</a> then append it to <var>textNodeList</var>.</p>
+         <li data-md>
+          <p>Set <var>curNode</var> to the next node in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order⑥">shadow-including tree order</a>.</p>
+        </ol>
+       <li data-md>
+        <p>Run the <a data-link-type="dfn" href="#find-a-range-from-a-node-list" id="ref-for-find-a-range-from-a-node-list">find a range from a node list</a> steps given <var>query</var>, <var>searchRange</var>, <var>textNodeList</var>, <var>wordStartBounded</var> and <var>wordEndBounded</var> as input. If the resulting <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②②">range</a> is not null, then return it.</p>
+       <li data-md>
+        <p>If <var>curNode</var> is null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break①">break</a>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert③">Assert</a>: <var>curNode</var> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-following" id="ref-for-concept-tree-following">follows</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑨">start node</a>.</p>
+       <li data-md>
+        <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑥">start</a> to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp③">boundary point</a> (<var>curNode</var>,
 0).</p>
-     </ol>
-    <li data-md>
-     <p>Return null.</p>
-   </ol>
-   <p>A node is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="search-invisible">search invisible</dfn> if it is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element④">element</a> in the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace">HTML
+      </ol>
+     <li data-md>
+      <p>Return null.</p>
+    </ol>
+   </div>
+   <p>A node is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="search-invisible">search invisible</dfn> if it is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element⑤">element</a> in the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace">HTML
 namespace</a> and meets any of the following conditions:</p>
    <ol>
     <li data-md>
@@ -2835,127 +2933,133 @@ namespace</a> and meets any of the following conditions:</p>
    </ol>
    <p>A node is part of a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="non-searchable-subtree">non-searchable subtree</dfn> if it is or has a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-ancestor" id="ref-for-concept-shadow-including-ancestor">shadow-including ancestor</a> that is <a data-link-type="dfn" href="#search-invisible" id="ref-for-search-invisible①">search invisible</a>.</p>
    <p>A node is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="visible-text-node">visible text node</dfn> if it is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text②">Text</a></code> node, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value①">computed value</a> of its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#parent-element" id="ref-for-parent-element">parent element</a>'s <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> property is <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css2/#valdef-visibility-visible" id="ref-for-valdef-visibility-visible">visible</a>, and it is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered" id="ref-for-being-rendered">being rendered</a>.</p>
-   <p>A node <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="has-block-level-display">has block-level display</dfn> if it is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element⑤">element</a> and the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value②">computed value</a> of its <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display①">display</a> property is any of <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-block" id="ref-for-valdef-display-block">block</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-table" id="ref-for-valdef-display-table">table</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root" id="ref-for-valdef-display-flow-root">flow-root</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-grid" id="ref-for-valdef-display-grid">grid</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flex" id="ref-for-valdef-display-flex">flex</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item" id="ref-for-valdef-display-list-item">list-item</a>.</p>
-   <p>To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="nearest-block-ancestor">nearest block ancestor</dfn> of a <var>node</var> follow the steps:</p>
-   <ol>
-    <li data-md>
-     <p>Let <var>curNode</var> be <var>node</var>.</p>
-    <li data-md>
-     <p>While <var>curNode</var> is non-null</p>
-     <ol>
-      <li data-md>
-       <p>If <var>curNode</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text③">Text</a></code> node and it <a data-link-type="dfn" href="#has-block-level-display" id="ref-for-has-block-level-display①">has block-level display</a> then
+   <p>A node <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="has-block-level-display">has block-level display</dfn> if it is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element⑥">element</a> and the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value②">computed value</a> of its <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display①">display</a> property is any of <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-block" id="ref-for-valdef-display-block">block</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-table" id="ref-for-valdef-display-table">table</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root" id="ref-for-valdef-display-flow-root">flow-root</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-grid" id="ref-for-valdef-display-grid">grid</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flex" id="ref-for-valdef-display-flex">flex</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item" id="ref-for-valdef-display-list-item">list-item</a>.</p>
+   <div class="algorithm" data-algorithm="nearest block ancestor">
+     To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="nearest-block-ancestor">nearest block ancestor</dfn> of a <var>node</var> follow the steps: 
+    <ol class="algorithm">
+     <li data-md>
+      <p>Let <var>curNode</var> be <var>node</var>.</p>
+     <li data-md>
+      <p>While <var>curNode</var> is non-null</p>
+      <ol>
+       <li data-md>
+        <p>If <var>curNode</var> is not a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text③">Text</a></code> node and it <a data-link-type="dfn" href="#has-block-level-display" id="ref-for-has-block-level-display①">has block-level display</a> then
 return <var>curNode</var>.</p>
-      <li data-md>
-       <p>Otherwise, set <var>curNode</var> to <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent②">parent</a>.</p>
-     </ol>
-    <li data-md>
-     <p>Return <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#document-element" id="ref-for-document-element">document element</a>.</p>
-   </ol>
-   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-node-list">find a range from a node list</dfn> given a search string <var>queryString</var>,
-a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②②">range</a> <var>searchRange</var>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑧">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text④">Text</a></code> nodes <var>nodes</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>, follow these steps:</p>
-   <div class="note" role="note">
-     Optionally, this will only return a match if the matched text begins and/or
-  ends on a <a data-link-type="dfn" href="#word-boundary" id="ref-for-word-boundary">word boundary</a>. For example: 
-    <div class="example" id="example-27ab4025">
-     <a class="self-link" href="#example-27ab4025"></a> The query string “range” will always match in “mountain range”, but 
-     <ol>
-      <li data-md>
-       <p>When requiring a word boundary at the beginning, it will not match in “color orange”.</p>
-      <li data-md>
-       <p>When requiring a word boundary at the end, it will not match in “forest ranger”.</p>
-     </ol>
-    </div>
-    <p>See <a href="#word-boundaries">§ 3.5.3 Word Boundaries</a> for details and more examples.</p>
+       <li data-md>
+        <p>Otherwise, set <var>curNode</var> to <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent②">parent</a>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#document-element" id="ref-for-document-element">document element</a>.</p>
+    </ol>
    </div>
-   <ol>
-    <li data-md>
-     <p>Let <var>searchBuffer</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-concatenate" id="ref-for-string-concatenate">concatenation</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data" id="ref-for-concept-cd-data①">data</a> of each item in <var>nodes</var>.</p>
-    <li data-md>
-     <p>Let <var>searchStart</var> be 0.</p>
-    <li data-md>
-     <p>If the first item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node①⓪">start node</a> then
+   <div class="algorithm" data-algorithm="range from node list">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-node-list">find a range from a node list</dfn> given a search string <var>queryString</var>,
+a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②③">range</a> <var>searchRange</var>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑧">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text④">Text</a></code> nodes <var>nodes</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>, follow these steps: 
+    <div class="note" role="note">
+      Optionally, this will only return a match if the matched text begins and/or
+  ends on a <a data-link-type="dfn" href="#word-boundary" id="ref-for-word-boundary">word boundary</a>. For example: 
+     <div class="example" id="example-27ab4025">
+      <a class="self-link" href="#example-27ab4025"></a> The query string “range” will always match in “mountain range”, but 
+      <ol>
+       <li data-md>
+        <p>When requiring a word boundary at the beginning, it will not match in “color orange”.</p>
+       <li data-md>
+        <p>When requiring a word boundary at the end, it will not match in “forest ranger”.</p>
+      </ol>
+     </div>
+     <p>See <a href="#word-boundaries">§ 3.5.3 Word Boundaries</a> for details and more examples.</p>
+    </div>
+    <ol class="algorithm">
+     <li data-md>
+      <p>Let <var>searchBuffer</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-concatenate" id="ref-for-string-concatenate">concatenation</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data" id="ref-for-concept-cd-data①">data</a> of each item in <var>nodes</var>.</p>
+     <li data-md>
+      <p>Let <var>searchStart</var> be 0.</p>
+     <li data-md>
+      <p>If the first item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node①⓪">start node</a> then
 set <var>searchStart</var> to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑨">start offset</a>.</p>
-    <li data-md>
-     <p>Let <var>start</var> and <var>end</var> be <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp④">boundary points</a>, initially null.</p>
-    <li data-md>
-     <p>Let <var>matchIndex</var> be null.</p>
-    <li data-md>
-     <p>While <var>matchIndex</var> is null</p>
-     <ol>
-      <li data-md>
-       <p>Set <var>matchIndex</var> to the index of the first instance of <var>queryString</var> in <var>searchBuffer</var>, starting at <var>searchStart</var>. The string search must be
+     <li data-md>
+      <p>Let <var>start</var> and <var>end</var> be <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp④">boundary points</a>, initially null.</p>
+     <li data-md>
+      <p>Let <var>matchIndex</var> be null.</p>
+     <li data-md>
+      <p>While <var>matchIndex</var> is null</p>
+      <ol>
+       <li data-md>
+        <p>Set <var>matchIndex</var> to the index of the first instance of <var>queryString</var> in <var>searchBuffer</var>, starting at <var>searchStart</var>. The string search must be
 performed using a base character comparison, or the <a href="http://www.unicode.org/reports/tr10/#Multi_Level_Comparison">primary
 level</a>, as defined in <a data-link-type="biblio" href="#biblio-uts10">[UTS10]</a>.</p>
-       <div class="note" role="note"> Intuitively, this is a case-insensitive search also ignoring accents
+        <div class="note" role="note"> Intuitively, this is a case-insensitive search also ignoring accents
   and other marks. </div>
-      <li data-md>
-       <p>If <var>matchIndex</var> is null, return null.</p>
-      <li data-md>
-       <p>Let <var>endIx</var> be <var>matchIndex</var> + <var>queryString</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length">length</a>.</p>
-       <div class="note" role="note"> <var>endIx</var> is the index of the last character in the match + 1. </div>
-      <li data-md>
-       <p>Set <var>start</var> to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑤">boundary point</a> result of <a data-link-type="dfn" href="#get-boundary-point-at-index" id="ref-for-get-boundary-point-at-index">get boundary point at
+       <li data-md>
+        <p>If <var>matchIndex</var> is null, return null.</p>
+       <li data-md>
+        <p>Let <var>endIx</var> be <var>matchIndex</var> + <var>queryString</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length">length</a>.</p>
+        <div class="note" role="note"> <var>endIx</var> is the index of the last character in the match + 1. </div>
+       <li data-md>
+        <p>Set <var>start</var> to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑤">boundary point</a> result of <a data-link-type="dfn" href="#get-boundary-point-at-index" id="ref-for-get-boundary-point-at-index">get boundary point at
 index</a> <var>matchIndex</var> run over <var>nodes</var> with <var>isEnd</var> false.</p>
-      <li data-md>
-       <p>Set <var>end</var> to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑥">boundary point</a> result of <a data-link-type="dfn" href="#get-boundary-point-at-index" id="ref-for-get-boundary-point-at-index①">get boundary point at
+       <li data-md>
+        <p>Set <var>end</var> to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑥">boundary point</a> result of <a data-link-type="dfn" href="#get-boundary-point-at-index" id="ref-for-get-boundary-point-at-index①">get boundary point at
 index</a> <var>endIx</var> run over <var>nodes</var> with <var>isEnd</var> true.</p>
-      <li data-md>
-       <p>If <var>wordStartBounded</var> is true and <var>matchIndex</var> <a data-link-type="dfn" href="#is-at-a-word-boundary" id="ref-for-is-at-a-word-boundary">is
+       <li data-md>
+        <p>If <var>wordStartBounded</var> is true and <var>matchIndex</var> <a data-link-type="dfn" href="#is-at-a-word-boundary" id="ref-for-is-at-a-word-boundary">is
 not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#language" id="ref-for-language">language</a> from <var>start</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#boundary-point-node" id="ref-for-boundary-point-node">node</a> as the <var>locale</var>; or <var>wordEndBounded</var> is true and <var>matchIndex</var> + <var>queryString</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length①">length</a> <a data-link-type="dfn" href="#is-at-a-word-boundary" id="ref-for-is-at-a-word-boundary①">is not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#language" id="ref-for-language①">language</a> from <var>end</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#boundary-point-node" id="ref-for-boundary-point-node①">node</a> as the <var>locale</var>:</p>
-       <ol>
-        <li data-md>
-         <p>Set <var>searchStart</var> to <var>matchIndex</var> + 1.</p>
-        <li data-md>
-         <p>Set <var>matchIndex</var> to null.</p>
-       </ol>
-     </ol>
-    <li data-md>
-     <p>Let <var>endInset</var> be 0.</p>
-    <li data-md>
-     <p>If the last item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node①">end node</a> then set <var>endInset</var> to (<var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node②">end node</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length②">length</a> − <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-offset" id="ref-for-concept-range-end-offset">end offset</a>)</p>
-     <div class="note" role="note"> <var>endInset</var> is the offset from the last position in the last node in the
+        <ol>
+         <li data-md>
+          <p>Set <var>searchStart</var> to <var>matchIndex</var> + 1.</p>
+         <li data-md>
+          <p>Set <var>matchIndex</var> to null.</p>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>Let <var>endInset</var> be 0.</p>
+     <li data-md>
+      <p>If the last item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node①">end node</a> then set <var>endInset</var> to (<var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node②">end node</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length②">length</a> − <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-offset" id="ref-for-concept-range-end-offset">end offset</a>)</p>
+      <div class="note" role="note"> <var>endInset</var> is the offset from the last position in the last node in the
   reverse direction. Alternatively, it is the length of the node that’s not
   included in the range. </div>
-    <li data-md>
-     <p>If <var>matchIndex</var> + <var>queryString</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length②">length</a> is greater than <var>searchBuffer</var>’s length − <var>endInset</var> return null.</p>
-     <div class="note" role="note"> If the match runs past the end of the search range, return null. </div>
-    <li data-md>
-     <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert④">Assert</a>: <var>start</var> and <var>end</var> are non-null, valid <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑦">boundary points</a> in <var>searchRange</var>.</p>
-    <li data-md>
-     <p>Return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②③">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑦">start</a> <var>start</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①④">end</a> <var>end</var>.</p>
-   </ol>
-   <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="get-boundary-point-at-index">get boundary point at index</dfn>, given an integer <var>index</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑨">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text⑤">Text</a></code> nodes <var>nodes</var>, and a boolean <var>isEnd</var>, follow these steps:</p>
-   <div class="note" role="note">
-    <p> This is a small helper routine used by the steps above to determine which
+     <li data-md>
+      <p>If <var>matchIndex</var> + <var>queryString</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-length" id="ref-for-string-length②">length</a> is greater than <var>searchBuffer</var>’s length − <var>endInset</var> return null.</p>
+      <div class="note" role="note"> If the match runs past the end of the search range, return null. </div>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert④">Assert</a>: <var>start</var> and <var>end</var> are non-null, valid <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑦">boundary points</a> in <var>searchRange</var>.</p>
+     <li data-md>
+      <p>Return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②④">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑦">start</a> <var>start</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①④">end</a> <var>end</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="boundary point at index">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="get-boundary-point-at-index">get boundary point at index</dfn>, given an integer <var>index</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑨">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text⑤">Text</a></code> nodes <var>nodes</var>, and a boolean <var>isEnd</var>, follow these steps: 
+    <div class="note" role="note">
+     <p> This is a small helper routine used by the steps above to determine which
     node a given index in the concatenated string belongs to. </p>
-    <p> <var>isEnd</var> is used to differentiate start and end indices. An end index points
+     <p> <var>isEnd</var> is used to differentiate start and end indices. An end index points
     to the "one-past-last" character of the matching string. If the match ends
     at node boundary, we want the end offset to remain within that node, rather
     than the start of the next node. </p>
+    </div>
+    <ol class="algorithm">
+     <li data-md>
+      <p>Let <var>counted</var> be 0.</p>
+     <li data-md>
+      <p>For each <var>curNode</var> of <var>nodes</var>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>nodeEnd</var> be <var>counted</var> + <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length③">length</a>.</p>
+       <li data-md>
+        <p>If <var>isEnd</var> is true, add 1 to <var>nodeEnd</var>.</p>
+       <li data-md>
+        <p>If <var>nodeEnd</var> is greater than <var>index</var> then:</p>
+        <ol>
+         <li data-md>
+          <p>Return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑧">boundary point</a> (<var>curNode</var>, <var>index</var> − <var>counted</var>).</p>
+        </ol>
+       <li data-md>
+        <p>Increment <var>counted</var> by <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length④">length</a>.</p>
+      </ol>
+     <li data-md>
+      <p>Return null.</p>
+    </ol>
    </div>
-   <ol>
-    <li data-md>
-     <p>Let <var>counted</var> be 0.</p>
-    <li data-md>
-     <p>For each <var>curNode</var> of <var>nodes</var>:</p>
-     <ol>
-      <li data-md>
-       <p>Let <var>nodeEnd</var> be <var>counted</var> + <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length③">length</a>.</p>
-      <li data-md>
-       <p>If <var>isEnd</var> is true, add 1 to <var>nodeEnd</var>.</p>
-      <li data-md>
-       <p>If <var>nodeEnd</var> is greater than <var>index</var> then:</p>
-       <ol>
-        <li data-md>
-         <p>Return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑧">boundary point</a> (<var>curNode</var>, <var>index</var> − <var>counted</var>).</p>
-       </ol>
-      <li data-md>
-       <p>Increment <var>counted</var> by <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length④">length</a>.</p>
-     </ol>
-    <li data-md>
-     <p>Return null.</p>
-   </ol>
    <h4 class="heading settled" data-level="3.5.3" id="word-boundaries"><span class="secno">3.5.3. </span><span class="content">Word Boundaries</span><a class="self-link" href="#word-boundaries"></a></h4>
    <div class="note" role="note"> Limiting matching to word boundaries is one of the mitigations to limit
   cross-origin information leakage. </div>
@@ -2974,7 +3078,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
   alphabet as valid, one-letter words. </p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="locale">locale</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑤">string</a> containing a valid <a data-link-type="biblio" href="#biblio-bcp47">[BCP47]</a> language tag, or the empty string. An empty string indicates that the primary
 language is unknown.</p>
-   <p>A substring is <dfn data-dfn-type="dfn" data-noexport id="word-bounded">word bounded<a class="self-link" href="#word-bounded"></a></dfn> in a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑥">string</a> <var>text</var>,
+   <p>A substring is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-bounded">word bounded</dfn> in a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑥">string</a> <var>text</var>,
 given <a data-link-type="dfn" href="#locale" id="ref-for-locale">locales</a> <var>startLocale</var> and <var>endLocale</var>, if both the position of its
 first character <a data-link-type="dfn" href="#is-at-a-word-boundary" id="ref-for-is-at-a-word-boundary②">is at a word boundary</a> given <var>startLocale</var>, and the position
 after its last character <a data-link-type="dfn" href="#is-at-a-word-boundary" id="ref-for-is-at-a-word-boundary③">is at a word boundary</a> given <var>endLocale</var>.</p>
@@ -2982,8 +3086,8 @@ after its last character <a data-link-type="dfn" href="#is-at-a-word-boundary" i
 boundary</a> immediately precedes the <var>position</var>th code unit, or <var>text</var>’s length
 is more than 0 and <var>position</var> equals either 0 or <var>text</var>’s length.</p>
    <div class="note" role="note">
-     Intuitively, a substring is word bounded if it neither begins nor ends in the
-  middle of a word. 
+     Intuitively, a substring is <a data-link-type="dfn" href="#word-bounded" id="ref-for-word-bounded">word bounded</a> if it neither begins nor ends in
+  the middle of a word. 
     <p>In languages with a word separator (e.g. " " space) this is (mostly)
   straightforward; though there are details covered by the above technical
   reports such as new lines, hyphenations, quotes, etc.</p>
@@ -3039,11 +3143,11 @@ persisted state</a> steps by inserting a new step after 2:</p>
    <ol start="3">
     <li data-md>
      <p><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
-the document policy value</a> of the "force-load-at-top" feature for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">Document</a>. If
+the document policy value</a> of the "force-load-at-top" feature for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①②">Document</a>. If
 the result is true, then the user agent should not restore the scroll
-position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①②">Document</a> or any of its scrollable regions. Scroll
+position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a> or any of its scrollable regions. Scroll
 positions for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#child-browsing-context" id="ref-for-child-browsing-context">child browsing contexts</a> should be restored based on the
-value of this policy in the child <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a>.</p>
+value of this policy in the child <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①④">Document</a>.</p>
    </ol>
    <h3 class="heading settled" data-level="3.8" id="feature-detectability"><span class="secno">3.8. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
@@ -3053,8 +3157,8 @@ the feature.</p>
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="fragmentdirective"><code><c- g>FragmentDirective</c-></code></dfn> {
 };
 </pre>
-   <p>We amend the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code> interface to include a <code>fragmentDirective</code> property:</p>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①"><c- g>Document</c-></a> {
+   <p>We amend the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> interface to include a <code>fragmentDirective</code> property:</p>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③"><c- g>Document</c-></a> {
     [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject" id="ref-for-SameObject"><c- g>SameObject</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-document-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-document-fragmentdirective"></a></dfn>;
 };
 </pre>
@@ -3333,7 +3437,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-dictdef-scrollintoviewoptions">
    <a href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions">https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dictdef-scrollintoviewoptions">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-dictdef-scrollintoviewoptions①">(2)</a>
+    <li><a href="#ref-for-dictdef-scrollintoviewoptions">3.5.1. Scroll a DOMRect into view</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-dom-range-getboundingclientrect">
@@ -3352,7 +3456,8 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-document">
    <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document">3.8. Feature Detectability</a> <a href="#ref-for-document①">(2)</a>
+    <li><a href="#ref-for-document">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-document①">(2)</a>
+    <li><a href="#ref-for-document②">3.8. Feature Detectability</a> <a href="#ref-for-document③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-text">
@@ -3395,10 +3500,10 @@ match based on whether the element-id was scrolled.</p>
    <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.3.1. Parsing the fragment directive</a>
-    <li><a href="#ref-for-concept-document①">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a> <a href="#ref-for-concept-document④">(4)</a> <a href="#ref-for-concept-document⑤">(5)</a> <a href="#ref-for-concept-document⑥">(6)</a> <a href="#ref-for-concept-document⑦">(7)</a>
-    <li><a href="#ref-for-concept-document⑧">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-concept-document⑨">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-document①⓪">(2)</a>
-    <li><a href="#ref-for-concept-document①①">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①②">(2)</a> <a href="#ref-for-concept-document①③">(3)</a>
+    <li><a href="#ref-for-concept-document①">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a> <a href="#ref-for-concept-document④">(4)</a> <a href="#ref-for-concept-document⑤">(5)</a> <a href="#ref-for-concept-document⑥">(6)</a> <a href="#ref-for-concept-document⑦">(7)</a> <a href="#ref-for-concept-document⑧">(8)</a>
+    <li><a href="#ref-for-concept-document⑨">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-document①⓪">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-document①①">(2)</a>
+    <li><a href="#ref-for-concept-document①②">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①③">(2)</a> <a href="#ref-for-concept-document①④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document-element">
@@ -3411,8 +3516,8 @@ match based on whether the element-id was scrolled.</p>
    <a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-element①">(2)</a>
-    <li><a href="#ref-for-concept-element②">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-concept-element③">(2)</a>
-    <li><a href="#ref-for-concept-element④">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-element⑤">(2)</a>
+    <li><a href="#ref-for-concept-element②">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-concept-element③">(2)</a> <a href="#ref-for-concept-element④">(3)</a>
+    <li><a href="#ref-for-concept-element⑤">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-element⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-range-end">
@@ -3481,8 +3586,8 @@ match based on whether the element-id was scrolled.</p>
    <a href="https://dom.spec.whatwg.org/#concept-range">https://dom.spec.whatwg.org/#concept-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-range①">(2)</a> <a href="#ref-for-concept-range②">(3)</a> <a href="#ref-for-concept-range③">(4)</a>
-    <li><a href="#ref-for-concept-range④">3.5.1. Scroll a DOMRect into view</a>
-    <li><a href="#ref-for-concept-range⑤">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range⑥">(2)</a> <a href="#ref-for-concept-range⑦">(3)</a> <a href="#ref-for-concept-range⑧">(4)</a> <a href="#ref-for-concept-range⑨">(5)</a> <a href="#ref-for-concept-range①⓪">(6)</a> <a href="#ref-for-concept-range①①">(7)</a> <a href="#ref-for-concept-range①②">(8)</a> <a href="#ref-for-concept-range①③">(9)</a> <a href="#ref-for-concept-range①④">(10)</a> <a href="#ref-for-concept-range①⑤">(11)</a> <a href="#ref-for-concept-range①⑥">(12)</a> <a href="#ref-for-concept-range①⑦">(13)</a> <a href="#ref-for-concept-range①⑧">(14)</a> <a href="#ref-for-concept-range①⑨">(15)</a> <a href="#ref-for-concept-range②⓪">(16)</a> <a href="#ref-for-concept-range②①">(17)</a> <a href="#ref-for-concept-range②②">(18)</a> <a href="#ref-for-concept-range②③">(19)</a>
+    <li><a href="#ref-for-concept-range④">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-concept-range⑤">(2)</a>
+    <li><a href="#ref-for-concept-range⑥">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range⑦">(2)</a> <a href="#ref-for-concept-range⑧">(3)</a> <a href="#ref-for-concept-range⑨">(4)</a> <a href="#ref-for-concept-range①⓪">(5)</a> <a href="#ref-for-concept-range①①">(6)</a> <a href="#ref-for-concept-range①②">(7)</a> <a href="#ref-for-concept-range①③">(8)</a> <a href="#ref-for-concept-range①④">(9)</a> <a href="#ref-for-concept-range①⑤">(10)</a> <a href="#ref-for-concept-range①⑥">(11)</a> <a href="#ref-for-concept-range①⑦">(12)</a> <a href="#ref-for-concept-range①⑧">(13)</a> <a href="#ref-for-concept-range①⑨">(14)</a> <a href="#ref-for-concept-range②⓪">(15)</a> <a href="#ref-for-concept-range②①">(16)</a> <a href="#ref-for-concept-range②②">(17)</a> <a href="#ref-for-concept-range②③">(18)</a> <a href="#ref-for-concept-range②④">(19)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-shadow-root">
@@ -3555,7 +3660,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-concept-request">
    <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-request①">(2)</a>
+    <li><a href="#ref-for-concept-request">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a> <a href="#ref-for-concept-request③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-response-url">
@@ -3567,7 +3672,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-domrect">
    <a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-domrect">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-domrect①">(2)</a>
+    <li><a href="#ref-for-domrect">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-domrect①">(2)</a> <a href="#ref-for-domrect②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-htmlaudioelement">
@@ -3880,10 +3985,10 @@ match based on whether the element-id was scrolled.</p>
      <li><span class="dfn-paneled" id="term-for-valdef-visibility-visible">visible</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[cssom-view-1]</a> defines the following terms:
+    <a data-link-type="biblio">[CSSOM-VIEW]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-dictdef-scrollintoviewoptions">ScrollIntoViewOptions</span>
-     <li><span class="dfn-paneled" id="term-for-dom-range-getboundingclientrect">getBoundingClientRect()</span>
+     <li><span class="dfn-paneled" id="term-for-dom-range-getboundingclientrect">getBoundingClientRect() <small>(for Range)</small></span>
      <li><span class="dfn-paneled" id="term-for-scroll-an-element-into-view">scroll an element into view</span>
     </ul>
    <li>
@@ -4005,7 +4110,7 @@ match based on whether the element-id was scrolled.</p>
    <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-display-3/">CSS Display Module Level 3</a>. 19 May 2020. CR. URL: <a href="https://www.w3.org/TR/css-display-3/">https://www.w3.org/TR/css-display-3/</a>
    <dt id="biblio-css21">[CSS21]
    <dd>Bert Bos; et al. <a href="https://www.w3.org/TR/CSS21/">Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/CSS21/">https://www.w3.org/TR/CSS21/</a>
-   <dt id="biblio-cssom-view-1">[CSSOM-VIEW-1]
+   <dt id="biblio-cssom-view">[CSSOM-VIEW]
    <dd>Simon Pieters. <a href="https://www.w3.org/TR/cssom-view-1/">CSSOM View Module</a>. 17 March 2016. WD. URL: <a href="https://www.w3.org/TR/cssom-view-1/">https://www.w3.org/TR/cssom-view-1/</a>
    <dt id="biblio-document-policy">[DOCUMENT-POLICY]
    <dd>Ian Clelland. <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html">Document Policy</a>. ED. URL: <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html">https://w3c.github.io/webappsec-permissions-policy/document-policy.html</a>
@@ -4034,6 +4139,8 @@ match based on whether the element-id was scrolled.</p>
   <dl>
    <dt id="biblio-bcp47">[BCP47]
    <dd>A. Phillips; M. Davis. <a href="https://tools.ietf.org/html/bcp47">Tags for Identifying Languages</a>. September 2009. IETF Best Current Practice. URL: <a href="https://tools.ietf.org/html/bcp47">https://tools.ietf.org/html/bcp47</a>
+   <dt id="biblio-fetch-metadata">[FETCH-METADATA]
+   <dd>Mike West. <a href="https://w3c.github.io/webappsec-fetch-metadata/">Fetch Metadata Request Headers</a>. WD. URL: <a href="https://w3c.github.io/webappsec-fetch-metadata/">https://w3c.github.io/webappsec-fetch-metadata/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
@@ -4189,16 +4296,16 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-percentencodedchar">3.3.2. Fragment directive grammar</a> <a href="#ref-for-percentencodedchar①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-textfragmenttoken">
-   <b><a href="#document-textfragmenttoken">#document-textfragmenttoken</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-document-textfragmenttoken">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-textfragmenttoken①">(2)</a> <a href="#ref-for-document-textfragmenttoken②">(3)</a> <a href="#ref-for-document-textfragmenttoken③">(4)</a> <a href="#ref-for-document-textfragmenttoken④">(5)</a> <a href="#ref-for-document-textfragmenttoken⑤">(6)</a> <a href="#ref-for-document-textfragmenttoken⑥">(7)</a> <a href="#ref-for-document-textfragmenttoken⑦">(8)</a> <a href="#ref-for-document-textfragmenttoken⑧">(9)</a> <a href="#ref-for-document-textfragmenttoken⑨">(10)</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="request-textfragmenttoken">
    <b><a href="#request-textfragmenttoken">#request-textfragmenttoken</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-textfragmenttoken">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-request-textfragmenttoken①">(2)</a> <a href="#ref-for-request-textfragmenttoken②">(3)</a>
+    <li><a href="#ref-for-request-textfragmenttoken">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-request-textfragmenttoken①">(2)</a> <a href="#ref-for-request-textfragmenttoken②">(3)</a> <a href="#ref-for-request-textfragmenttoken③">(4)</a> <a href="#ref-for-request-textfragmenttoken④">(5)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="document-textfragmenttoken">
+   <b><a href="#document-textfragmenttoken">#document-textfragmenttoken</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-document-textfragmenttoken">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-textfragmenttoken①">(2)</a> <a href="#ref-for-document-textfragmenttoken②">(3)</a> <a href="#ref-for-document-textfragmenttoken③">(4)</a> <a href="#ref-for-document-textfragmenttoken④">(5)</a> <a href="#ref-for-document-textfragmenttoken⑤">(6)</a> <a href="#ref-for-document-textfragmenttoken⑥">(7)</a> <a href="#ref-for-document-textfragmenttoken⑦">(8)</a> <a href="#ref-for-document-textfragmenttoken⑧">(9)</a> <a href="#ref-for-document-textfragmenttoken⑨">(10)</a> <a href="#ref-for-document-textfragmenttoken①⓪">(11)</a> <a href="#ref-for-document-textfragmenttoken①①">(12)</a> <a href="#ref-for-document-textfragmenttoken①②">(13)</a> <a href="#ref-for-document-textfragmenttoken①③">(14)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="document-allowtextfragmentdirective">
@@ -4313,6 +4420,12 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-locale">3.5.3. Word Boundaries</a> <a href="#ref-for-locale①">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="word-bounded">
+   <b><a href="#word-bounded">#word-bounded</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-word-bounded">3.5.3. Word Boundaries</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="is-at-a-word-boundary">
    <b><a href="#is-at-a-word-boundary">#is-at-a-word-boundary</a></b><b>Referenced in:</b>
    <ul>
@@ -4382,3 +4495,87 @@ document.body.addEventListener("click", function(e) {
 
 });
 </script>
+<script>/* script-var-click-highlighting */
+
+    document.addEventListener("click", e=>{
+        if(e.target.nodeName == "VAR") {
+            highlightSameAlgoVars(e.target);
+        }
+    });
+    {
+        const indexCounts = new Map();
+        const indexNames = new Map();
+        function highlightSameAlgoVars(v) {
+            // Find the algorithm container.
+            let algoContainer = null;
+            let searchEl = v;
+            while(algoContainer == null && searchEl != document.body) {
+                searchEl = searchEl.parentNode;
+                if(searchEl.hasAttribute("data-algorithm")) {
+                    algoContainer = searchEl;
+                }
+            }
+
+            // Not highlighting document-global vars,
+            // too likely to be unrelated.
+            if(algoContainer == null) return;
+
+            const algoName = algoContainer.getAttribute("data-algorithm");
+            const varName = getVarName(v);
+            const addClass = !v.classList.contains("selected");
+            let highlightClass = null;
+            if(addClass) {
+                const index = chooseHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] += 1;
+                indexNames.set(algoName+"///"+varName, index);
+                highlightClass = nameFromIndex(index);
+            } else {
+                const index = previousHighlightIndex(algoName, varName);
+                indexCounts.get(algoName)[index] -= 1;
+                highlightClass = nameFromIndex(index);
+            }
+
+            // Find all same-name vars, and toggle their class appropriately.
+            for(const el of algoContainer.querySelectorAll("var")) {
+                if(getVarName(el) == varName) {
+                    el.classList.toggle("selected", addClass);
+                    el.classList.toggle(highlightClass, addClass);
+                }
+            }
+        }
+        function getVarName(el) {
+            return el.textContent.replace(/(\s| )+/, " ").trim();
+        }
+        function chooseHighlightIndex(algoName, varName) {
+            let indexes = null;
+            if(indexCounts.has(algoName)) {
+                indexes = indexCounts.get(algoName);
+            } else {
+                // 7 classes right now
+                indexes = [0,0,0,0,0,0,0];
+                indexCounts.set(algoName, indexes);
+            }
+
+            // If the element was recently unclicked,
+            // *and* that color is still unclaimed,
+            // give it back the same color.
+            const lastIndex = previousHighlightIndex(algoName, varName);
+            if(indexes[lastIndex] === 0) return lastIndex;
+
+            // Find the earliest index with the lowest count.
+            const minCount = Math.min.apply(null, indexes);
+            let index = null;
+            for(var i = 0; i < indexes.length; i++) {
+                if(indexes[i] == minCount) {
+                    return i;
+                }
+            }
+        }
+        function previousHighlightIndex(algoName, varName) {
+            return indexNames.get(algoName+"///"+varName);
+        }
+        function nameFromIndex(index) {
+            return "selected" + index;
+        }
+    }
+    </script>


### PR DESCRIPTION
This commit adds algorithm and monkeypatch annotations on relevant
sections. No change to meaning is intended.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/ScrollToTextFragment/pull/154.html" title="Last updated on Nov 13, 2020, 4:04 PM UTC (acbc6a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/154/fda9439...bokand:acbc6a7.html" title="Last updated on Nov 13, 2020, 4:04 PM UTC (acbc6a7)">Diff</a>