### PR TITLE
Add section on bidirectional behavior

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -170,6 +170,59 @@ to "an example" in "this is an example text fragment", but not match to "an
 example" in "here is an example text".
 </div>
 
+### BiDi Considerations ### {#bidi-considerations}
+
+<div class='note'>This section is non-normative</div>
+
+<div class='note'>
+  See <a
+  href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics.en">Unicode
+  Bidirectional Algorithm basics</a> for a good overview of how Bidirectional
+  text works.
+</div>
+
+Since URL strings are ASCII encoded, they provide no built-in support for
+bi-directional text. However, the content that we wish to target on a page may
+be LTR (left-to-right), RTL (right-to-left) or both (Bidirectional/BiDi). This
+section provides an intuitive description the behavior implicitly described by
+the normative sections further in this spec.
+
+The characters of each term in the text fragment are in <em>logical order</em>,
+that is, the order in which a native reader would read them in (and also the
+order in which characters are stored in memory).
+
+Similarly, the <code>prefix</code> and <code>textStart</code> terms identify
+text coming before another term in logical order, while <code>suffix</code> and
+<code>textEnd</code> follow other terms in logical order.
+
+Note: user agents may visually render URLs in a manner friendlier to a native
+reader, for example, by converting the displayed string to Unicode. However, the
+string representation of a URL remains plain ASCII characters.
+
+<div class="example">
+  Suppose we want to select the text <code>مِصر‎</code> (Egypt, in Arabic),
+  that's preceeded by <code>البحرين‎</code> (Bahrain, in Arabic). We would
+  first percent encode each term:
+
+  <code>مِصر‎</code> becomes "%D9%85%D8%B5%D8%B1" (Note: UTF-8 character
+  [0xD9,0x85] is the first (right-most) character of the Arabic word.)
+
+  <code>البحرين‎</code> becomes "%D8%A7%D9%84%D8%A8%D8%AD%D8%B1%D9%8A%D9%86"
+
+  The text fragment would then become:
+
+  <code>
+    :~:text=%D8%A7%D9%84%D8%A8%D8%AD%D8%B1%D9%8A%D9%86-,%D9%85%D8%B5%D8%B1
+  </code>
+
+  When displayed in a browser's address bar, the browser may visually render the
+  text in its natural RTL direction, appearing to the user:
+
+  <code>
+    :~:text=البحرين-,مِصر
+  </code>
+</div>
+
 ## The Fragment Directive ## {#the-fragment-directive}
 
 To avoid compatibility issues with usage of existing URL fragments, this spec
@@ -207,7 +260,7 @@ following additions and changes.
 
 To the definition of [=Document=], add:
 
->   <strong>Monkeypatching [[HTML]]:</strong>
+>   <strong>Monkeypatching [[DOM]]:</strong>
 >
 >   <em>
 >     Each document has an associated <dfn>fragment directive</dfn> which is
@@ -220,7 +273,7 @@ Document's [=fragment directive=].
 
 Add a series of steps that will process a fragment directive on a [=Document/URL=]:
 
->   <strong>Monkeypatching [[HTML]]:</strong>
+>   <strong>Monkeypatching [[DOM]]:</strong>
 >
 >   To <dfn>process and consume fragment directive</dfn> from a [=/URL=]
 >   |url| and [=Document=] |document|, run these steps:
@@ -393,7 +446,7 @@ used.
 
 <div algorithm="parse a text directive">
 
-To <dfn>parse a text directive</dfn>, on a <a spec="infra">string</a> |text
+To <dfn>parse a text directive</dfn>, on an <a spec="infra">ASCII string</a> |text
 directive input|, run these steps:
 
 <div class="note">
@@ -1079,8 +1132,8 @@ Define a new algorithm for scrolling [=Range=] into view:
 </div>
 
 <div algorithm="process a fragment directive">
-To <dfn>process a fragment directive</dfn>, given as input a <a
-spec=infra>string</a> |fragment directive input| and a [=Document=]
+To <dfn>process a fragment directive</dfn>, given as input an <a
+spec=infra>ASCII string</a> |fragment directive input| and a [=Document=]
 |document|, run these steps:
 
 <div class="note">
@@ -1094,11 +1147,11 @@ spec=infra>string</a> |fragment directive input| and a [=Document=]
   <ol class="algorithm">
     1. If |fragment directive input| is not a [=valid fragment directive=], then
         return an empty <a spec=infra>list</a>.
-    2. Let |directives| be a <a spec=infra>list</a> of <a spec=infra>string</a>s
+    2. Let |directives| be a <a spec=infra>list</a> of <a spec=infra>ASCII string</a>s
         that is the result of [=strictly split a string|strictly splitting the
         string=] |fragment directive input| on "&".
     3. Let |ranges| be a <a spec=infra>list</a> of [=ranges=], initially empty.
-    4. For each <a spec=infra>string</a> |directive| of |directives|:
+    4. For each <a spec=infra>ASCII string</a> |directive| of |directives|:
         1. If |directive| does not match the production [=TextDirective=],
             then [=iteration/continue=].
         1. Let |parsedValues| be the result of running the [=parse a text

--- a/index.html
+++ b/index.html
@@ -1485,7 +1485,7 @@ Possible extra rowspan handling
 	}
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version ef9d3c0a, updated Fri Nov 13 17:14:48 2020 -0800" name="generator">
+  <meta content="Bikeshed version c5172e83, updated Fri Nov 20 15:35:20 2020 -0800" name="generator">
   <link href="https://wicg.github.io/scroll-to-text-fragment/" rel="canonical">
 <style>/* style-autolinks */
 
@@ -2098,7 +2098,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-11-16">16 November 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-11-24">24 November 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2156,6 +2156,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <a href="#syntax"><span class="secno">3.2</span> <span class="content">Syntax</span></a>
        <ol class="toc">
         <li><a href="#context-terms"><span class="secno">3.2.1</span> <span class="content">Context Terms</span></a>
+        <li><a href="#bidi-considerations"><span class="secno">3.2.2</span> <span class="content">BiDi Considerations</span></a>
        </ol>
       <li>
        <a href="#the-fragment-directive"><span class="secno">3.3</span> <span class="content">The Fragment Directive</span></a>
@@ -2304,6 +2305,37 @@ visually indicated.</p>
    <div class="example" id="example-5c87b699"><a class="self-link" href="#example-5c87b699"></a> <code>#:~:text=this%20is-,an%20example,-text%20fragment</code> would match
 to "an example" in "this is an example text fragment", but not match to "an
 example" in "here is an example text". </div>
+   <h4 class="heading settled" data-level="3.2.2" id="bidi-considerations"><span class="secno">3.2.2. </span><span class="content">BiDi Considerations</span><a class="self-link" href="#bidi-considerations"></a></h4>
+   <div class="note" role="note">This section is non-normative</div>
+   <div class="note" role="note"> See <a href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics.en">Unicode
+  Bidirectional Algorithm basics</a> for a good overview of how Bidirectional
+  text works. </div>
+   <p>Since URL strings are ASCII encoded, they provide no built-in support for
+bi-directional text. However, the content that we wish to target on a page may
+be LTR (left-to-right), RTL (right-to-left) or both (Bidirectional/BiDi). This
+section provides an intuitive description the behavior implicitly described by
+the normative sections further in this spec.</p>
+   <p>The characters of each term in the text fragment are in <em>logical order</em>,
+that is, the order in which a native reader would read them in (and also the
+order in which characters are stored in memory).</p>
+   <p>Similarly, the <code>prefix</code> and <code>textStart</code> terms identify
+text coming before another term in logical order, while <code>suffix</code> and <code>textEnd</code> follow other terms in logical order.</p>
+   <p class="note" role="note"><span>Note:</span> user agents may visually render URLs in a manner friendlier to a native
+reader, for example, by converting the displayed string to Unicode. However, the
+string representation of a URL remains plain ASCII characters.</p>
+   <div class="example" id="example-9f4a4e2f">
+    <a class="self-link" href="#example-9f4a4e2f"></a> Suppose we want to select the text <code>مِصر‎</code> (Egypt, in Arabic),
+  that’s preceeded by <code>البحرين‎</code> (Bahrain, in Arabic). We would
+  first percent encode each term: 
+    <p><code>مِصر‎</code> becomes "%D9%85%D8%B5%D8%B1" (Note: UTF-8 character
+  [0xD9,0x85] is the first (right-most) character of the Arabic word.)</p>
+    <p><code>البحرين‎</code> becomes "%D8%A7%D9%84%D8%A8%D8%AD%D8%B1%D9%8A%D9%86"</p>
+    <p>The text fragment would then become:</p>
+    <p><code> :~:text=%D8%A7%D9%84%D8%A8%D8%AD%D8%B1%D9%8A%D9%86-,%D9%85%D8%B5%D8%B1 </code></p>
+    <p>When displayed in a browser’s address bar, the browser may visually render the
+  text in its natural RTL direction, appearing to the user:</p>
+    <p><code> :~:text=البحرين-,مِصر </code></p>
+   </div>
    <h3 class="heading settled" data-level="3.3" id="the-fragment-directive"><span class="secno">3.3. </span><span class="content">The Fragment Directive</span><a class="self-link" href="#the-fragment-directive"></a></h3>
    <p>To avoid compatibility issues with usage of existing URL fragments, this spec
 introduces the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①">fragment directive</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive②">fragment directive</a> is a portion
@@ -2325,7 +2357,7 @@ UA sets the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-d
 following additions and changes.</p>
    <p>To the definition of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a>, add:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>:</strong></p>
     <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is
     either null or an ASCII string holding data used by the UA to process the
     resource. It is initially null. </em></p>
@@ -2334,7 +2366,7 @@ following additions and changes.</p>
 Document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a>.</p>
    <p>Add a series of steps that will process a fragment directive on a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url②">URL</a>:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>:</strong></p>
     <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-and-consume-fragment-directive">process and consume fragment directive</dfn> from a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">URL</a> <var>url</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a> <var>document</var>, run these steps:</p>
     <ol>
      <li data-md>
@@ -2467,7 +2499,7 @@ of these items.</p>
    <p>See <a href="#syntax">§ 3.2 Syntax</a> for the what each of these components means and how they’re
 used.</p>
    <div class="algorithm" data-algorithm="parse a text directive">
-    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parse-a-text-directive">parse a text directive</dfn>, on a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a> <var>text
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parse-a-text-directive">parse a text directive</dfn>, on an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> <var>text
 directive input</var>, run these steps:</p>
     <div class="note" role="note">
      <p> This algorithm takes a single text directive string as input (e.g.
@@ -2987,7 +3019,7 @@ text=bar,baz
   list.</p>
    </div>
    <div class="algorithm" data-algorithm="process a fragment directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a> <var>document</var>, run these steps: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a> <var>document</var>, run these steps: 
     <div class="note" role="note"> This algorithm takes as input a the <var>fragment directive input</var>, that is the
   raw text of the fragment directive and the <var>document</var> over which it operates.
   It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑨">ranges</a> that are to be visually
@@ -2998,13 +3030,13 @@ text=bar,baz
       <p>If <var>fragment directive input</var> is not a <a data-link-type="dfn" href="#valid-fragment-directive" id="ref-for-valid-fragment-directive">valid fragment directive</a>, then
 return an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list④">list</a>.</p>
      <li data-md>
-      <p>Let <var>directives</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a>s
+      <p>Let <var>directives</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a>s
 that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split">strictly splitting the
 string</a> <var>fragment directive input</var> on "&amp;".</p>
      <li data-md>
       <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑥">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⓪">ranges</a>, initially empty.</p>
      <li data-md>
-      <p>For each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> <var>directive</var> of <var>directives</var>:</p>
+      <p>For each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a> <var>directive</var> of <var>directives</var>:</p>
       <ol>
        <li data-md>
         <p>If <var>directive</var> does not match the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective③">TextDirective</a>,
@@ -3216,7 +3248,7 @@ descendant</a> of <var>node</var>, and set its <a data-link-type="dfn" href="htt
     </ol>
    </div>
    <div class="algorithm" data-algorithm="find a string in a range">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-string-in-range">find a string in range</dfn> given a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string④">string</a> <var>query</var>, a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑨">range</a> <var>searchRange</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>,
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-string-in-range">find a string in range</dfn> given a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a> <var>query</var>, a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑨">range</a> <var>searchRange</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>,
 run these steps: 
     <div class="note" role="note"> This algorithm will return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⓪">range</a> that represents the first instance of
   the <var>query</var> text that is fully contained within <var>searchRange</var>, optionally
@@ -3455,13 +3487,13 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
   word from the next. In such cases, and where the alphabet contains fewer
   than 100 characters, the dictionary must not contain more than 20% of the
   alphabet as valid, one-letter words. </p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="locale">locale</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑤">string</a> containing a valid <a data-link-type="biblio" href="#biblio-bcp47">[BCP47]</a> language tag, or the empty string. An empty string indicates that the primary
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="locale">locale</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> containing a valid <a data-link-type="biblio" href="#biblio-bcp47">[BCP47]</a> language tag, or the empty string. An empty string indicates that the primary
 language is unknown.</p>
-   <p>A substring is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-bounded">word bounded</dfn> in a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑥">string</a> <var>text</var>,
+   <p>A substring is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-bounded">word bounded</dfn> in a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a> <var>text</var>,
 given <a data-link-type="dfn" href="#locale" id="ref-for-locale">locales</a> <var>startLocale</var> and <var>endLocale</var>, if both the position of its
 first character <a data-link-type="dfn" href="#is-at-a-word-boundary" id="ref-for-is-at-a-word-boundary②">is at a word boundary</a> given <var>startLocale</var>, and the position
 after its last character <a data-link-type="dfn" href="#is-at-a-word-boundary" id="ref-for-is-at-a-word-boundary③">is at a word boundary</a> given <var>endLocale</var>.</p>
-   <p>A number <var>position</var> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="is-at-a-word-boundary">is at a word boundary</dfn> in a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string⑦">string</a> <var>text</var>, given a <a data-link-type="dfn" href="#locale" id="ref-for-locale①">locale</a> <var>locale</var>, if, using <var>locale</var>, either a <a data-link-type="dfn" href="#word-boundary" id="ref-for-word-boundary①">word
+   <p>A number <var>position</var> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="is-at-a-word-boundary">is at a word boundary</dfn> in a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a> <var>text</var>, given a <a data-link-type="dfn" href="#locale" id="ref-for-locale①">locale</a> <var>locale</var>, if, using <var>locale</var>, either a <a data-link-type="dfn" href="#word-boundary" id="ref-for-word-boundary①">word
 boundary</a> immediately precedes the <var>position</var>th code unit, or <var>text</var>’s length
 is more than 0 and <var>position</var> equals either 0 or <var>text</var>’s length.</p>
    <div class="note" role="note">
@@ -3532,7 +3564,7 @@ recommendations for how UAs should handle these cases.</p>
    </div>
    <p>The general principle is that a URL should include the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑥">fragment directive</a> only while the visual indicator is visible (i.e. not dismissed). If the user
 dismisses the indicator, the URL should not include the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑦">fragment directive</a>.</p>
-   <p>If the URL includes a text fragment but a match wasn’t found on in the current
+   <p>If the URL includes a text fragment but a match wasn’t found in the current
 page, the UA may choose to omit it from the exposed URL.</p>
    <div class="note" role="note">
     <p> A text fragment that isn’t found on the page may be useful information to
@@ -3556,7 +3588,7 @@ even if a match wasn’t located in the document.</p>
 to the current page in the UA’s interface.</p>
    <p>A newly created bookmark should, by default, include the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑨">fragment directive</a> in the URL if, and only if, a match was found and the visual indicator hasn’t
 been dismissed.</p>
-   <p>Navigating to a URL from a bookmarks should process a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive②⓪">fragment directive</a> as
+   <p>Navigating to a URL from a bookmark should process a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive②⓪">fragment directive</a> as
 if it were navigated to in a typical navigation.</p>
    <h5 class="heading settled" data-level="3.6.1.3" id="urls-in-sharing"><span class="secno">3.6.1.3. </span><span class="content">Sharing</span><a class="self-link" href="#urls-in-sharing"></a></h5>
    <p>Some UAs provide a method for users to share the current page with others,
@@ -3567,7 +3599,7 @@ been dismissed.</p>
    <h3 class="heading settled" data-level="3.7" id="document-policy-integration"><span class="secno">3.7. </span><span class="content">Document Policy Integration</span><a class="self-link" href="#document-policy-integration"></a></h3>
    <p>This specification defines a <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point">configuration point</a> in <a data-link-type="biblio" href="#biblio-document-policy">Document Policy</a> with name "force-load-at-top". Its <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point-type">type</a> is <code>boolean</code> with <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point-default-value">default value</a> <code>false</code>.</p>
    <div class="note" role="note"> When enabled, this policy disables all automatic scroll-on-load features:
-  text-fragments, element framgments, history scroll restoration. </div>
+  text-fragments, element fragments, history scroll restoration. </div>
    <div class="example" id="example-ae692635">
     <a class="self-link" href="#example-ae692635"></a> Suppose the user navigates to <code>https://example.com#:~:text=foo</code>. The
   example.com server response includes the header: 
@@ -4278,6 +4310,13 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-list-append">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-ascii-string">
+   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-ascii-string">3.3.2. Parsing the fragment directive</a>
+    <li><a href="#ref-for-ascii-string①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-ascii-string②">(2)</a> <a href="#ref-for-ascii-string③">(3)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-assert">
    <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
@@ -4356,9 +4395,8 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-string">
    <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string">3.3.2. Parsing the fragment directive</a>
-    <li><a href="#ref-for-string①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a> <a href="#ref-for-string④">(4)</a>
-    <li><a href="#ref-for-string⑤">3.5.3. Word Boundaries</a> <a href="#ref-for-string⑥">(2)</a> <a href="#ref-for-string⑦">(3)</a>
+    <li><a href="#ref-for-string">3.5.2. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-string①">3.5.3. Word Boundaries</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-struct">
@@ -4516,6 +4554,7 @@ match based on whether the element-id was scrolled.</p>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-list-append">append</span>
+     <li><span class="dfn-paneled" id="term-for-ascii-string">ascii string</span>
      <li><span class="dfn-paneled" id="term-for-assert">assert</span>
      <li><span class="dfn-paneled" id="term-for-iteration-break">break</span>
      <li><span class="dfn-paneled" id="term-for-code-point">code point</span>


### PR DESCRIPTION
Describes the behavior in cases where text is non-LTR. The behavior is non-obvious but correct as specified so this just adds a non-normative section with an example to make this clearer for readers.

Also fixes mis-matched Monkeymatched directives that meant to target DOM rather than HTML specs.

Also clarifies that a few strings are expected to be ASCII strings.

Fixes #99


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/ScrollToTextFragment/pull/156.html" title="Last updated on Nov 25, 2020, 2:21 AM UTC (21e3748)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/156/8bfc9f8...bokand:21e3748.html" title="Last updated on Nov 25, 2020, 2:21 AM UTC (21e3748)">Diff</a>