### PR TITLE
Link to TextNode.data issue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1488,6 +1488,11 @@ a [=range=] |searchRange|, a [=/list=] of {{Text}} nodes |nodes|, and booleans
   <ol class="algorithm">
     1. Let |searchBuffer| be the [=string/concatenate|concatenation=] of the
         [=CharacterData/data=] of each item in |nodes|.
+
+        ISSUE(WICG/scroll-to-text-fragment#98): [=CharacterData/data=] is not
+        correct here since that's the text data as it exists in the DOM. This
+        algorithm means to run over the text as rendered (and then convert back
+        to Ranges in the DOM).
     1. Let |searchStart| be 0.
     1. If the first item in |nodes| is |searchRange|'s [=range/start node=] then
         set |searchStart| to |searchRange|'s [=range/start offset=].

--- a/index.html
+++ b/index.html
@@ -2098,13 +2098,14 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-11-24">24 November 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-11-25">25 November 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://wicg.github.io/scroll-to-text-fragment/">https://wicg.github.io/scroll-to-text-fragment/</a>
      <dt>Issue Tracking:
      <dd><a href="https://github.com/wicg/scroll-to-text-fragment/issues/">GitHub</a>
+     <dd><a href="#issues-index">Inline In Spec</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:nburris@chromium.org">Nick Burris</a> (<a class="p-org org" href="https://www.google.com">Google</a>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:bokan@chromium.org">David Bokan</a> (<a class="p-org org" href="https://www.google.com">Google</a>)
@@ -2220,6 +2221,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
      </ol>
     <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+    <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
    </ol>
   </nav>
   <main>
@@ -3383,6 +3385,10 @@ a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="
     <ol class="algorithm">
      <li data-md>
       <p>Let <var>searchBuffer</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-concatenate" id="ref-for-string-concatenate">concatenation</a> of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data" id="ref-for-concept-cd-data①">data</a> of each item in <var>nodes</var>.</p>
+      <p class="issue" id="issue-96fe4755"><a class="self-link" href="#issue-96fe4755"></a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data" id="ref-for-concept-cd-data②">data</a> is not
+correct here since that’s the text data as it exists in the DOM. This
+algorithm means to run over the text as rendered (and then convert back
+to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/issues/98">&lt;https://github.com/WICG/scroll-to-text-fragment/issues/98></a></p>
      <li data-md>
       <p>Let <var>searchStart</var> be 0.</p>
      <li data-md>
@@ -3960,7 +3966,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-concept-cd-data">
    <a href="https://dom.spec.whatwg.org/#concept-cd-data">https://dom.spec.whatwg.org/#concept-cd-data</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-cd-data">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-data①">(2)</a>
+    <li><a href="#ref-for-concept-cd-data">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-data①">(2)</a> <a href="#ref-for-concept-cd-data②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-doctype">
@@ -4636,6 +4642,13 @@ match based on whether the element-id was scrolled.</p>
 };
 
 </pre>
+  <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <div style="counter-reset:issue">
+   <div class="issue"> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data">data</a> is not
+correct here since that’s the text data as it exists in the DOM. This
+algorithm means to run over the text as rendered (and then convert back
+to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/issues/98">&lt;https://github.com/WICG/scroll-to-text-fragment/issues/98></a><a href="#issue-96fe4755"> ↵ </a></div>
+  </div>
   <aside class="dfn-panel" data-for="fragment-directive-delimiter">
    <b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
    <ul>


### PR DESCRIPTION
Adds an issue in the spec that links to #98 so readers at least know the intent until we fix that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/ScrollToTextFragment/pull/157.html" title="Last updated on Nov 25, 2020, 10:22 PM UTC (2de4884)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/157/52da8b6...bokand:2de4884.html" title="Last updated on Nov 25, 2020, 10:22 PM UTC (2de4884)">Diff</a>