### PR TITLE
fix: Invalid CODE tags nesting in DL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -508,29 +508,29 @@ A <dfn>valid fragment directive</dfn> is a sequence of characters that appears
 in the [=fragment directive=] that matches the production:
 <dl>
   <dt>
-    <dfn id="fragmentdirectiveproduction">FragmentDirective</dfn> ::=
+    <dfn id="fragmentdirectiveproduction">`FragmentDirective`</dfn> `::=`
   </dt>
   <dd>
-    ([=TextDirective=] | [=UnknownDirective=]) ("&" [=FragmentDirective=])?
+    <code>([=TextDirective=] | [=UnknownDirective=]) ("&" [=FragmentDirective=])?</code>
   </dd>
   <dt>
-    <dfn>UnknownDirective</dfn> ::=
+    <dfn>`UnknownDirective`</dfn> `::=`
   </dt>
   <dd>
-    [=CharacterString=]
+    <code>[=CharacterString=]</code>
   </dd>
   <dt>
-    <dfn>CharacterString</dfn> ::=
+    <dfn>`CharacterString`</dfn> `::=`
   </dt>
   <dd>
-    ([=ExplicitChar=] | [=PercentEncodedChar=])+
+    <code>([=ExplicitChar=] | [=PercentEncodedChar=])+</code>
   </dd>
   <dt>
-    <dfn>ExplicitChar</dfn> ::=
+    <dfn>`ExplicitChar`</dfn> `::=`
   </dt>
   <dd>
-    [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
-    ";" | "=" | "?" | "@" | "_" | "~" | "&" | "," | "-"
+    <code>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
+    ";" | "=" | "?" | "@" | "_" | "~" | "&" | "," | "-"</code>
   <div class = "note">
     An [=ExplicitChar=] may be any [=URL code point=].
   </div>
@@ -549,31 +549,35 @@ The <dfn>text fragment directive</dfn> is one such [=fragment directive=] that
 enables specifying a piece of text on the page, that matches the production:
 
 <dl>
-  <dt><dfn>TextDirective</dfn> ::=</dt>
-  <dd>"text=" [=TextDirectiveParameters=]</dd>
-  <dt><dfn>TextDirectiveParameters</dfn> ::=</dt>
+  <dt><dfn>`TextDirective`</dfn> `::=`</dt>
+  <dd><code>"text=" [=TextDirectiveParameters=]</code></dd>
+  <dt><dfn>`TextDirectiveParameters`</dfn> `::=`</dt>
   <dd>
+    <code>
     ([=TextDirectivePrefix=] ",")? [=TextDirectiveString=]
     ("," [=TextDirectiveString=])?  ("," [=TextDirectiveSuffix=])?
+    </code>
   </dd>
-  <dt><dfn>TextDirectivePrefix</dfn> ::=</dt>
-  <dd>[=TextDirectiveString=]"-"</dd>
-  <dt><dfn>TextDirectiveSuffix</dfn> ::=</dt>
-  <dd>"-"[=TextDirectiveString=]</dd>
-  <dt><dfn>TextDirectiveString</dfn> ::=</dt>
-  <dd>([=TextDirectiveExplicitChar=] | [=PercentEncodedChar=])+</dd>
-  <dt><dfn>TextDirectiveExplicitChar</dfn> ::=</dt>
+  <dt><dfn>`TextDirectivePrefix`</dfn> `::=`</dt>
+  <dd><code>[=TextDirectiveString=]"-"</code></dd>
+  <dt><dfn>`TextDirectiveSuffix`</dfn> `::=`</dt>
+  <dd><code>"-"[=TextDirectiveString=]</code></dd>
+  <dt><dfn>`TextDirectiveString`</dfn> `::=`</dt>
+  <dd><code>([=TextDirectiveExplicitChar=] | [=PercentEncodedChar=])+</code></dd>
+  <dt><dfn>`TextDirectiveExplicitChar`</dfn> `::=`</dt>
   <dd>
+  <code>
     [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
     ";" | "=" | "?" | "@" | "_" | "~"
+    </code>
   <div class = "note">
     A [=TextDirectiveExplicitChar=] may be any [=URL code point=] that is not
     explicitly used in the [=TextDirective=] syntax, that is "&", "-", and ",",
     which must be percent-encoded.
   </div>
   </dd>
-  <dt><dfn>PercentEncodedChar</dfn> ::=</dt>
-  <dd>"%" [a-zA-Z0-9]+</dd>
+  <dt><dfn>`PercentEncodedChar`</dfn> `::=`</dt>
+  <dd><code>"%" [a-zA-Z0-9]+</code></dd>
 </dl>
 
 ## Security and Privacy ## {#security-and-privacy}

--- a/index.bs
+++ b/index.bs
@@ -507,42 +507,34 @@ directive input|, run these steps:
 A <dfn>valid fragment directive</dfn> is a sequence of characters that appears
 in the [=fragment directive=] that matches the production:
 <dl>
-  <code>
-    <dt>
-      <dfn id="fragmentdirectiveproduction">FragmentDirective</dfn> ::=
-    </dt>
-    <dd>
-      ([=TextDirective=] | [=UnknownDirective=]) ("&" [=FragmentDirective=])?
-    </dd>
-  </code>
-  <code>
-    <dt>
-      <dfn>UnknownDirective</dfn> ::=
-    </dt>
-    <dd>
-      [=CharacterString=]
-    </dd>
-  </code>
-  <code>
-    <dt>
-      <dfn>CharacterString</dfn> ::=
-    </dt>
-    <dd>
-      ([=ExplicitChar=] | [=PercentEncodedChar=])+
-    </dd>
-  </code>
-  <code>
-    <dt>
-      <dfn>ExplicitChar</dfn> ::=
-    </dt>
-    <dd>
-      [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
-      ";" | "=" | "?" | "@" | "_" | "~" | "&" | "," | "-"
-    </dd>
-  </code>
+  <dt>
+    <dfn id="fragmentdirectiveproduction">FragmentDirective</dfn> ::=
+  </dt>
+  <dd>
+    ([=TextDirective=] | [=UnknownDirective=]) ("&" [=FragmentDirective=])?
+  </dd>
+  <dt>
+    <dfn>UnknownDirective</dfn> ::=
+  </dt>
+  <dd>
+    [=CharacterString=]
+  </dd>
+  <dt>
+    <dfn>CharacterString</dfn> ::=
+  </dt>
+  <dd>
+    ([=ExplicitChar=] | [=PercentEncodedChar=])+
+  </dd>
+  <dt>
+    <dfn>ExplicitChar</dfn> ::=
+  </dt>
+  <dd>
+    [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
+    ";" | "=" | "?" | "@" | "_" | "~" | "&" | "," | "-"
   <div class = "note">
     An [=ExplicitChar=] may be any [=URL code point=].
   </div>
+  </dd>
 </dl>
 
 <div class="note">
@@ -557,52 +549,31 @@ The <dfn>text fragment directive</dfn> is one such [=fragment directive=] that
 enables specifying a piece of text on the page, that matches the production:
 
 <dl>
-  <code>
-    <dt><dfn>TextDirective</dfn> ::=</dt>
-    <dd>"text=" [=TextDirectiveParameters=]</dd>
-  </code>
-
-  <code>
-    <dt><dfn>TextDirectiveParameters</dfn> ::=</dt>
-    <dd>
-      ([=TextDirectivePrefix=] ",")? [=TextDirectiveString=]
-      ("," [=TextDirectiveString=])?  ("," [=TextDirectiveSuffix=])?
-    </dd>
-  </code>
-
-  <code>
-    <dt><dfn>TextDirectivePrefix</dfn> ::=</dt>
-    <dd>[=TextDirectiveString=]"-"</dd>
-  </code>
-
-  <code>
-    <dt><dfn>TextDirectiveSuffix</dfn> ::=</dt>
-    <dd>"-"[=TextDirectiveString=]</dd>
-  </code>
-
-  <code>
-    <dt><dfn>TextDirectiveString</dfn> ::=</dt>
-    <dd>([=TextDirectiveExplicitChar=] | [=PercentEncodedChar=])+</dd>
-    </code>
-
-  <code>
-    <dt><dfn>TextDirectiveExplicitChar</dfn> ::=</dt>
-    <dd>
-      [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
-      ";" | "=" | "?" | "@" | "_" | "~"
-    </dd>
-  </code>
-
+  <dt><dfn>TextDirective</dfn> ::=</dt>
+  <dd>"text=" [=TextDirectiveParameters=]</dd>
+  <dt><dfn>TextDirectiveParameters</dfn> ::=</dt>
+  <dd>
+    ([=TextDirectivePrefix=] ",")? [=TextDirectiveString=]
+    ("," [=TextDirectiveString=])?  ("," [=TextDirectiveSuffix=])?
+  </dd>
+  <dt><dfn>TextDirectivePrefix</dfn> ::=</dt>
+  <dd>[=TextDirectiveString=]"-"</dd>
+  <dt><dfn>TextDirectiveSuffix</dfn> ::=</dt>
+  <dd>"-"[=TextDirectiveString=]</dd>
+  <dt><dfn>TextDirectiveString</dfn> ::=</dt>
+  <dd>([=TextDirectiveExplicitChar=] | [=PercentEncodedChar=])+</dd>
+  <dt><dfn>TextDirectiveExplicitChar</dfn> ::=</dt>
+  <dd>
+    [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
+    ";" | "=" | "?" | "@" | "_" | "~"
   <div class = "note">
     A [=TextDirectiveExplicitChar=] may be any [=URL code point=] that is not
     explicitly used in the [=TextDirective=] syntax, that is "&", "-", and ",",
     which must be percent-encoded.
   </div>
-
-  <code>
-    <dt><dfn>PercentEncodedChar</dfn> ::=</dt>
-    <dd>"%" [a-zA-Z0-9]+</dd>
-  </code>
+  </dd>
+  <dt><dfn>PercentEncodedChar</dfn> ::=</dt>
+  <dd>"%" [a-zA-Z0-9]+</dd>
 </dl>
 
 ## Security and Privacy ## {#security-and-privacy}


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/scroll-to-text-fragment/pull/164.html" title="Last updated on Feb 8, 2021, 4:41 PM UTC (3f63052)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/164/d7a3c5d...nschonni:3f63052.html" title="Last updated on Feb 8, 2021, 4:41 PM UTC (3f63052)">Diff</a>