### PR TITLE
Update the algorithm for finding rangeEnd

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1251,41 +1251,57 @@ following steps:
             1. If |potentialMatch| is null, return null.
             1. Set |searchRange|'s [=range/start=] to the first [=/boundary point=]
                 [=boundary point/after=] |potentialMatch|'s [=range/start=]
-        1. If |parsedValues|'s [=ParsedTextDirective/textEnd=] item is
-            non-null, then:
-            1. Let |textEndRange| be a [=range=] whose [=range/start=] is
-                |potentialMatch|'s [=range/end=] and whose [=range/end=] is
-                |searchRange|'s [=range/end=].
-            1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
-                [=ParsedTextDirective/suffix=] is null, false otherwise.
-            1. Let |textEndMatch| be the result of running the [=find a string
-                in range=] steps with |query| |parsedValues|'s
-                [=ParsedTextDirective/textEnd=], |searchRange| |textEndRange|,
-                |wordStartBounded| true, and |wordEndBounded|
-                |mustEndAtWordBoundary|.
-            1. If |textEndMatch| is null then return null.
-            1. Set |potentialMatch|'s [=range/end=] to |textEndMatch|'s
-                [=range/end=].
-        1. [=/Assert=]: |potentialMatch| is non-null, not [=range/collapsed=] and
-            represents a range exactly containing an instance of matching text.
-        1. If |parsedValues|'s [=ParsedTextDirective/suffix=] is null, return
-            |potentialMatch|.
-        1. Let |suffixRange| be a [=range=] with [=range/start=] equal to
-            |potentialMatch|'s [=range/end=] and [=range/end=] equal to
+        1. Let |rangeEndSearchRange| be a [=range=] whose [=range/start=] is
+            |potentialMatch|'s [=range/end=] and whose [=range/end=] is
             |searchRange|'s [=range/end=].
-        1. Advance |suffixRange|'s [=range/start=] to the [=next non-whitespace
-            position=].
-        1. Let |suffixMatch| be result of running the [=find a string in range=]
-            steps with |query| |parsedValues|'s [=ParsedTextDirective/suffix=],
-            |searchRange| |suffixRange|, |wordStartBounded| false, and
-            |wordEndBounded| true.
-        1. If |suffixMatch| is null then return null.
-            <div class="note">
-              If the suffix doesn't appear in the remaining text of the document,
-              there's no possible way to make a match.
-            </div>
-        1. If |suffixMatch|'s [=range/start=] is |suffixRange|'s [=range/start=],
-            return |potentialMatch|.
+        1. While |rangeEndSearchRange| is not [=range/collapsed=]:
+            1. If |parsedValues|'s [=ParsedTextDirective/textEnd=] item is
+                non-null, then:
+                1. Let |mustEndAtWordBoundary| be true if |parsedValues|'s
+                    [=ParsedTextDirective/suffix=] is null, false otherwise.
+                1. Let |textEndMatch| be the result of running the [=find a string
+                    in range=] steps with |query| |parsedValues|'s
+                    [=ParsedTextDirective/textEnd=], |searchRange| |rangeEndSearchRange|,
+                    |wordStartBounded| true, and |wordEndBounded|
+                    |mustEndAtWordBoundary|.
+                1. If |textEndMatch| is null then return null.
+                1. Set |potentialMatch|'s [=range/end=] to |textEndMatch|'s
+                    [=range/end=].
+            1. [=/Assert=]: |potentialMatch| is non-null, not [=range/collapsed=] and
+                represents a range exactly containing an instance of matching text.
+            1. If |parsedValues|'s [=ParsedTextDirective/suffix=] is null, return
+                |potentialMatch|.
+            1. Let |suffixRange| be a [=range=] with [=range/start=] equal to
+                |potentialMatch|'s [=range/end=] and [=range/end=] equal to
+                |searchRange|'s [=range/end=].
+            1. Advance |suffixRange|'s [=range/start=] to the [=next non-whitespace
+                position=].
+            1. Let |suffixMatch| be result of running the [=find a string in range=]
+                steps with |query| |parsedValues|'s [=ParsedTextDirective/suffix=],
+                |searchRange| |suffixRange|, |wordStartBounded| false, and
+                |wordEndBounded| true.
+            1. If |suffixMatch| is null then return null.
+                <div class="note">
+                  If the suffix doesn't appear in the remaining text of the document,
+                  there's no possible way to make a match.
+                </div>
+            1. If |suffixMatch|'s [=range/start=] is |suffixRange|'s [=range/start=],
+                return |potentialMatch|.
+            1. If |parsedValues|'s [=ParsedTextDirective/textEnd=] item is null
+                then [=iteration/break=];
+                <div class="note">
+                  If this is an exact match and the suffix doesn't match,
+                  start searching for the next potentialMatch by starting at
+                  the top of the outer loop.
+                </div>
+            1. Set |rangeEndSearchRange|'s [=range/end=] to |potentialMatch|'s
+                [=range/end=].
+                <div class="note">
+                  Otherwise, it is possible that we found the correct range
+                  start, but not the correct range end. Continue the inner
+                  loop to keep searching for another matching instance of
+                  rangeEnd.
+                </div>
     1. Return null
   </ol>
 

--- a/index.html
+++ b/index.html
@@ -4,9 +4,8 @@
   <title>Text Fragments</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version b9f8371cc, updated Fri Mar 5 18:35:23 2021 -0800" name="generator">
+  <meta content="Bikeshed version 83b904c2e, updated Wed Nov 3 17:20:53 2021 -0700" name="generator">
   <link href="https://wicg.github.io/scroll-to-text-fragment/" rel="canonical">
-  <meta content="f61d33e1a05c9b4c6364fccffe09d009d630022f" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -113,9 +112,9 @@ pre .property::before, pre .property::after {
     --ins-bg: transparent;
 
     --a-normal-text: #034575;
-    --a-normal-underline: #707070;
+    --a-normal-underline: #bbb;
     --a-visited-text: var(--a-normal-text);
-    --a-visited-underline: #bbb;
+    --a-visited-underline: #707070;
     --a-hover-bg: rgba(75%, 75%, 75%, .25);
     --a-active-text: #c00;
     --a-active-underline: #c00;
@@ -247,6 +246,16 @@ figcaption:not(.no-marker)::before {
 }
 
 .dfn-paneled { cursor: pointer; }
+</style>
+<style>/* style-issues */
+
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
 </style>
 <style>/* style-md-lists */
 
@@ -387,17 +396,17 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 <style>/* style-wpt */
 
 :root {
-    --wpt-border: hsl(290, 70%, 60%);
-    --wpt-bg: hsl(290, 70%, 95%);
+    --wpt-border: hsl(0, 0%, 60%);
+    --wpt-bg: hsl(0, 0%, 95%);
     --wpt-text: var(--text);
-    --wptheading-text: hsl(290, 70%, 30%);
+    --wptheading-text: hsl(0, 0%, 30%);
 }
 @media (prefers-color-scheme: dark) {
     :root {
-        --wpt-border: hsl(290, 70%, 30%);
+        --wpt-border: hsl(0, 0%, 30%);
         --wpt-bg: var(--borderedblock-bg);
         --wpt-text: var(--text);
-        --wptheading-text: hsl(290, 70%, 60%);
+        --wptheading-text: hsl(0, 0%, 60%);
     }
 }
 .wpt-tests-block {
@@ -407,15 +416,96 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     color: var(--wpt-text);
     margin: 1em auto;
     padding: .5em;
+}
+.wpt-tests-block summary {
+    color: var(--wptheading-text);
+    font-weight: normal;
+    text-transform: uppercase;
+}
+.wpt-tests-block summary::marker{
+    color: var(--wpt-border);
+}
+.wpt-tests-block summary:hover::marker{
+    color: var(--wpt-text);
+}
+/*
+   The only content  of a wpt test block in its closed state is the <summary>,
+   which contains the word TESTS,
+   and that is absolutely positioned.
+   In that closed state, wpt test blocks are styled
+   to have a top margin whose height is exactly equal
+   to the height of the absolutely positioned <summary>,
+   and no other background/padding/margin/border.
+   The wpt test block elements will therefore allow the maring
+   of the previous/next block elements
+   to collapse through them;
+   if this combined margin would be larger than its own top margin,
+   it stays as is,
+   and therefore the pre-existing vertical rhythm of the document is undisturbed.
+   If that combined margin would be smaller, it is grown to that size.
+   This means that the wpt test block ensures
+   that there's always enough vertical space to insert the summary,
+   without adding more than is needed.
+*/
+.wpt-tests-block:not([open]){
+    padding: 0;
+    border: none;
+    background: none;
+    font-size: 0.75em;
+    line-height: 1;
+    position: relative;
+    margin: 1em 0 0;
+}
+.wpt-tests-block:not([open]) summary {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+}
+/*
+   It is possible that both the last child of a block element
+   and the block element itself
+   would be annotated with a <wpt> block each.
+   If the block element has a padding or a border,
+   that's fine, but otherwise
+   the bottom margin of the block and of its last child would collapse
+   and both <wpt> elements would overlap, being both placed there.
+   To avoid that, add 1px of padding to the <wpt> element annotating the last child
+   to prevent the bottom margin of the block and of its last child from collapsing
+   (and as much negative margin,
+   as wel only want to prevent margin collapsing,
+   but are not trying to actually take more space).
+*/
+.wpt-tests-block:not([open]):last-child {
+    padding-bottom: 1px;
+    margin-bottom: -1px;
+}
+/*
+   Exception to the previous rule:
+   don't do that in non-last list items,
+   because it's not necessary,
+   and would therefore consume more space than strictly needed.
+   Lists must have list items as children, not <wpt> elements,
+   so a <wpt> element cannot be a sibling of a list item,
+   and the collision that the previous rule avoids cannot happen.
+*/
+li:not(:last-child) > .wpt-tests-block:not([open]):last-child,
+dd:not(:last-child) > .wpt-tests-block:not([open]):last-child {
+    padding-bottom: 0;
+    margin-bottom: 0;
+}
+.wpt-tests-block:not([open]):not(:hover){
+    opacity: 0.5;
+}
+.wpt-tests-list {
+    list-style: none;
     display: grid;
-    grid-template-columns: 1fr auto auto;
+    margin: 0;
+    padding: 0;
+    grid-template-columns: 1fr max-content auto auto;
     grid-column-gap: .5em;
 }
-.wpt-tests-block::before {
-    content: "Tests";
-    grid-column: 1/-1;
-    color: var(--wptheading-text);
-    text-transform: uppercase;
+.wpt-tests-block hr:last-child {
+    display: none;
 }
 .wpt-test {
     display: contents;
@@ -425,8 +515,21 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     border: none;
 }
 .wpt-test > .wpt-name { grid-column: 1; }
-.wpt-test > .wpt-live { grid-column: 2; }
-.wpt-test > .wpt-source { grid-column: 3; }
+.wpt-test > .wpt-results { grid-column: 2; }
+.wpt-test > .wpt-live { grid-column: 3; }
+.wpt-test > .wpt-source { grid-column: 4; }
+
+.wpt-test > .wpt-results {
+    display: flex;
+    gap: .1em;
+}
+.wpt-test .wpt-result {
+    display: inline-block;
+    height: 1em;
+    width: 1em;
+    border-radius: 50%;
+    position: relative;
+}
 </style>
 <style>/* style-darkmode */
 
@@ -622,7 +725,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-03-08">8 March 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-11-04">4 November 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -633,6 +736,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:nburris@chromium.org">Nick Burris</a> (<a class="p-org org" href="https://www.google.com">Google</a>)
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:bokan@chromium.org">David Bokan</a> (<a class="p-org org" href="https://www.google.com">Google</a>)
+     <dt>Test Suite:
+     <dd class="wpt-overview"><a href="https://wpt.fyi/results/scroll-to-text-fragment/">https://wpt.fyi/results/scroll-to-text-fragment/</a>
     </dl>
    </div>
    <div data-fill-with="warning"></div>
@@ -1381,7 +1486,7 @@ steps of the task queued in step 2:</p>
     </ol>
    </blockquote>
    <h3 class="heading settled" data-level="3.5" id="navigating-to-text-fragment"><span class="secno">3.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
-   <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">HTML 5 §7.10.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive④">text fragment directive</a> is
+   <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.11.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive④">text fragment directive</a> is
 present and a match is found in the page, the text fragment takes precedent over
 the element fragment as the indicated part of the document. We amend the
 indicated part of the document to optionally include a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range">range</a> that
@@ -1686,48 +1791,67 @@ range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-t
           <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑧">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp①">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after①">after</a> <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑨">start</a></p>
         </ol>
        <li data-md>
-        <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑧">textEnd</a> item is
-non-null, then:</p>
+        <p>Let <var>rangeEndSearchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑥">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⓪">start</a> is <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑤">end</a> and whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑥">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑦">end</a>.</p>
+       <li data-md>
+        <p>While <var>rangeEndSearchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed②">collapsed</a>:</p>
         <ol>
          <li data-md>
-          <p>Let <var>textEndRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑥">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⓪">start</a> is <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑤">end</a> and whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑥">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑦">end</a>.</p>
+          <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑧">textEnd</a> item is
+non-null, then:</p>
+          <ol>
+           <li data-md>
+            <p>Let <var>mustEndAtWordBoundary</var> be true if <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑤">suffix</a> is null, false otherwise.</p>
+           <li data-md>
+            <p>Let <var>textEndMatch</var> be the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range③">find a string
+in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑨">textEnd</a>, <var>searchRange</var> <var>rangeEndSearchRange</var>, <var>wordStartBounded</var> true, and <var>wordEndBounded</var> <var>mustEndAtWordBoundary</var>.</p>
+           <li data-md>
+            <p>If <var>textEndMatch</var> is null then return null.</p>
+           <li data-md>
+            <p>Set <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑧">end</a> to <var>textEndMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑨">end</a>.</p>
+          </ol>
          <li data-md>
-          <p>Let <var>mustEndAtWordBoundary</var> be true if <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑤">suffix</a> is null, false otherwise.</p>
-         <li data-md>
-          <p>Let <var>textEndMatch</var> be the result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range③">find a string
-in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend⑨">textEnd</a>, <var>searchRange</var> <var>textEndRange</var>, <var>wordStartBounded</var> true, and <var>wordEndBounded</var> <var>mustEndAtWordBoundary</var>.</p>
-         <li data-md>
-          <p>If <var>textEndMatch</var> is null then return null.</p>
-         <li data-md>
-          <p>Set <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑧">end</a> to <var>textEndMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑨">end</a>.</p>
-        </ol>
-       <li data-md>
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">Assert</a>: <var>potentialMatch</var> is non-null, not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed②">collapsed</a> and
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">Assert</a>: <var>potentialMatch</var> is non-null, not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed③">collapsed</a> and
 represents a range exactly containing an instance of matching text.</p>
-       <li data-md>
-        <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑥">suffix</a> is null, return <var>potentialMatch</var>.</p>
-       <li data-md>
-        <p>Let <var>suffixRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①①">start</a> equal to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⓪">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①①">end</a> equal to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①②">end</a>.</p>
-       <li data-md>
-        <p>Advance <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①②">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position①">next non-whitespace
+         <li data-md>
+          <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑥">suffix</a> is null, return <var>potentialMatch</var>.</p>
+         <li data-md>
+          <p>Let <var>suffixRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①①">start</a> equal to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⓪">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①①">end</a> equal to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①②">end</a>.</p>
+         <li data-md>
+          <p>Advance <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①②">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position①">next non-whitespace
 position</a>.</p>
-       <li data-md>
-        <p>Let <var>suffixMatch</var> be result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range④">find a string in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑦">suffix</a>, <var>searchRange</var> <var>suffixRange</var>, <var>wordStartBounded</var> false, and <var>wordEndBounded</var> true.</p>
-       <li data-md>
-        <p>If <var>suffixMatch</var> is null then return null.</p>
-        <div class="note" role="note"> If the suffix doesn’t appear in the remaining text of the document,
+         <li data-md>
+          <p>Let <var>suffixMatch</var> be result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range④">find a string in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑦">suffix</a>, <var>searchRange</var> <var>suffixRange</var>, <var>wordStartBounded</var> false, and <var>wordEndBounded</var> true.</p>
+         <li data-md>
+          <p>If <var>suffixMatch</var> is null then return null.</p>
+          <div class="note" role="note"> If the suffix doesn’t appear in the remaining text of the document,
   there’s no possible way to make a match. </div>
-       <li data-md>
-        <p>If <var>suffixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①③">start</a> is <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①④">start</a>,
+         <li data-md>
+          <p>If <var>suffixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①③">start</a> is <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①④">start</a>,
 return <var>potentialMatch</var>.</p>
+         <li data-md>
+          <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend①⓪">textEnd</a> item is null
+then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break">break</a>;</p>
+          <div class="note" role="note"> If this is an exact match and the suffix doesn’t match,
+  start searching for the next potentialMatch by starting at
+  the top of the outer loop. </div>
+         <li data-md>
+          <p>Set <var>rangeEndSearchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①③">end</a> to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①④">end</a>.</p>
+          <div class="note" role="note"> Otherwise, it is possible that we found the correct range
+  start, but not the correct range end. Continue the inner
+  loop to keep searching for another matching instance of
+  rangeEnd. </div>
+        </ol>
       </ol>
      <li data-md>
       <p>Return null</p>
     </ol>
    </div>
-   <ul class="wpt-tests-block">
-    <li class="wpt-test"><a class="wpt-name" href="https://wpt.fyi/results/scroll-to-text-fragment/find-range-from-text-directive.html">find-range-from-text-directive.html</a> <a class="wpt-live" href="http://wpt.live/scroll-to-text-fragment/find-range-from-text-directive.html" title="scroll-to-text-fragment/find-range-from-text-directive.html"><small>(live test)</small></a> <a class="wpt-source" href="https://github.com/web-platform-tests/wpt/blob/master/scroll-to-text-fragment/find-range-from-text-directive.html"><small>(source)</small></a>
-   </ul>
+   <details class="wpt-tests-block" dir="ltr" lang="en" open>
+    <summary>Tests</summary>
+    <ul class="wpt-tests-list">
+     <li class="wpt-test"><a class="wpt-name" href="https://wpt.fyi/results/scroll-to-text-fragment/find-range-from-text-directive.html" title="scroll-to-text-fragment/find-range-from-text-directive.html">find-range-from-text-directive.html</a> <a class="wpt-live" href="http://wpt.live/scroll-to-text-fragment/find-range-from-text-directive.html"><small>(live test)</small></a> <a class="wpt-source" href="https://github.com/web-platform-tests/wpt/blob/master/scroll-to-text-fragment/find-range-from-text-directive.html"><small>(source)</small></a>
+    </ul>
+   </details>
    <div class="algorithm" data-algorithm="advance range start to next non-whitespace position">
      To advance a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑧">range</a> <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑤">start</a> to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="next non-whitespace position" data-noexport id="next-non-whitespace-position">next
 non-whitespace position</dfn> follow the steps: 
@@ -1806,7 +1930,7 @@ run these steps:
     </div>
     <ol class="algorithm">
      <li data-md>
-      <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed③">collapsed</a>:</p>
+      <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed④">collapsed</a>:</p>
       <ol>
        <li data-md>
         <p>Let <var>curNode</var> be <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑥">start node</a>.</p>
@@ -1834,10 +1958,10 @@ set its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range
         <p>Let <var>textNodeList</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑦">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text①">Text</a></code> nodes,
 initially empty.</p>
        <li data-md>
-        <p>While <var>curNode</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant②">shadow-including descendant</a> of <var>blockAncestor</var> and the position of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp②">boundary point</a> (<var>curNode</var>, 0) is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after②">after</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①③">end</a>:</p>
+        <p>While <var>curNode</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant②">shadow-including descendant</a> of <var>blockAncestor</var> and the position of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp②">boundary point</a> (<var>curNode</var>, 0) is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after②">after</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⑤">end</a>:</p>
         <ol>
          <li data-md>
-          <p>If <var>curNode</var> <a data-link-type="dfn" href="#has-block-level-display" id="ref-for-has-block-level-display">has block-level display</a> then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break">break</a>.</p>
+          <p>If <var>curNode</var> <a data-link-type="dfn" href="#has-block-level-display" id="ref-for-has-block-level-display">has block-level display</a> then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break①">break</a>.</p>
          <li data-md>
           <p>If <var>curNode</var> is <a data-link-type="dfn" href="#search-invisible" id="ref-for-search-invisible">search invisible</a>:</p>
           <ol>
@@ -1855,7 +1979,7 @@ order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.
        <li data-md>
         <p>Run the <a data-link-type="dfn" href="#find-a-range-from-a-node-list" id="ref-for-find-a-range-from-a-node-list">find a range from a node list</a> steps given <var>query</var>, <var>searchRange</var>, <var>textNodeList</var>, <var>wordStartBounded</var> and <var>wordEndBounded</var> as input. If the resulting <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②②">range</a> is not null, then return it.</p>
        <li data-md>
-        <p>If <var>curNode</var> is null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break①">break</a>.</p>
+        <p>If <var>curNode</var> is null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break②">break</a>.</p>
        <li data-md>
         <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert③">Assert</a>: <var>curNode</var> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-following" id="ref-for-concept-tree-following">follows</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑨">start node</a>.</p>
        <li data-md>
@@ -1879,7 +2003,7 @@ namespace</a> and meets any of the following conditions:</p>
      <p>Is a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element" id="ref-for-the-select-element">select</a></code> element whose <code><a data-link-type="element-sub" href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple" id="ref-for-attr-select-multiple">multiple</a></code> content attribute is absent.</p>
    </ol>
    <p>A node is part of a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="non-searchable-subtree">non-searchable subtree</dfn> if it is or has a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-ancestor" id="ref-for-concept-shadow-including-ancestor">shadow-including ancestor</a> that is <a data-link-type="dfn" href="#search-invisible" id="ref-for-search-invisible①">search invisible</a>.</p>
-   <p>A node is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="visible-text-node">visible text node</dfn> if it is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text②">Text</a></code> node, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value①">computed value</a> of its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#parent-element" id="ref-for-parent-element">parent element</a>'s <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css2/#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> property is <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css2/#valdef-visibility-visible" id="ref-for-valdef-visibility-visible">visible</a>, and it is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered" id="ref-for-being-rendered">being rendered</a>.</p>
+   <p>A node is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="visible-text-node">visible text node</dfn> if it is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text②">Text</a></code> node, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value①">computed value</a> of its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#parent-element" id="ref-for-parent-element">parent element</a>'s <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> property is <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-visibility-visible" id="ref-for-valdef-visibility-visible">visible</a>, and it is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered" id="ref-for-being-rendered">being rendered</a>.</p>
    <p>A node <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="has-block-level-display">has block-level display</dfn> if it is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element⑥">element</a> and the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value②">computed value</a> of its <a class="property" data-link-type="propdesc" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display①">display</a> property is any of <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-block" id="ref-for-valdef-display-block">block</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-table" id="ref-for-valdef-display-table">table</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root" id="ref-for-valdef-display-flow-root">flow-root</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-grid" id="ref-for-valdef-display-grid">grid</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flex" id="ref-for-valdef-display-flex">flex</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item" id="ref-for-valdef-display-list-item">list-item</a>.</p>
    <div class="algorithm" data-algorithm="nearest block ancestor">
      To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="nearest-block-ancestor">nearest block ancestor</dfn> of a <var>node</var> follow the steps: 
@@ -1922,7 +2046,7 @@ a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="
       <p class="issue" id="issue-96fe4755"><a class="self-link" href="#issue-96fe4755"></a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data" id="ref-for-concept-cd-data②">data</a> is not
 correct here since that’s the text data as it exists in the DOM. This
 algorithm means to run over the text as rendered (and then convert back
-to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/issues/98">&lt;https://github.com/WICG/scroll-to-text-fragment/issues/98></a></p>
+to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/issues/98">[Issue #WICG/scroll-to-text-fragment#98]</a></p>
      <li data-md>
       <p>Let <var>searchStart</var> be 0.</p>
      <li data-md>
@@ -1975,7 +2099,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
      <li data-md>
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert④">Assert</a>: <var>start</var> and <var>end</var> are non-null, valid <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑦">boundary points</a> in <var>searchRange</var>.</p>
      <li data-md>
-      <p>Return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②④">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑦">start</a> <var>start</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①④">end</a> <var>end</var>.</p>
+      <p>Return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②④">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑦">start</a> <var>start</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⑥">end</a> <var>end</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="boundary point at index">
@@ -2018,7 +2142,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
   proposal to specify unicode segmentation, including word segmentation. Once
   specified, this algorithm may be improved by making use of the Intl.Segmenter
   API for word boundary matching. </div>
-   <p> A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-boundary">word boundary</dfn> is defined in <a data-link-type="biblio" href="#biblio-uax29">[UAX29]</a> in <a href="https://www.unicode.org/reports/tr29/tr29-37.html#Word_Boundaries">Unicode Text Segmentation §Word_Boundaries</a>. <a href="https://www.unicode.org/reports/tr29/tr29-37.html#Default_Word_Boundaries">Unicode Text Segmentation §Default_Word_Boundaries</a> defines a
+   <p> A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-boundary">word boundary</dfn> is defined in <a data-link-type="biblio" href="#biblio-uax29">[UAX29]</a> in <a href="https://www.unicode.org/reports/tr29/tr29-39.html#Word_Boundaries">Unicode Text Segmentation § Word_Boundaries</a>. <a href="https://www.unicode.org/reports/tr29/tr29-39.html#Default_Word_Boundaries">Unicode Text Segmentation § Default_Word_Boundaries</a> defines a
   default set of what constitutes a word boundary, but as the specification
   mentions, a more sophisticated algorithm should be used based on the locale. </p>
    <p> Dictionary-based word bounding should take specific care in locales without a
@@ -2165,13 +2289,13 @@ value of this policy in the child <a data-link-type="dfn" href="https://dom.spec
    <p>For feature detectability, we propose adding a new FragmentDirective interface
 that is exposed via <code>document.fragmentDirective</code> if the UA supports
 the feature.</p>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="fragmentdirective"><code><c- g>FragmentDirective</c-></code></dfn> {
 };
 </pre>
    <p>We amend the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> interface to include a <code>fragmentDirective</code> property:</p>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③"><c- g>Document</c-></a> {
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject" id="ref-for-SameObject"><c- g>SameObject</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-document-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-document-fragmentdirective"></a></dfn>;
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SameObject" id="ref-for-SameObject"><c- g>SameObject</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#fragmentdirective" id="ref-for-fragmentdirective"><c- n>FragmentDirective</c-></a> <dfn class="idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export data-readonly data-type="FragmentDirective" id="dom-document-fragmentdirective"><code><c- g>fragmentDirective</c-></code><a class="self-link" href="#dom-document-fragmentdirective"></a></dfn>;
 };
 </pre>
    <p>This object may be used to expose additional information about the text
@@ -2306,7 +2430,17 @@ match based on whether the element-id was scrolled.</p>
     and are set apart from the normative text
     with <code>class="note"</code>,
     like this: </p>
-   <p class="note" role="note">Note, this is an informative note. </p>
+   <p class="note" role="note">
+    Note, this is an informative note. 
+    <details class="wpt-tests-block" dir="ltr" lang="en" open>
+     <summary>Tests</summary>
+     <p>Tests relating to the content of this specification
+                     may be documented in “Tests” blocks like this one.
+                     Any such block is non-normative.</p>
+     <ul class="wpt-tests-list"></ul>
+     <hr>
+    </details>
+   </p>
    <h3 class="no-ref no-num heading settled" id="w3c-conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#w3c-conformant-algorithms"></a></h3>
    <p>Requirements phrased in the imperative as part of algorithms
     (such as "strip any leading space characters"
@@ -2326,60 +2460,60 @@ match based on whether the element-id was scrolled.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#document-allowtextfragmentdirective">allowTextFragmentDirective</a><span>, in §3.4.4</span>
-   <li><a href="#characterstring">CharacterString</a><span>, in §3.3.3</span>
-   <li><a href="#explicitchar">ExplicitChar</a><span>, in §3.3.3</span>
-   <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in §3.5.2</span>
-   <li><a href="#find-a-range-from-a-text-directive">find a range from a text directive</a><span>, in §3.5.2</span>
-   <li><a href="#find-a-string-in-range">find a string in range</a><span>, in §3.5.2</span>
-   <li><a href="#first-common-ancestor">first common ancestor</a><span>, in §3.5</span>
-   <li><a href="#fragment-directive">fragment directive</a><span>, in §3.3.1</span>
+   <li><a href="#document-allowtextfragmentdirective">allowTextFragmentDirective</a><span>, in § 3.4.4</span>
+   <li><a href="#characterstring">CharacterString</a><span>, in § 3.3.3</span>
+   <li><a href="#explicitchar">ExplicitChar</a><span>, in § 3.3.3</span>
+   <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in § 3.5.2</span>
+   <li><a href="#find-a-range-from-a-text-directive">find a range from a text directive</a><span>, in § 3.5.2</span>
+   <li><a href="#find-a-string-in-range">find a string in range</a><span>, in § 3.5.2</span>
+   <li><a href="#first-common-ancestor">first common ancestor</a><span>, in § 3.5</span>
+   <li><a href="#fragment-directive">fragment directive</a><span>, in § 3.3.1</span>
    <li>
     FragmentDirective
     <ul>
-     <li><a href="#fragmentdirective">(interface)</a><span>, in §3.8</span>
-     <li><a href="#fragmentdirectiveproduction">definition of</a><span>, in §3.3.3</span>
+     <li><a href="#fragmentdirective">(interface)</a><span>, in § 3.8</span>
+     <li><a href="#fragmentdirectiveproduction">definition of</a><span>, in § 3.3.3</span>
     </ul>
-   <li><a href="#dom-document-fragmentdirective">fragmentDirective</a><span>, in §3.8</span>
-   <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in §3.3</span>
-   <li><a href="#get-boundary-point-at-index">get boundary point at index</a><span>, in §3.5.2</span>
-   <li><a href="#has-block-level-display">has block-level display</a><span>, in §3.5.2</span>
-   <li><a href="#is-at-a-word-boundary">is at a word boundary</a><span>, in §3.5.3</span>
-   <li><a href="#locale">locale</a><span>, in §3.5.3</span>
-   <li><a href="#nearest-block-ancestor">nearest block ancestor</a><span>, in §3.5.2</span>
-   <li><a href="#next-non-whitespace-position">next non-whitespace position</a><span>, in §3.5.2</span>
-   <li><a href="#non-searchable-subtree">non-searchable subtree</a><span>, in §3.5.2</span>
-   <li><a href="#parse-a-text-directive">parse a text directive</a><span>, in §3.3.2</span>
-   <li><a href="#parsedtextdirective">ParsedTextDirective</a><span>, in §3.3.2</span>
-   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in §3.3.3</span>
-   <li><a href="#parsedtextdirective-prefix">prefix</a><span>, in §3.3.2</span>
-   <li><a href="#process-a-fragment-directive">process a fragment directive</a><span>, in §3.5.2</span>
-   <li><a href="#process-and-consume-fragment-directive">process and consume fragment directive</a><span>, in §3.3.1</span>
-   <li><a href="#scroll-a-domrect-into-view">scroll a DOMRect into view</a><span>, in §3.5.1</span>
-   <li><a href="#scroll-a-range-into-view">scroll a Range into view</a><span>, in §3.5.1</span>
-   <li><a href="#search-invisible">search invisible</a><span>, in §3.5.2</span>
-   <li><a href="#shadow-including-parent">shadow-including parent</a><span>, in §3.5</span>
-   <li><a href="#parsedtextdirective-suffix">suffix</a><span>, in §3.3.2</span>
-   <li><a href="#textdirective">TextDirective</a><span>, in §3.3.3</span>
-   <li><a href="#textdirectiveexplicitchar">TextDirectiveExplicitChar</a><span>, in §3.3.3</span>
-   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in §3.3.3</span>
-   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in §3.3.3</span>
-   <li><a href="#textdirectivestring">TextDirectiveString</a><span>, in §3.3.3</span>
-   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in §3.3.3</span>
-   <li><a href="#parsedtextdirective-textend">textEnd</a><span>, in §3.3.2</span>
-   <li><a href="#text-fragment-directive">text fragment directive</a><span>, in §3.3.3</span>
+   <li><a href="#dom-document-fragmentdirective">fragmentDirective</a><span>, in § 3.8</span>
+   <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in § 3.3</span>
+   <li><a href="#get-boundary-point-at-index">get boundary point at index</a><span>, in § 3.5.2</span>
+   <li><a href="#has-block-level-display">has block-level display</a><span>, in § 3.5.2</span>
+   <li><a href="#is-at-a-word-boundary">is at a word boundary</a><span>, in § 3.5.3</span>
+   <li><a href="#locale">locale</a><span>, in § 3.5.3</span>
+   <li><a href="#nearest-block-ancestor">nearest block ancestor</a><span>, in § 3.5.2</span>
+   <li><a href="#next-non-whitespace-position">next non-whitespace position</a><span>, in § 3.5.2</span>
+   <li><a href="#non-searchable-subtree">non-searchable subtree</a><span>, in § 3.5.2</span>
+   <li><a href="#parse-a-text-directive">parse a text directive</a><span>, in § 3.3.2</span>
+   <li><a href="#parsedtextdirective">ParsedTextDirective</a><span>, in § 3.3.2</span>
+   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in § 3.3.3</span>
+   <li><a href="#parsedtextdirective-prefix">prefix</a><span>, in § 3.3.2</span>
+   <li><a href="#process-a-fragment-directive">process a fragment directive</a><span>, in § 3.5.2</span>
+   <li><a href="#process-and-consume-fragment-directive">process and consume fragment directive</a><span>, in § 3.3.1</span>
+   <li><a href="#scroll-a-domrect-into-view">scroll a DOMRect into view</a><span>, in § 3.5.1</span>
+   <li><a href="#scroll-a-range-into-view">scroll a Range into view</a><span>, in § 3.5.1</span>
+   <li><a href="#search-invisible">search invisible</a><span>, in § 3.5.2</span>
+   <li><a href="#shadow-including-parent">shadow-including parent</a><span>, in § 3.5</span>
+   <li><a href="#parsedtextdirective-suffix">suffix</a><span>, in § 3.3.2</span>
+   <li><a href="#textdirective">TextDirective</a><span>, in § 3.3.3</span>
+   <li><a href="#textdirectiveexplicitchar">TextDirectiveExplicitChar</a><span>, in § 3.3.3</span>
+   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in § 3.3.3</span>
+   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in § 3.3.3</span>
+   <li><a href="#textdirectivestring">TextDirectiveString</a><span>, in § 3.3.3</span>
+   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in § 3.3.3</span>
+   <li><a href="#parsedtextdirective-textend">textEnd</a><span>, in § 3.3.2</span>
+   <li><a href="#text-fragment-directive">text fragment directive</a><span>, in § 3.3.3</span>
    <li>
     textFragmentToken
     <ul>
-     <li><a href="#document-textfragmenttoken">dfn for document</a><span>, in §3.4.4</span>
-     <li><a href="#request-textfragmenttoken">dfn for request</a><span>, in §3.4.4</span>
+     <li><a href="#document-textfragmenttoken">dfn for document</a><span>, in § 3.4.4</span>
+     <li><a href="#request-textfragmenttoken">dfn for request</a><span>, in § 3.4.4</span>
     </ul>
-   <li><a href="#parsedtextdirective-textstart">textStart</a><span>, in §3.3.2</span>
-   <li><a href="#unknowndirective">UnknownDirective</a><span>, in §3.3.3</span>
-   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in §3.3.3</span>
-   <li><a href="#visible-text-node">visible text node</a><span>, in §3.5.2</span>
-   <li><a href="#word-boundary">word boundary</a><span>, in §3.5.3</span>
-   <li><a href="#word-bounded">word bounded</a><span>, in §3.5.3</span>
+   <li><a href="#parsedtextdirective-textstart">textStart</a><span>, in § 3.3.2</span>
+   <li><a href="#unknowndirective">UnknownDirective</a><span>, in § 3.3.3</span>
+   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in § 3.3.3</span>
+   <li><a href="#visible-text-node">visible text node</a><span>, in § 3.5.2</span>
+   <li><a href="#word-boundary">word boundary</a><span>, in § 3.5.3</span>
+   <li><a href="#word-bounded">word bounded</a><span>, in § 3.5.3</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-computed-value">
    <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
@@ -2436,13 +2570,13 @@ match based on whether the element-id was scrolled.</p>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css2/#propdef-visibility">https://drafts.csswg.org/css2/#propdef-visibility</a><b>Referenced in:</b>
+   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-valdef-visibility-visible">
-   <a href="https://drafts.csswg.org/css2/#valdef-visibility-visible">https://drafts.csswg.org/css2/#valdef-visibility-visible</a><b>Referenced in:</b>
+   <a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-visible">https://drafts.csswg.org/css-display-3/#valdef-visibility-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-visible">3.5.2. Finding Ranges in a Document</a>
    </ul>
@@ -2494,7 +2628,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-range-collapsed">
    <a href="https://dom.spec.whatwg.org/#range-collapsed">https://dom.spec.whatwg.org/#range-collapsed</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-range-collapsed">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-range-collapsed①">(2)</a> <a href="#ref-for-range-collapsed②">(3)</a> <a href="#ref-for-range-collapsed③">(4)</a>
+    <li><a href="#ref-for-range-collapsed">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-range-collapsed①">(2)</a> <a href="#ref-for-range-collapsed②">(3)</a> <a href="#ref-for-range-collapsed③">(4)</a> <a href="#ref-for-range-collapsed④">(5)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-cd-data">
@@ -2537,7 +2671,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-concept-range-end">
    <a href="https://dom.spec.whatwg.org/#concept-range-end">https://dom.spec.whatwg.org/#concept-range-end</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range-end">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end①">(2)</a> <a href="#ref-for-concept-range-end②">(3)</a> <a href="#ref-for-concept-range-end③">(4)</a> <a href="#ref-for-concept-range-end④">(5)</a> <a href="#ref-for-concept-range-end⑤">(6)</a> <a href="#ref-for-concept-range-end⑥">(7)</a> <a href="#ref-for-concept-range-end⑦">(8)</a> <a href="#ref-for-concept-range-end⑧">(9)</a> <a href="#ref-for-concept-range-end⑨">(10)</a> <a href="#ref-for-concept-range-end①⓪">(11)</a> <a href="#ref-for-concept-range-end①①">(12)</a> <a href="#ref-for-concept-range-end①②">(13)</a> <a href="#ref-for-concept-range-end①③">(14)</a> <a href="#ref-for-concept-range-end①④">(15)</a>
+    <li><a href="#ref-for-concept-range-end">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end①">(2)</a> <a href="#ref-for-concept-range-end②">(3)</a> <a href="#ref-for-concept-range-end③">(4)</a> <a href="#ref-for-concept-range-end④">(5)</a> <a href="#ref-for-concept-range-end⑤">(6)</a> <a href="#ref-for-concept-range-end⑥">(7)</a> <a href="#ref-for-concept-range-end⑦">(8)</a> <a href="#ref-for-concept-range-end⑧">(9)</a> <a href="#ref-for-concept-range-end⑨">(10)</a> <a href="#ref-for-concept-range-end①⓪">(11)</a> <a href="#ref-for-concept-range-end①①">(12)</a> <a href="#ref-for-concept-range-end①②">(13)</a> <a href="#ref-for-concept-range-end①③">(14)</a> <a href="#ref-for-concept-range-end①④">(15)</a> <a href="#ref-for-concept-range-end①⑤">(16)</a> <a href="#ref-for-concept-range-end①⑥">(17)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-range-end-node">
@@ -2867,7 +3001,7 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-iteration-break">
    <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-iteration-break">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-iteration-break①">(2)</a>
+    <li><a href="#ref-for-iteration-break">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-iteration-break①">(2)</a> <a href="#ref-for-iteration-break②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-code-point">
@@ -2971,13 +3105,13 @@ match based on whether the element-id was scrolled.</p>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.8. Feature Detectability</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://heycam.github.io/webidl/#SameObject">https://heycam.github.io/webidl/#SameObject</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.8. Feature Detectability</a>
    </ul>
@@ -3000,10 +3134,6 @@ match based on whether the element-id was scrolled.</p>
      <li><span class="dfn-paneled" id="term-for-valdef-display-list-item">list-item</span>
      <li><span class="dfn-paneled" id="term-for-valdef-display-none">none</span>
      <li><span class="dfn-paneled" id="term-for-valdef-display-table">table</span>
-    </ul>
-   <li>
-    <a data-link-type="biblio">[CSS21]</a> defines the following terms:
-    <ul>
      <li><span class="dfn-paneled" id="term-for-propdef-visibility">visibility</span>
      <li><span class="dfn-paneled" id="term-for-valdef-visibility-visible">visible</span>
     </ul>
@@ -3119,7 +3249,7 @@ match based on whether the element-id was scrolled.</p>
      <li><span class="dfn-paneled" id="term-for-url-code-points">url code point</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
+    <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-Exposed">Exposed</span>
      <li><span class="dfn-paneled" id="term-for-SameObject">SameObject</span>
@@ -3129,50 +3259,48 @@ match based on whether the element-id was scrolled.</p>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-css-cascade-5">[CSS-CASCADE-5]
-   <dd>Elika Etemad; Miriam Suzanne; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-5/">CSS Cascading and Inheritance Level 5</a>. 19 January 2021. WD. URL: <a href="https://www.w3.org/TR/css-cascade-5/">https://www.w3.org/TR/css-cascade-5/</a>
+   <dd>Elika Etemad; Miriam Suzanne; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-5/"><cite>CSS Cascading and Inheritance Level 5</cite></a>. 15 October 2021. WD. URL: <a href="https://www.w3.org/TR/css-cascade-5/">https://www.w3.org/TR/css-cascade-5/</a>
    <dt id="biblio-css-display-3">[CSS-DISPLAY-3]
-   <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-display-3/">CSS Display Module Level 3</a>. 18 December 2020. CR. URL: <a href="https://www.w3.org/TR/css-display-3/">https://www.w3.org/TR/css-display-3/</a>
-   <dt id="biblio-css21">[CSS21]
-   <dd>Bert Bos; et al. <a href="https://www.w3.org/TR/CSS21/">Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification</a>. 7 June 2011. REC. URL: <a href="https://www.w3.org/TR/CSS21/">https://www.w3.org/TR/CSS21/</a>
+   <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-display-3/"><cite>CSS Display Module Level 3</cite></a>. 3 September 2021. CR. URL: <a href="https://www.w3.org/TR/css-display-3/">https://www.w3.org/TR/css-display-3/</a>
    <dt id="biblio-cssom-view">[CSSOM-VIEW]
-   <dd>Simon Pieters. <a href="https://www.w3.org/TR/cssom-view-1/">CSSOM View Module</a>. 17 March 2016. WD. URL: <a href="https://www.w3.org/TR/cssom-view-1/">https://www.w3.org/TR/cssom-view-1/</a>
+   <dd>Simon Pieters. <a href="https://www.w3.org/TR/cssom-view-1/"><cite>CSSOM View Module</cite></a>. 17 March 2016. WD. URL: <a href="https://www.w3.org/TR/cssom-view-1/">https://www.w3.org/TR/cssom-view-1/</a>
    <dt id="biblio-document-policy">[DOCUMENT-POLICY]
-   <dd>Ian Clelland. <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html">Document Policy</a>. ED. URL: <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html">https://w3c.github.io/webappsec-permissions-policy/document-policy.html</a>
+   <dd>Ian Clelland. <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html"><cite>Document Policy</cite></a>. ED. URL: <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html">https://w3c.github.io/webappsec-permissions-policy/document-policy.html</a>
    <dt id="biblio-dom">[DOM]
-   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-fetch">[FETCH]
-   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-geometry-1">[GEOMETRY-1]
-   <dd>Simon Pieters; Chris Harrelson. <a href="https://www.w3.org/TR/geometry-1/">Geometry Interfaces Module Level 1</a>. 4 December 2018. CR. URL: <a href="https://www.w3.org/TR/geometry-1/">https://www.w3.org/TR/geometry-1/</a>
+   <dd>Simon Pieters; Chris Harrelson. <a href="https://www.w3.org/TR/geometry-1/"><cite>Geometry Interfaces Module Level 1</cite></a>. 4 December 2018. CR. URL: <a href="https://www.w3.org/TR/geometry-1/">https://www.w3.org/TR/geometry-1/</a>
    <dt id="biblio-html">[HTML]
-   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-infra">[INFRA]
-   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
-   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-uax29">[UAX29]
-   <dd>Mark Davis; Christopher Chapman. <a href="https://www.unicode.org/reports/tr29/tr29-37.html">Unicode Text Segmentation</a>. 19 February 2020. Unicode Standard Annex #29. URL: <a href="https://www.unicode.org/reports/tr29/tr29-37.html">https://www.unicode.org/reports/tr29/tr29-37.html</a>
+   <dd>Mark Davis; Christopher Chapman. <a href="https://www.unicode.org/reports/tr29/tr29-39.html"><cite>Unicode Text Segmentation</cite></a>. 24 August 2021. Unicode Standard Annex #29. URL: <a href="https://www.unicode.org/reports/tr29/tr29-39.html">https://www.unicode.org/reports/tr29/tr29-39.html</a>
    <dt id="biblio-url">[URL]
-   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL Standard</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-uts10">[UTS10]
-   <dd>Ken Whistler; Markus Scherer. <a href="https://www.unicode.org/reports/tr10/tr10-43.html">Unicode Collation Algorithm</a>. 7 February 2020. Unicode Technical Standard #10. URL: <a href="https://www.unicode.org/reports/tr10/tr10-43.html">https://www.unicode.org/reports/tr10/tr10-43.html</a>
-   <dt id="biblio-webidl">[WebIDL]
-   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Ken Whistler; Markus Scherer. <a href="https://www.unicode.org/reports/tr10/tr10-45.html"><cite>Unicode Collation Algorithm</cite></a>. 27 August 2021. Unicode Technical Standard #10. URL: <a href="https://www.unicode.org/reports/tr10/tr10-45.html">https://www.unicode.org/reports/tr10/tr10-45.html</a>
+   <dt id="biblio-webidl">[WEBIDL]
+   <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-bcp47">[BCP47]
-   <dd>A. Phillips; M. Davis. <a href="https://tools.ietf.org/html/bcp47">Tags for Identifying Languages</a>. September 2009. IETF Best Current Practice. URL: <a href="https://tools.ietf.org/html/bcp47">https://tools.ietf.org/html/bcp47</a>
+   <dd>A. Phillips, Ed.; M. Davis, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc5646"><cite>Tags for Identifying Languages</cite></a>. September 2009. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc5646">https://www.rfc-editor.org/rfc/rfc5646</a>
    <dt id="biblio-fetch-metadata">[FETCH-METADATA]
-   <dd>Mike West. <a href="https://w3c.github.io/webappsec-fetch-metadata/">Fetch Metadata Request Headers</a>. WD. URL: <a href="https://w3c.github.io/webappsec-fetch-metadata/">https://w3c.github.io/webappsec-fetch-metadata/</a>
+   <dd>Mike West. <a href="https://w3c.github.io/webappsec-fetch-metadata/"><cite>Fetch Metadata Request Headers</cite></a>. WD. URL: <a href="https://w3c.github.io/webappsec-fetch-metadata/">https://w3c.github.io/webappsec-fetch-metadata/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#fragmentdirective"><code><c- g>FragmentDirective</c-></code></a> {
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document"><c- g>Document</c-></a> {
-    [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SameObject"><c- g>SameObject</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#fragmentdirective"><c- n>FragmentDirective</c-></a> <a data-readonly data-type="FragmentDirective" href="#dom-document-fragmentdirective"><code><c- g>fragmentDirective</c-></code></a>;
+    [<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SameObject"><c- g>SameObject</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#fragmentdirective"><c- n>FragmentDirective</c-></a> <a data-readonly data-type="FragmentDirective" href="#dom-document-fragmentdirective"><code><c- g>fragmentDirective</c-></code></a>;
 };
 
 </pre>
@@ -3181,7 +3309,7 @@ match based on whether the element-id was scrolled.</p>
    <div class="issue"> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data">data</a> is not
 correct here since that’s the text data as it exists in the DOM. This
 algorithm means to run over the text as rendered (and then convert back
-to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/issues/98">&lt;https://github.com/WICG/scroll-to-text-fragment/issues/98></a><a href="#issue-96fe4755"> ↵ </a></div>
+to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/issues/98">[Issue #WICG/scroll-to-text-fragment#98]</a> <a class="issue-return" href="#issue-96fe4755" title="Jump to section">↵</a></div>
   </div>
   <aside class="dfn-panel" data-for="fragment-directive-delimiter">
    <b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
@@ -3229,7 +3357,7 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
    <b><a href="#parsedtextdirective-textend">#parsedtextdirective-textend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsedtextdirective-textend">3.3.2. Parsing the fragment directive</a>
-    <li><a href="#ref-for-parsedtextdirective-textend①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-textend②">(2)</a> <a href="#ref-for-parsedtextdirective-textend③">(3)</a> <a href="#ref-for-parsedtextdirective-textend④">(4)</a> <a href="#ref-for-parsedtextdirective-textend⑤">(5)</a> <a href="#ref-for-parsedtextdirective-textend⑥">(6)</a> <a href="#ref-for-parsedtextdirective-textend⑦">(7)</a> <a href="#ref-for-parsedtextdirective-textend⑧">(8)</a> <a href="#ref-for-parsedtextdirective-textend⑨">(9)</a>
+    <li><a href="#ref-for-parsedtextdirective-textend①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-textend②">(2)</a> <a href="#ref-for-parsedtextdirective-textend③">(3)</a> <a href="#ref-for-parsedtextdirective-textend④">(4)</a> <a href="#ref-for-parsedtextdirective-textend⑤">(5)</a> <a href="#ref-for-parsedtextdirective-textend⑥">(6)</a> <a href="#ref-for-parsedtextdirective-textend⑦">(7)</a> <a href="#ref-for-parsedtextdirective-textend⑧">(8)</a> <a href="#ref-for-parsedtextdirective-textend⑨">(9)</a> <a href="#ref-for-parsedtextdirective-textend①⓪">(10)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="parsedtextdirective-prefix">
@@ -3621,3 +3749,108 @@ document.body.addEventListener("click", function(e) {
         }
     }
     </script>
+<script>/* script-wpt */
+let wptPath = "/scroll-to-text-fragment/";
+"use strict";
+
+document.addEventListener("DOMContentLoaded", async ()=>{
+    if(wptPath == "/") return;
+
+    const runsUrl = "https://wpt.fyi/api/runs?label=master&label=stable&max-count=1&product=chrome&product=firefox&product=safari&product=edge";
+    const runs = await (await fetch(runsUrl)).json();
+
+    const testResults = await( await fetch("https://wpt.fyi/api/search", {
+        method:"POST",
+        headers:{
+            "Content-Type":"application/json",
+        },
+        body: JSON.stringify({
+            "run_ids": runs.map(x=>x.id),
+            "query": {"path": wptPath},
+        })
+    })).json();
+
+    const browsers = runs.map(x=>({name:x.browser_name, version:x.browser_version, passes:0, total: 0}));
+    const resultsFromPath = new Map(testResults.results.map(result=>{
+        const testPath = result.test;
+        const passes = result.legacy_status.map(x=>[x.passes, x.total]);
+        return [testPath, passes];
+    }));
+    document.querySelectorAll(".wpt-name").forEach(nameEl=>{
+        const passData = resultsFromPath.get("/" + nameEl.getAttribute("title"));
+        const numTests = passData[0][1];
+        if(numTests > 1) {
+            nameEl.insertAdjacentElement("beforeend",
+                el("small", {}, ` (${numTests} tests)`));
+        }
+        if(passData == undefined) return;
+        passData.forEach((p,i) => {
+            browsers[i].passes += p[0];
+            browsers[i].total += p[1];
+        })
+        const resultsEl = el("span",{"class":"wpt-results"},
+            ...passData.map((p,i) => el("span",
+            {
+                "title": `${browsers[i].name} ${p[0]}/${p[1]}`,
+                "class": "wpt-result",
+                "style": `background: conic-gradient(forestgreen ${p[0]/p[1]*360}deg, darkred 0deg);`,
+            })),
+        );
+        nameEl.insertAdjacentElement("afterend", resultsEl);
+    });
+    const overview = document.querySelector(".wpt-overview");
+    if(overview) {
+        overview.appendChild(el('ul',{}, ...browsers.map(formatWptResult)));
+        document.head.appendChild(el('style', {},
+            `.wpt-overview ul { display: flex; flex-flow: row wrap; gap: .2em; justify-content: start; list-style: none; padding: 0; margin: 0;}
+             .wpt-overview li { padding: .25em 1em; color: black; text-align: center; }
+             .wpt-overview img { height: 1.5em; height: max(1.5em, 32px); background: transparent; }
+             .wpt-overview .browser { font-weight: bold; }
+             .wpt-overview .passes-none { background: #e57373; }
+             .wpt-overview .passes-hardly { background: #ffb74d; }
+             .wpt-overview .passes-a-few { background: #ffd54f; }
+             .wpt-overview .passes-half { background: #fff176; }
+             .wpt-overview .passes-lots { background: #dce775; }
+             .wpt-overview .passes-most { background: #aed581; }
+             .wpt-overview .passes-all { background: #81c784; }`));
+    }
+});
+function el(name, attrs, ...content) {
+    const x = document.createElement(name);
+    for(const [k,v] of Object.entries(attrs)) {
+        x.setAttribute(k, v);
+    }
+    for(let child of content) {
+        if(typeof child == "string") child = document.createTextNode(child);
+        try {
+        x.appendChild(child);
+        } catch(e) { console.log({x, child}); }
+    }
+    return x;
+}
+function formatWptResult({name, version, passes, total}) {
+    const passRate = passes/total;
+    let passClass = "";
+    if(passRate == 0)      passClass = "passes-none";
+    else if(passRate < .2) passClass = "passes-hardly";
+    else if(passRate < .4) passClass = "passes-a-few";
+    else if(passRate < .6) passClass = "passes-half";
+    else if(passRate < .8) passClass = "passes-lots";
+    else if(passRate < 1)  passClass = "passes-most";
+    else                   passClass = "passes-all";
+
+    name = name[0].toUpperCase() + name.slice(1);
+    const shortVersion = /^\d+/.exec(version);
+    const icon = []
+
+    if(name == "Chrome") icon.push(el('img', {alt:"", src:"https://wpt.fyi/static/chrome-dev_64x64.png"}));
+    if(name == "Edge") icon.push(el('img', {alt:"", src:"https://wpt.fyi/static/edge-dev_64x64.png"}));
+    if(name == "Safari") icon.push(el('img', {alt:"", src:"https://wpt.fyi/static/safari-preview_64x64.png"}));
+    if(name == "Firefox") icon.push(el('img', {alt:"", src:"https://wpt.fyi/static/firefox-nightly_64x64.png"}));
+
+    return el('li', {"class":passClass},
+        el('nobr', {'class':'browser'}, ...icon, ` ${name} ${shortVersion}`),
+        el('br', {}),
+        el('nobr', {'class':'pass-rate'}, `${passes}/${total}`)
+    );
+}</script>


### PR DESCRIPTION
Fixes a bug in the algorithm where an unmatched `rangeEnd+suffx` will continue the search by starting to look for the next prefix. However, if we didn't find the correct `rangeEnd+suffix` pair, we should continue to look until the end of the document because there may be another one. For example:

```
matchStart foo matchEnd bar matchEnd baz
```

If the directive is `text=matchStart,matchEnd,-baz`, the current algorithm will find the first instance of `matchEnd`, realize the suffix doesn't match and iterate the loop which will continue the search from the beginning, starting from `foo`.

This PR changes the algorithm to continue searching for a matching `rangeEnd+suffix` until the end of the document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/ScrollToTextFragment/pull/176.html" title="Last updated on Nov 5, 2021, 8:27 PM UTC (17ec778)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/176/3271b8b...bokand:17ec778.html" title="Last updated on Nov 5, 2021, 8:27 PM UTC (17ec778)">Diff</a>