### PR TITLE
[Alternative Content Types proposal] Allow `:has()` pseudo class

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -164,6 +164,10 @@ Restrictions:
       selectors allowed (i.e. `[src^=val]`, `[src$=val]`, `[src*=val]`)
     * The [case sensitivity](https://www.w3.org/TR/selectors-4/#attribute-case) attribute
       is allowed
+  * Within the constraints above, the
+    [`:has()`](https://drafts.csswg.org/selectors/#relational) pseudo-class, which is
+    useful for matching nested structures like `<video><source src="foo" /></video>`
+    based on the `src` attribute.
 
 ### Invocation restrictions
 


### PR DESCRIPTION
We found `has:()` to be very useful to select nested structures like `<video><source src="foo" /></video>` based on the `src` attribute.

https://github.com/tomayac/link-to-media/blob/62eb5f0aec182382e9a7b37682f8da5cdbda0815/polyfill/create-link.js#L50-L57