### PR TITLE
Call out umlauts specifically

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1508,7 +1508,7 @@ a [=range=] |searchRange|, a [=/list=] of {{Text}} nodes |nodes|, and booleans
             <a href="http://www.unicode.org/reports/tr10/#Multi_Level_Comparison">primary
             level</a>, as defined in [[!UTS10]].
             <div class="note">
-              Intuitively, this is a case-insensitive search also ignoring accents
+              Intuitively, this is a case-insensitive search also ignoring accents, umlauts,
               and other marks.
             </div>
         1. If |matchIndex| is null, return null.


### PR DESCRIPTION
Via https://github.com/GoogleChromeLabs/link-to-text-fragment/issues/53


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tomayac/scroll-to-text-fragment/pull/184.html" title="Last updated on Feb 28, 2022, 10:30 AM UTC (9e27027)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/184/c5a7035...tomayac:9e27027.html" title="Last updated on Feb 28, 2022, 10:30 AM UTC (9e27027)">Diff</a>