### PR TITLE
[Spec] Fix linking errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -694,7 +694,7 @@ This specification does not specify exactly how a UA achieves this as there are
 multiple solutions with differing tradeoffs. For example, a UA <em>may</em>
 continue to walk the tree even after a match is found in [=find a range from a
 text directive=].  Alternatively, it <em>may</em> schedule an asynchronous task
-to find and set the indicated part of the document.
+to find and set the [=Document=]'s indicated part.
 
 ### Restricting the Text Fragment ### {#restricting-the-text-fragment}
 
@@ -789,7 +789,7 @@ field for the [=document/textFragmentToken=]:
 </div>
 
 Amend the <a
-href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">create
+href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object">create
 and initialize a Document object</a> steps by adding the following steps before returning |document|:
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
@@ -852,13 +852,6 @@ and initialize a Document object</a> steps by adding the following steps before 
 >           </div>
 >       1. If |textFragmentToken| is false, set
 >           [=document/allowTextFragmentDirective=] to false and abort these sub-steps.
->       1. If the [=document=] of the <a spec=HTML>latest entry</a> in
->           |document|'s [=Document/browsing context=]'s <a spec=HTML>session history</a> is
->           equal to |document|, set [=document/allowTextFragmentDirective=] to false
->           and abort these sub-steps.
->           <div class="note">
->             i.e. Forbidden on a same-document navigation.
->           </div>
 >       1. If the |navigationParam|'s
 >           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
 >           has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
@@ -907,7 +900,7 @@ steps of the task queued in step 2:
 >       the fragment, then clear <em>document</em>'s
 >       [=allowTextFragmentDirective=] flag and abort these steps.
 >   2. Scroll to the fragment given in document's URL. If this does not find an
->       indicated part of the document, then try to scroll to the fragment for
+>       indicated part, then try to scroll to the fragment for
 >       document.
 >   3. Clear <em>document</em>'s [=allowTextFragmentDirective=] flag
 
@@ -918,43 +911,55 @@ steps of the task queued in step 2:
 The text fragment specification proposes an amendment to
 [[html#scroll-to-fragid]]. In summary, if a [=text fragment directive=] is
 present and a match is found in the page, the text fragment takes precedent over
-the element fragment as the indicated part of the document. We amend the
-indicated part of the document to optionally include a [=range=] that
+the element fragment as the indicated part. We amend the HTML Document's
+indicated part processing model to optionally include a [=range=] that
 may be scrolled into view instead of the containing element.
 </div>
 
-Replace step 3.1 of the <a spec=HTML>scroll to the fragment</a> algorithm with
-the following:
+Replace step 3 of the <a spec=HTML>scroll to the fragment</a> algorithm as follows:
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
+>   Replace:
+>
+>   1. <strike>Assert: document's indicated part is an element.</strike>
+>   1. <strike>Let target be document's indicated part.</strike>
+>   1. <strike>Set document's target element to target.</strike>
+>   1. <strike>Run the ancestor details revealing algorithm on target.</strike>
+>   1. <strike>Run the ancestor hidden-until-found revealing algorithm on target.</strike>
+>   1. <strike>Scroll target into view, with behavior set to "auto", block set to "start", and inline set to "nearest".</strike>
+>   1. <strike>Run the focusing steps for target, with the Document's viewport as the fallback target.</strike>
+>   1. <strike>Move the sequential focus navigation starting point to target.</strike>
+>
+>   With:
+>
+>   1. Assert: document's indicated part is an [=/element=] and [=range=].
 >   1. Let <em>target, range</em> be the [=/element=] and [=range=] that is
->       <a spec=HTML>the indicated part of the document</a>.
-
-Replace step 3.3 of the <a spec=HTML>scroll to the fragment</a> algorithm with
-the following:
-
->   <strong>Monkeypatching [[HTML]]:</strong>
->
->   3. <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
+>       <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">indicated part</a>.
+>   1. Set document's target element to target.
+>   1. Run the ancestor details revealing algorithm on target.
+>   1. Run the ancestor hidden-until-found revealing algorithm on target.
+>   1. <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
 >       the policy value</a> for `force-load-at-top` in the
->       [=Document=]. If the result is true, abort these steps.
->   4. If <em>range</em> is non-null:
->       1. If the UA supports scrolling of text fragments on navigation, invoke
->           [=scroll a Range into view|Scroll range into view=], with range
->           <em>range</em>, containingElement <em>target</em>, <em>behavior</em> set
->           to "auto", <em>block</em> set to "center", and <em>inline</em> set to
->           "nearest".
->   5. Otherwise:
->       1. <a spec=cssom-view lt="scroll an element into view">Scroll target
->           into view</a>, with <em>behavior</em> set to "auto", <em>block</em>
->           set to "start", and <em>inline</em> set to "nearest".
->           <div class="note">
->               This otherwise case is the same as the current step 3.3.
->           </div>
+>       [=Document=]. If the result is false:
+>       1. If <em>range</em> is non-null:
+>           1. If the UA supports scrolling of text fragments on navigation, invoke
+>               [=scroll a Range into view|Scroll range into view=], with range
+>               <em>range</em>, containingElement <em>target</em>, <em>behavior</em> set
+>               to "auto", <em>block</em> set to "center", and <em>inline</em> set to
+>               "nearest".
+>       1. Otherwise:
+>           1. <a spec=cssom-view lt="scroll an element into view">Scroll target
+>               into view</a>, with <em>behavior</em> set to "auto", <em>block</em>
+>               set to "start", and <em>inline</em> set to "nearest".
+>               <div class="note">
+>                   This otherwise case is the same as the current step 3.3.
+>               </div>
+>   1. Run the focusing steps for target, with the Document's viewport as the fallback target.
+>   1. Move the sequential focus navigation starting point to target.
 
-Add the following steps to the beginning of the processing model for
-<a spec=HTML>the indicated part of the document</a>:
+Add the following steps to the beginning of the processing model for the [=HTML Document=]'s
+<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">indicated part</a>:
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
@@ -975,7 +980,7 @@ Add the following steps to the beginning of the processing model for
 >               [=range/start node=] and [=range/end node=].
 >           1. While |node| is non-null and is not an [=element=], set |node| to
 >               |node|'s [=tree/parent=].
->           1. The indicated part of the document is |node| and |range|; return.
+>           1. The indicated part is |node| and |range|; return.
 
 <div algorithm="first common ancestor">
 To find the <dfn>first common ancestor</dfn> of two nodes |nodeA| and |nodeB|,
@@ -1808,8 +1813,8 @@ with <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy
   ```
 
   When the page loads, the element containing "foo" will be marked as the
-  indicated part of the document and set as the document's target element.
-  However, "foo" will not be scrolled into view.
+  indicated part and set as the document's target element. However, "foo"
+  will not be scrolled into view.
 </div>
 
 Fragment-based scroll blocking from this policy is specified in an amendment to the
@@ -1822,9 +1827,7 @@ persisted state</a> steps by inserting a new step after 2:
 3. <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
     the document policy value</a> of the "force-load-at-top" feature for the [=Document=]. If
     the result is true, then the user agent should not restore the scroll
-    position for the [=Document=] or any of its scrollable regions. Scroll
-    positions for [=child browsing contexts=] should be restored based on the
-    value of this policy in the child [=Document=].
+    position for the [=Document=] or any of its scrollable regions.
 
 
 ## Feature Detectability ## {#feature-detectability}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <title>Text Fragments</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 44af0bf3e, updated Fri Jul 29 17:05:16 2022 -0700" name="generator">
+  <meta content="Bikeshed version 26e85e599, updated Thu Dec 8 15:29:31 2022 -0800" name="generator">
   <link href="https://wicg.github.io/scroll-to-text-fragment/" rel="canonical">
 <style>/* style-autolinks */
 
@@ -293,6 +293,14 @@ a.self-link:hover {
 }
 .heading > a.self-link {
     font-size: 83%;
+}
+.example > a.self-link,
+.note > a.self-link,
+.issue > a.self-link {
+    /* These blocks are overflow:auto, so positioning outside
+       doesn't work. */
+    left: auto;
+    right: 0;
 }
 li > a.self-link {
     left: calc(-1 * (3.5rem - 26px) - 2em);
@@ -725,7 +733,7 @@ dd:not(:last-child) > .wpt-tests-block:not([open]):last-child {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-09-02">2 September 2022</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-12-20">20 December 2022</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -855,7 +863,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   </nav>
   <main>
    <h2 class="heading settled" data-level="1" id="infrastructure"><span class="secno">1. </span><span class="content">Infrastructure</span><a class="self-link" href="#infrastructure"></a></h2>
-   <p>This specification depends on the Infra Standard. <a data-link-type="biblio" href="#biblio-infra">[INFRA]</a> </p>
+   <p>This specification depends on the Infra Standard. <a data-link-type="biblio" href="#biblio-infra" title="Infra Standard">[INFRA]</a> </p>
    <h2 class="heading settled" data-level="2" id="introduction"><span class="secno">2. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
    <div class="note" role="note">This section is non-normative</div>
    <h3 class="heading settled" data-level="2.1" id="use-cases"><span class="secno">2.1. </span><span class="content">Use cases</span><a class="self-link" href="#use-cases"></a></h3>
@@ -988,7 +996,7 @@ UA sets the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-d
 following additions and changes.</p>
    <p>To the definition of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a>, add:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-dom" title="DOM Standard">[DOM]</a>:</strong></p>
     <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive">fragment directive</dfn> which is
     either null or an ASCII string holding data used by the UA to process the
     resource. It is initially null. </em></p>
@@ -997,7 +1005,7 @@ following additions and changes.</p>
 Document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a>.</p>
    <p>Add a series of steps that will process a fragment directive on a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url②">URL</a>:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-dom">[DOM]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-dom" title="DOM Standard">[DOM]</a>:</strong></p>
     <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-and-consume-fragment-directive">process and consume fragment directive</dfn> from a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">URL</a> <var>url</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a> <var>document</var>, run these steps:</p>
     <ol>
      <li data-md>
@@ -1036,7 +1044,7 @@ the fragment is the string "test" and the <a data-link-type="dfn" href="#fragmen
    <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to parse and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑨">fragment directive</a> by inserting the following steps right before the
 setting <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url③">URL</a> (<a href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#initialise-the-document-object">currently</a> step 9):</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
     <ol start="9">
      <li data-md>
       <p>Run the <a data-link-type="dfn" href="#process-and-consume-fragment-directive" id="ref-for-process-and-consume-fragment-directive">process and consume fragment directive</a> steps on <var>creationURL</var> and <var>document</var>.</p>
@@ -1046,7 +1054,7 @@ setting <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.w
    </blockquote>
    <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history"> traverse the history</a> steps to process the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⓪">fragment directive</a> during a history navigation by inserting steps before setting the <var>newDocument</var>’s URL (<a href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#traverse-the-history">currently</a> step 6).</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
     <ol start="6">
      <li data-md>
       <p>Let <var>processedURL</var> be a copy of <var>entry</var>’s URL.</p>
@@ -1058,7 +1066,7 @@ setting <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.w
    </blockquote>
    <div class="note" role="note">
     <p> The changes in this section imply that a URL is only stripped of its fragment
-    directive when it is set on a Document. Notably, since a window’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/history.html#location" id="ref-for-location">Location</a></code> object is a representation of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①">URL</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active
+    directive when it is set on a Document. Notably, since a window’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location" id="ref-for-location">Location</a></code> object is a representation of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①">URL</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document">active
     document</a>, all getters on it will show a fragment-directive-stripped
     version of the URL. </p>
     <p> Some examples should help clarify various edge cases. </p>
@@ -1316,27 +1324,27 @@ has been successfully found</em>.</p>
    <p>This specification does not specify exactly how a UA achieves this as there are
 multiple solutions with differing tradeoffs. For example, a UA <em>may</em> continue to walk the tree even after a match is found in <a data-link-type="dfn" href="#find-a-range-from-a-text-directive" id="ref-for-find-a-range-from-a-text-directive">find a range from a
 text directive</a>.  Alternatively, it <em>may</em> schedule an asynchronous task
-to find and set the indicated part of the document.</p>
+to find and set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a>'s indicated part.</p>
    <h4 class="heading settled" data-level="3.4.4" id="restricting-the-text-fragment"><span class="secno">3.4.4. </span><span class="content">Restricting the Text Fragment</span><a class="self-link" href="#restricting-the-text-fragment"></a></h4>
-   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a> to include a new
+   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a> to include a new
 field for the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken">textFragmentToken</a>:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a>:</strong></p>
     <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> has an associated <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport id="request-textfragmenttoken">textFragmentToken</dfn> flag</p>
    </blockquote>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
-    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-textfragmenttoken">textFragmentToken</dfn> flag that is
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
+    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-textfragmenttoken">textFragmentToken</dfn> flag that is
   consumed in order to allow a single activation of a text fragment. This flag is
   generated only during loading if the navigation occurs as a result of a user
   activation.</p>
-    <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①">textFragmentToken</a> isn’t consumed to activate
-  a text fragment, it may be consumed to set the <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken">textFragmentToken</a> flag of a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>. In this way, a <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken②">textFragmentToken</a> can be propagated from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a> to another across a navigation.</p>
-    <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken③">textFragmentToken</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken①">textFragmentToken</a> must always consume the value,
+    <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①">textFragmentToken</a> isn’t consumed to activate
+  a text fragment, it may be consumed to set the <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken">textFragmentToken</a> flag of a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>. In this way, a <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken②">textFragmentToken</a> can be propagated from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> to another across a navigation.</p>
+    <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken③">textFragmentToken</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken①">textFragmentToken</a> must always consume the value,
   such that the token cannot be cloned.</p>
    </blockquote>
    <div class="note" role="note">
-    <p> A <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken④">textFragmentToken</a> is generated when a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a> is loaded
+    <p> A <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken④">textFragmentToken</a> is generated when a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> is loaded
     as a result of a user gesture. It grants its holder permission (in terms of
     user activation) to activate a single text fragment. Alternatively, it may be
     propagated through a navigation to allow a future document to activate a text
@@ -1366,8 +1374,8 @@ field for the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref
     <p> See <a href="redirects.md">redirects.md</a> for a more in-depth discussion. </p>
    </div>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
-    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allowtextfragmentdirective">allowTextFragmentDirective</dfn> flag that is used to determine whether a text fragment directive should be
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
+    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allowtextfragmentdirective">allowTextFragmentDirective</dfn> flag that is used to determine whether a text fragment directive should be
   allowed to activate. If this flag is false, the text fragment must not
   cause any observable effects.</p>
    </blockquote>
@@ -1385,10 +1393,10 @@ field for the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref
    <div class="note" role="note"> TODO: This should really only prevent potentially observable side-effects like
   automatic scrolling. Unobservable effects like a highlight could be safely
   allowed in all cases. </div>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">create
+   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object">create
 and initialize a Document object</a> steps by adding the following steps before returning <var>document</var>:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
     <ol start="15">
      <li data-md>
       <p>Set the <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑦">textFragmentToken</a> flag on <var>document</var>:</p>
@@ -1398,7 +1406,7 @@ and initialize a Document object</a> steps by adding the following steps before 
   a window that had a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation" id="ref-for-transient-activation">transient activation</a> at the time the
   navigation was initiated, or the UA has reason to believe it comes from a
   direct user gesture (e.g. user typed into the address bar).</p>
-        <div class="note" role="note"> TODO: it’d be better to refer to the userActivationFlag on the <var>request</var>. See <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a> in <a data-link-type="biblio" href="#biblio-fetch-metadata">[FETCH-METADATA]</a>. </div>
+        <div class="note" role="note"> TODO: it’d be better to refer to the userActivationFlag on the <var>request</var>. See <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a> in <a data-link-type="biblio" href="#biblio-fetch-metadata" title="Fetch Metadata Request Headers">[FETCH-METADATA]</a>. </div>
        <li data-md>
         <p>If <var>browsing context</var> is a top-level browsing context and if either of <var>is
   user activated</var> or the <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken②">textFragmentToken</a> flag of <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> object is true, set the <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken⑧">textFragmentToken</a> flag to true. Otherwise, set it to false.</p>
@@ -1434,29 +1442,24 @@ and initialize a Document object</a> steps by adding the following steps before 
        <li data-md>
         <p>If <var>textFragmentToken</var> is false, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective④">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
        <li data-md>
-        <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">document</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#latest-entry" id="ref-for-latest-entry">latest entry</a> in <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/history.html#session-history" id="ref-for-session-history">session history</a> is
-  equal to <var>document</var>, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑤">allowTextFragmentDirective</a> to false
-  and abort these sub-steps.</p>
-        <div class="note" role="note"> i.e. Forbidden on a same-document navigation. </div>
-       <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑥">allowTextFragmentDirective</a> to true and abort these
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑤">allowTextFragmentDirective</a> to true and abort these
   sub-steps.</p>
        <li data-md>
-        <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc" id="ref-for-concept-document-bc①">browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing
-  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑦">allowTextFragmentDirective</a> to true and abort these sub-steps.</p>
+        <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing
+  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑥">allowTextFragmentDirective</a> to true and abort these sub-steps.</p>
         <div class="note" role="note"> i.e. Only allow navigation from a cross-origin element/script if the
     document is loaded in a noopener context. That is, a new top level
     browsing context group to which the navigator does not have script access
     and which may be placed into a separate process. </div>
        <li data-md>
-        <p>Otherwise, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑧">allowTextFragmentDirective</a> to false.</p>
+        <p>Otherwise, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑦">allowTextFragmentDirective</a> to false.</p>
       </ol>
     </ol>
    </blockquote>
-   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken③">textFragmentToken</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document①">active document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①①">textFragmentToken</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document②">active document</a>'s value to
+   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-textfragmenttoken" id="ref-for-request-textfragmenttoken③">textFragmentToken</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document①">active document</a>'s <a data-link-type="dfn" href="#document-textfragmenttoken" id="ref-for-document-textfragmenttoken①①">textFragmentToken</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document②">active document</a>'s value to
 false.</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
     <ol start="2">
      <li data-md>
       <p>Set request’s client to sourceBrowsingContext’s active document’s relevant
@@ -1471,69 +1474,95 @@ false.</p>
    <p>Amend the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment">try to scroll to the fragment</a> steps by replacing the
 steps of the task queued in step 2:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
     <ol>
      <li data-md>
       <p>If document has no parser, or its parser has stopped parsing, or the user
   agent has reason to believe the user is no longer interested in scrolling to
-  the fragment, then clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑨">allowTextFragmentDirective</a> flag and abort these steps.</p>
+  the fragment, then clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑧">allowTextFragmentDirective</a> flag and abort these steps.</p>
      <li data-md>
       <p>Scroll to the fragment given in document’s URL. If this does not find an
-  indicated part of the document, then try to scroll to the fragment for
+  indicated part, then try to scroll to the fragment for
   document.</p>
      <li data-md>
-      <p>Clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①⓪">allowTextFragmentDirective</a> flag</p>
+      <p>Clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑨">allowTextFragmentDirective</a> flag</p>
     </ol>
    </blockquote>
    <h3 class="heading settled" data-level="3.5" id="navigating-to-text-fragment"><span class="secno">3.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
-   <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.11.9 Navigating to a fragment</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive④">text fragment directive</a> is
+   <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.4.2.3.3 Fragment navigations</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive④">text fragment directive</a> is
 present and a match is found in the page, the text fragment takes precedent over
-the element fragment as the indicated part of the document. We amend the
-indicated part of the document to optionally include a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range">range</a> that
+the element fragment as the indicated part. We amend the HTML Document’s
+indicated part processing model to optionally include a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range">range</a> that
 may be scrolled into view instead of the containing element. </div>
-   <p>Replace step 3.1 of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier①">scroll to the fragment</a> algorithm with
-the following:</p>
+   <p>Replace step 3 of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier①">scroll to the fragment</a> algorithm as follows:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
+    <p>Replace:</p>
     <ol>
      <li data-md>
-      <p>Let <em>target, range</em> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element">element</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①">range</a> that is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document" id="ref-for-the-indicated-part-of-the-document">the indicated part of the document</a>.</p>
+      <strike>Assert: document’s indicated part is an element.</strike>
+     <li data-md>
+      <strike>Let target be document’s indicated part.</strike>
+     <li data-md>
+      <strike>Set document’s target element to target.</strike>
+     <li data-md>
+      <strike>Run the ancestor details revealing algorithm on target.</strike>
+     <li data-md>
+      <strike>Run the ancestor hidden-until-found revealing algorithm on target.</strike>
+     <li data-md>
+      <strike>Scroll target into view, with behavior set to "auto", block set to "start", and inline set to "nearest".</strike>
+     <li data-md>
+      <strike>Run the focusing steps for target, with the Document’s viewport as the fallback target.</strike>
+     <li data-md>
+      <strike>Move the sequential focus navigation starting point to target.</strike>
     </ol>
-   </blockquote>
-   <p>Replace step 3.3 of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier②">scroll to the fragment</a> algorithm with
-the following:</p>
-   <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
-    <ol start="3">
+    <p>With:</p>
+    <ol>
+     <li data-md>
+      <p class="assertion">Assert: document’s indicated part is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element">element</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①">range</a>.</p>
+     <li data-md>
+      <p>Let <em>target, range</em> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element①">element</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②">range</a> that is <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">indicated part</a>.</p>
+     <li data-md>
+      <p>Set document’s target element to target.</p>
+     <li data-md>
+      <p>Run the ancestor details revealing algorithm on target.</p>
+     <li data-md>
+      <p>Run the ancestor hidden-until-found revealing algorithm on target.</p>
      <li data-md>
       <p><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
-  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①②">Document</a>. If the result is true, abort these steps.</p>
-     <li data-md>
-      <p>If <em>range</em> is non-null:</p>
+  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①②">Document</a>. If the result is false:</p>
       <ol>
        <li data-md>
-        <p>If the UA supports scrolling of text fragments on navigation, invoke <a data-link-type="dfn" href="#scroll-a-range-into-view" id="ref-for-scroll-a-range-into-view">Scroll range into view</a>, with range <em>range</em>, containingElement <em>target</em>, <em>behavior</em> set
+        <p>If <em>range</em> is non-null:</p>
+        <ol>
+         <li data-md>
+          <p>If the UA supports scrolling of text fragments on navigation, invoke <a data-link-type="dfn" href="#scroll-a-range-into-view" id="ref-for-scroll-a-range-into-view">Scroll range into view</a>, with range <em>range</em>, containingElement <em>target</em>, <em>behavior</em> set
   to "auto", <em>block</em> set to "center", and <em>inline</em> set to
   "nearest".</p>
+        </ol>
+       <li data-md>
+        <p>Otherwise:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view">Scroll target
+  into view</a>, with <em>behavior</em> set to "auto", <em>block</em> set to "start", and <em>inline</em> set to "nearest".</p>
+          <div class="note" role="note"> This otherwise case is the same as the current step 3.3. </div>
+        </ol>
       </ol>
      <li data-md>
-      <p>Otherwise:</p>
-      <ol>
-       <li data-md>
-        <p><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view">Scroll target
-  into view</a>, with <em>behavior</em> set to "auto", <em>block</em> set to "start", and <em>inline</em> set to "nearest".</p>
-        <div class="note" role="note"> This otherwise case is the same as the current step 3.3. </div>
-      </ol>
+      <p>Run the focusing steps for target, with the Document’s viewport as the fallback target.</p>
+     <li data-md>
+      <p>Move the sequential focus navigation starting point to target.</p>
     </ol>
    </blockquote>
-   <p>Add the following steps to the beginning of the processing model for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document" id="ref-for-the-indicated-part-of-the-document①">the indicated part of the document</a>:</p>
+   <p>Add the following steps to the beginning of the processing model for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#html-document" id="ref-for-html-document">HTML Document</a>'s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">indicated part</a>:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html">[HTML]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
     <ol>
      <li data-md>
       <p>Let <var>fragment directive string</var> be the document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment directive</a>.</p>
      <li data-md>
-      <p>If the document’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①①">allowTextFragmentDirective</a> flag is true then:</p>
+      <p>If the document’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①⓪">allowTextFragmentDirective</a> flag is true then:</p>
       <ol>
        <li data-md>
         <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
@@ -1544,16 +1573,16 @@ the following:</p>
         <ol>
          <li data-md>
           <p>Let <var>range</var> be the first item of <var>ranges</var>.</p>
-          <div class="note" role="note"> The first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②">range</a> in <var>ranges</var> is specifically
-    scrolled into view. This <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range③">range</a>, along with the
+          <div class="note" role="note"> The first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range③">range</a> in <var>ranges</var> is specifically
+    scrolled into view. This <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range④">range</a>, along with the
     remaining <var>ranges</var> should be visually indicated in a way that
     is not revealed to script, which is left as UA-defined behavior. </div>
          <li data-md>
           <p>Let <var>node</var> be the <a data-link-type="dfn" href="#first-common-ancestor" id="ref-for-first-common-ancestor">first common ancestor</a> of <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node">start node</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node">end node</a>.</p>
          <li data-md>
-          <p>While <var>node</var> is non-null and is not an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element①">element</a>, set <var>node</var> to <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent">parent</a>.</p>
+          <p>While <var>node</var> is non-null and is not an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element②">element</a>, set <var>node</var> to <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent">parent</a>.</p>
          <li data-md>
-          <p>The indicated part of the document is <var>node</var> and <var>range</var>; return.</p>
+          <p>The indicated part is <var>node</var> and <var>range</var>; return.</p>
         </ol>
       </ol>
     </ol>
@@ -1585,18 +1614,18 @@ ancestor</a> of <var>nodeB</var>, let <var>commonAncestor</var> be <var>commonAn
   to separate the steps for scrolling a DOMRect into view, so it can be used to
   scroll a Range into view. </div>
    <p>Move the <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view②">scroll an element into view</a> algorithm’s steps
-3-14 into a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-domrect-into-view">scroll a DOMRect into view</dfn>, with input <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrect" id="ref-for-domrect">DOMRect</a></code> <var>bounding box</var>, <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions" id="ref-for-dictdef-scrollintoviewoptions">ScrollIntoViewOptions</a></code> dictionary <var>options</var>, and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element②">element</a> <var>startingElement</var>.</p>
+3-14 into a new algorithm <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-domrect-into-view">scroll a DOMRect into view</dfn>, with input <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrect" id="ref-for-domrect">DOMRect</a></code> <var>bounding box</var>, <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions" id="ref-for-dictdef-scrollintoviewoptions">ScrollIntoViewOptions</a></code> dictionary <var>options</var>, and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element③">element</a> <var>startingElement</var>.</p>
    <p>Also move the recursive behavior described at the top of the <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view③">scroll an element into view</a> algorithm to the <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view">scroll a
 DOMRect into view</a> algorithm: "run these steps for each ancestor element or
 viewport <b>of <var>startingElement</var></b> that establishes a scrolling box <var>scrolling box</var>, in order of innermost to outermost scrolling box".</p>
    <div class="note" role="note"> <var>bounding box</var> is renamed from <var>element bounding border box</var>. </div>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-cssom-view">[CSSOM-VIEW]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-cssom-view" title="CSSOM View Module">[CSSOM-VIEW]</a>:</strong></p>
     <p>To scroll a DOMRect into view given a <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrect" id="ref-for-domrect①">DOMRect</a></code> <var>bounding box</var>,
   a scroll behavior <var>behavior</var>,
   a block flow direction position <var>block</var>,
   and an inline base direction position <var>inline</var>,
-  and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element③">element</a> <var>startingElement</var>, means to run these steps for each ancestor element or viewport of <var>startingElement</var> that establishes
+  and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element④">element</a> <var>startingElement</var>, means to run these steps for each ancestor element or viewport of <var>startingElement</var> that establishes
   a scrolling box <var>scrolling box</var>, in order of innermost to outermost scrolling box:</p>
     <p><em>OMITTED</em></p>
     <div class="note" role="note"> TODO: There’s more to do here since the <var>bounding box</var> needs to be
@@ -1604,7 +1633,7 @@ viewport <b>of <var>startingElement</var></b> that establishes a scrolling box <
    </blockquote>
    <p>Replace steps 3-14 of the <a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element-into-view" id="ref-for-scroll-an-element-into-view④">scroll an element into view</a> algorithm with a call to <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view①">scroll a DOMRect into view</a>:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-cssom-view">[CSSOM-VIEW]</a>:</strong></p>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-cssom-view" title="CSSOM View Module">[CSSOM-VIEW]</a>:</strong></p>
     <p>To scroll an element into view <var>element</var>,
   with a scroll behavior <var>behavior</var>,
   a block flow direction position <var>block</var>,
@@ -1619,14 +1648,14 @@ viewport <b>of <var>startingElement</var></b> that establishes a scrolling box <
       <p>Perform <a data-link-type="dfn" href="#scroll-a-domrect-into-view" id="ref-for-scroll-a-domrect-into-view②">scroll a DOMRect into view</a> given <var>element bounding border box</var>, <var>options</var> and <var>element</var>.</p>
     </ol>
    </blockquote>
-   <p>Define a new algorithm for scrolling <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range④">Range</a> into view:</p>
+   <p>Define a new algorithm for scrolling <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑤">Range</a> into view:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-cssom-view">[CSSOM-VIEW]</a>:</strong></p>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-range-into-view">scroll a Range into view</dfn>, with input <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑤">range</a> <var>range</var>,
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-cssom-view" title="CSSOM View Module">[CSSOM-VIEW]</a>:</strong></p>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="scroll-a-range-into-view">scroll a Range into view</dfn>, with input <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑥">range</a> <var>range</var>,
   scroll behavior <var>behavior</var>,
   a block flow direction position <var>block</var>,
   an inline base direction position <var>inline</var>,
-  and an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element④">element</a> <var>containingElement</var>:</p>
+  and an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element⑤">element</a> <var>containingElement</var>:</p>
     <ol>
      <li data-md>
       <p>Let <var>bounding rect</var> be the <code class="idl"><a data-link-type="idl" href="https://drafts.fxtf.org/geometry-1/#domrect" id="ref-for-domrect②">DOMRect</a></code> that is the return value of
@@ -1638,7 +1667,7 @@ viewport <b>of <var>startingElement</var></b> that establishes a scrolling box <
    <h4 class="heading settled" data-level="3.5.2" id="finding-ranges-in-a-document"><span class="secno">3.5.2. </span><span class="content">Finding Ranges in a Document</span><a class="self-link" href="#finding-ranges-in-a-document"></a></h4>
    <div class="note" role="note">
      This section outlines several algorithms and definitions that specify how to
-  turn a full fragment directive string into a list of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑥">Ranges</a> in the
+  turn a full fragment directive string into a list of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑦">Ranges</a> in the
   document. 
     <p>At a high level, we take a fragment directive string that looks like this:</p>
 <pre>text=prefix-,foo&amp;unknown&amp;text=bar,baz
@@ -1651,9 +1680,9 @@ text=bar,baz
   instance of rendered text that matches the restrictions in the directive.
   Each search is independent of any others; that is, the result is the same
   regardless of how many other directives are provided or their match result.</p>
-    <p>If a directive successfully matches to text in the document, it returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑦">range</a> indicating that match in the document. The <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive①">process a fragment
+    <p>If a directive successfully matches to text in the document, it returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑧">range</a> indicating that match in the document. The <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive①">process a fragment
   directive</a> steps are the high level API provided by this section. These
-  return a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑧">ranges</a> that were matched by the
+  return a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑨">ranges</a> that were matched by the
   individual directive matching steps, in the order the directives were
   specified in the fragment directive string.</p>
     <p>If a directive was not matched, it does not add an item to the returned
@@ -1663,7 +1692,7 @@ text=bar,baz
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a> <var>document</var>, run these steps: 
     <div class="note" role="note"> This algorithm takes as input a the <var>fragment directive input</var>, that is the
   raw text of the fragment directive and the <var>document</var> over which it operates.
-  It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑨">ranges</a> that are to be visually
+  It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⓪">ranges</a> that are to be visually
   indicated, the first of which may be scrolled into view (if the UA scrolls
   automatically). </div>
     <ol class="algorithm">
@@ -1675,7 +1704,7 @@ return an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#lis
 that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split">strictly splitting the
 string</a> <var>fragment directive input</var> on "&amp;".</p>
      <li data-md>
-      <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑥">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⓪">ranges</a>, initially empty.</p>
+      <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑥">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①①">ranges</a>, initially empty.</p>
      <li data-md>
       <p>For each <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a> <var>directive</var> of <var>directives</var>:</p>
       <ol>
@@ -1699,12 +1728,12 @@ directive</a> steps on <var>directive</var>.</p>
 following steps: 
     <div class="note" role="note">
       This algorithm takes as input a successfully parsed text directive and a
-  document in which to search. It returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①①">range</a> that points to the first
+  document in which to search. It returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①②">range</a> that points to the first
   text passage within the document that matches the searched-for text and
   satisfies the surrounding context. Returns null if no such passage exists. 
      <p><a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend①">textEnd</a> may be null. If omitted, this is an "exact"
-  search and the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①②">range</a> must contain a string exactly matching <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart②">textStart</a>. If <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend②">textEnd</a> is
-  provided, this is a "range" search; the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①③">range</a> must start with <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart③">textStart</a> and end with <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend③">textEnd</a>. In the normative text below, we’ll call a
+  search and the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①③">range</a> must contain a string exactly matching <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart②">textStart</a>. If <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend②">textEnd</a> is
+  provided, this is a "range" search; the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①④">range</a> must start with <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart③">textStart</a> and end with <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend③">textEnd</a>. In the normative text below, we’ll call a
   text passage that matches the provided <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart④">textStart</a> and <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend④">textEnd</a>, regardless of which mode we’re in, the
   "matching text".</p>
      <p>Either or both of <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix①">prefix</a> and <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix①">suffix</a> may be null, in which case context on that
@@ -1734,7 +1763,7 @@ following steps:
     </div>
     <ol class="algorithm">
      <li data-md>
-      <p>Let <var>searchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①④">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start">start</a> (<var>document</var>, 0) and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end">end</a> (<var>document</var>, <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length">length</a>)</p>
+      <p>Let <var>searchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑤">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start">start</a> (<var>document</var>, 0) and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end">end</a> (<var>document</var>, <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length">length</a>)</p>
      <li data-md>
       <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed">collapsed</a>:</p>
       <ol>
@@ -1751,7 +1780,7 @@ in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-lin
          <li data-md>
           <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after">after</a> <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start②">start</a></p>
          <li data-md>
-          <p>Let <var>matchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑤">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start③">start</a> is <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end②">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end③">end</a>.</p>
+          <p>Let <var>matchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑥">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start③">start</a> is <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end②">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end③">end</a>.</p>
          <li data-md>
           <p>Advance <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start④">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position">next non-whitespace position</a>.</p>
          <li data-md>
@@ -1791,7 +1820,7 @@ range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-t
           <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑧">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp①">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after①">after</a> <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑨">start</a></p>
         </ol>
        <li data-md>
-        <p>Let <var>rangeEndSearchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑥">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⓪">start</a> is <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑤">end</a> and whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑥">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑦">end</a>.</p>
+        <p>Let <var>rangeEndSearchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⓪">start</a> is <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑤">end</a> and whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑥">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑦">end</a>.</p>
        <li data-md>
         <p>While <var>rangeEndSearchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed②">collapsed</a>:</p>
         <ol>
@@ -1815,7 +1844,7 @@ represents a range exactly containing an instance of matching text.</p>
          <li data-md>
           <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix⑥">suffix</a> is null, return <var>potentialMatch</var>.</p>
          <li data-md>
-          <p>Let <var>suffixRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①①">start</a> equal to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⓪">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①①">end</a> equal to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①②">end</a>.</p>
+          <p>Let <var>suffixRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑧">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①①">start</a> equal to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⓪">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①①">end</a> equal to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①②">end</a>.</p>
          <li data-md>
           <p>Advance <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①②">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position①">next non-whitespace
 position</a>.</p>
@@ -1867,7 +1896,7 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-brea
     </ul>
    </details>
    <div class="algorithm" data-algorithm="advance range start to next non-whitespace position">
-     To advance a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑧">range</a> <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑥">start</a> to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="next non-whitespace position" data-noexport id="next-non-whitespace-position">next
+     To advance a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑨">range</a> <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑥">start</a> to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="next non-whitespace position" data-noexport id="next-non-whitespace-position">next
 non-whitespace position</dfn> follow the steps: 
     <ol class="algorithm">
      <li data-md>
@@ -1914,16 +1943,16 @@ not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text
     </ol>
    </div>
    <div class="algorithm" data-algorithm="find a string in a range">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-string-in-range">find a string in range</dfn> given a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a> <var>query</var>, a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑨">range</a> <var>searchRange</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>,
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-string-in-range">find a string in range</dfn> given a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a> <var>query</var>, a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⓪">range</a> <var>searchRange</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>,
 run these steps: 
-    <div class="note" role="note"> This algorithm will return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⓪">range</a> that represents the first instance of
+    <div class="note" role="note"> This algorithm will return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②①">range</a> that represents the first instance of
   the <var>query</var> text that is fully contained within <var>searchRange</var>, optionally
   restricting itself to matches that start and/or end at word boundaries (see <a href="#word-boundaries">§ 3.5.3 Word Boundaries</a>). Returns null if none is found. </div>
     <div class="note" role="note">
      <p> The basic premise of this algorithm is to walk all searchable text nodes
     within a block, collecting them into a list. The list is then concatenated
     into a single string in which we can search, using the node list to
-    determine offsets with a node so we can return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②①">range</a>. </p>
+    determine offsets with a node so we can return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②②">range</a>. </p>
      <p> Collection breaks when we hit a block node, e.g. searching over this tree: </p>
 <pre>&lt;div>
   a&lt;em>b&lt;/em>c&lt;div>d&lt;/div>e
@@ -1986,7 +2015,7 @@ order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.
           <p>Set <var>curNode</var> to the next node in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order④">shadow-including tree order</a>.</p>
         </ol>
        <li data-md>
-        <p>Run the <a data-link-type="dfn" href="#find-a-range-from-a-node-list" id="ref-for-find-a-range-from-a-node-list">find a range from a node list</a> steps given <var>query</var>, <var>searchRange</var>, <var>textNodeList</var>, <var>wordStartBounded</var> and <var>wordEndBounded</var> as input. If the resulting <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②②">range</a> is not null, then return it.</p>
+        <p>Run the <a data-link-type="dfn" href="#find-a-range-from-a-node-list" id="ref-for-find-a-range-from-a-node-list">find a range from a node list</a> steps given <var>query</var>, <var>searchRange</var>, <var>textNodeList</var>, <var>wordStartBounded</var> and <var>wordEndBounded</var> as input. If the resulting <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②③">range</a> is not null, then return it.</p>
        <li data-md>
         <p>If <var>curNode</var> is null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break③">break</a>.</p>
        <li data-md>
@@ -1999,7 +2028,7 @@ order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.
       <p>Return null.</p>
     </ol>
    </div>
-   <p>A node is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="search-invisible">search invisible</dfn> if it is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element⑤">element</a> in the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace">HTML
+   <p>A node is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="search-invisible">search invisible</dfn> if it is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element⑥">element</a> in the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace">HTML
 namespace</a> and meets any of the following conditions:</p>
    <ol>
     <li data-md>
@@ -2013,7 +2042,7 @@ namespace</a> and meets any of the following conditions:</p>
    </ol>
    <p>A node is part of a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="non-searchable-subtree">non-searchable subtree</dfn> if it is or has a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-ancestor" id="ref-for-concept-shadow-including-ancestor">shadow-including ancestor</a> that is <a data-link-type="dfn" href="#search-invisible" id="ref-for-search-invisible①">search invisible</a>.</p>
    <p>A node is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="visible-text-node">visible text node</dfn> if it is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text②">Text</a></code> node, the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value①">computed value</a> of its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#parent-element" id="ref-for-parent-element">parent element</a>'s <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-display-3/#propdef-visibility" id="ref-for-propdef-visibility">visibility</a> property is <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-visibility-visible" id="ref-for-valdef-visibility-visible">visible</a>, and it is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered" id="ref-for-being-rendered">being rendered</a>.</p>
-   <p>A node <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="has-block-level-display">has block-level display</dfn> if it is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element⑥">element</a> and the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value②">computed value</a> of its <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display①">display</a> property is any of <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-block" id="ref-for-valdef-display-block">block</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-table" id="ref-for-valdef-display-table">table</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root" id="ref-for-valdef-display-flow-root">flow-root</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-grid" id="ref-for-valdef-display-grid">grid</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flex" id="ref-for-valdef-display-flex">flex</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item" id="ref-for-valdef-display-list-item">list-item</a>.</p>
+   <p>A node <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="has-block-level-display">has block-level display</dfn> if it is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element⑦">element</a> and the <a data-link-type="dfn" href="https://drafts.csswg.org/css-cascade-5/#computed-value" id="ref-for-computed-value②">computed value</a> of its <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-display-3/#propdef-display" id="ref-for-propdef-display①">display</a> property is any of <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-block" id="ref-for-valdef-display-block">block</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-table" id="ref-for-valdef-display-table">table</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root" id="ref-for-valdef-display-flow-root">flow-root</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-grid" id="ref-for-valdef-display-grid">grid</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-flex" id="ref-for-valdef-display-flex">flex</a>, <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item" id="ref-for-valdef-display-list-item">list-item</a>.</p>
    <div class="algorithm" data-algorithm="nearest block ancestor">
      To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="nearest-block-ancestor">nearest block ancestor</dfn> of a <var>node</var> follow the steps: 
     <ol class="algorithm">
@@ -2034,7 +2063,7 @@ return <var>curNode</var>.</p>
    </div>
    <div class="algorithm" data-algorithm="range from node list">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-node-list">find a range from a node list</dfn> given a search string <var>queryString</var>,
-a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②③">range</a> <var>searchRange</var>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑧">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text④">Text</a></code> nodes <var>nodes</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>, follow these steps: 
+a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②④">range</a> <var>searchRange</var>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑧">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text④">Text</a></code> nodes <var>nodes</var>, and booleans <var>wordStartBounded</var> and <var>wordEndBounded</var>, follow these steps: 
     <div class="note" role="note">
       Optionally, this will only return a match if the matched text begins and/or
   ends on a <a data-link-type="dfn" href="#word-boundary" id="ref-for-word-boundary">word boundary</a>. For example: 
@@ -2071,7 +2100,7 @@ set <var>searchStart</var> to <var>searchRange</var>’s <a data-link-type="dfn"
        <li data-md>
         <p>Set <var>matchIndex</var> to the index of the first instance of <var>queryString</var> in <var>searchBuffer</var>, starting at <var>searchStart</var>. The string search must be
 performed using a base character comparison, or the <a href="http://www.unicode.org/reports/tr10/#Multi_Level_Comparison">primary
-level</a>, as defined in <a data-link-type="biblio" href="#biblio-uts10">[UTS10]</a>.</p>
+level</a>, as defined in <a data-link-type="biblio" href="#biblio-uts10" title="Unicode Collation Algorithm">[UTS10]</a>.</p>
         <div class="note" role="note"> Intuitively, this is a case-insensitive search also ignoring accents, umlauts,
   and other marks. </div>
        <li data-md>
@@ -2108,7 +2137,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
      <li data-md>
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert⑤">Assert</a>: <var>start</var> and <var>end</var> are non-null, valid <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑦">boundary points</a> in <var>searchRange</var>.</p>
      <li data-md>
-      <p>Return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②④">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑧">start</a> <var>start</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⑤">end</a> <var>end</var>.</p>
+      <p>Return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⑤">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑧">start</a> <var>start</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⑤">end</a> <var>end</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="boundary point at index">
@@ -2151,7 +2180,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
   proposal to specify unicode segmentation, including word segmentation. Once
   specified, this algorithm may be improved by making use of the Intl.Segmenter
   API for word boundary matching. </div>
-   <p> A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-boundary">word boundary</dfn> is defined in <a data-link-type="biblio" href="#biblio-uax29">[UAX29]</a> in <a href="https://www.unicode.org/reports/tr29/tr29-39.html#Word_Boundaries">Unicode Text Segmentation § Word_Boundaries</a>. <a href="https://www.unicode.org/reports/tr29/tr29-39.html#Default_Word_Boundaries">Unicode Text Segmentation § Default_Word_Boundaries</a> defines a
+   <p> A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-boundary">word boundary</dfn> is defined in <a data-link-type="biblio" href="#biblio-uax29" title="Unicode Text Segmentation">[UAX29]</a> in <a href="https://www.unicode.org/reports/tr29/tr29-41.html#Word_Boundaries">Unicode Text Segmentation § Word_Boundaries</a>. <a href="https://www.unicode.org/reports/tr29/tr29-41.html#Default_Word_Boundaries">Unicode Text Segmentation § Default_Word_Boundaries</a> defines a
   default set of what constitutes a word boundary, but as the specification
   mentions, a more sophisticated algorithm should be used based on the locale. </p>
    <p> Dictionary-based word bounding should take specific care in locales without a
@@ -2160,7 +2189,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
   word from the next. In such cases, and where the alphabet contains fewer
   than 100 characters, the dictionary must not contain more than 20% of the
   alphabet as valid, one-letter words. </p>
-   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="locale">locale</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> containing a valid <a data-link-type="biblio" href="#biblio-bcp47">[BCP47]</a> language tag, or the empty string. An empty string indicates that the primary
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="locale">locale</dfn> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> containing a valid <a data-link-type="biblio" href="#biblio-bcp47" title="Tags for Identifying Languages">[BCP47]</a> language tag, or the empty string. An empty string indicates that the primary
 language is unknown.</p>
    <p>A substring is <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-bounded">word bounded</dfn> in a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a> <var>text</var>,
 given <a data-link-type="dfn" href="#locale" id="ref-for-locale">locales</a> <var>startLocale</var> and <var>endLocale</var>, if both the position of its
@@ -2270,19 +2299,19 @@ typically by providing the URL to another app or messaging service.</p>
 directive</a> if, and only if, a match was found and the visual indicator hasn’t
 been dismissed.</p>
    <h3 class="heading settled" data-level="3.7" id="document-policy-integration"><span class="secno">3.7. </span><span class="content">Document Policy Integration</span><a class="self-link" href="#document-policy-integration"></a></h3>
-   <p>This specification defines a <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point">configuration point</a> in <a data-link-type="biblio" href="#biblio-document-policy">Document Policy</a> with name "force-load-at-top". Its <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point-type">type</a> is <code>boolean</code> with <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point-default-value">default value</a> <code>false</code>.</p>
+   <p>This specification defines a <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point">configuration point</a> in <a data-link-type="biblio" href="#biblio-document-policy" title="Document Policy">Document Policy</a> with name "force-load-at-top". Its <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point-type">type</a> is <code>boolean</code> with <a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#configuration-point-default-value">default value</a> <code>false</code>.</p>
    <div class="note" role="note"> When enabled, this policy disables all automatic scroll-on-load features:
   text-fragments, element fragments, history scroll restoration. </div>
-   <div class="example" id="example-ae692635">
-    <a class="self-link" href="#example-ae692635"></a> Suppose the user navigates to <code>https://example.com#:~:text=foo</code>. The
+   <div class="example" id="example-a128f34b">
+    <a class="self-link" href="#example-a128f34b"></a> Suppose the user navigates to <code>https://example.com#:~:text=foo</code>. The
   example.com server response includes the header: 
 <pre>Document-Policy: force-load-at-top
 </pre>
     <p>When the page loads, the element containing "foo" will be marked as the
-  indicated part of the document and set as the document’s target element.
-  However, "foo" will not be scrolled into view.</p>
+  indicated part and set as the document’s target element. However, "foo"
+  will not be scrolled into view.</p>
    </div>
-   <p>Fragment-based scroll blocking from this policy is specified in an amendment to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier③">scroll to the fragment</a> algorithm in the <a href="#navigating-to-text-fragment">§ 3.5 Navigating to a Text Fragment</a> section of this document.</p>
+   <p>Fragment-based scroll blocking from this policy is specified in an amendment to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier②">scroll to the fragment</a> algorithm in the <a href="#navigating-to-text-fragment">§ 3.5 Navigating to a Text Fragment</a> section of this document.</p>
    <p>History scroll restoration is blocked by amending the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state" id="ref-for-restore-persisted-state">restore
 persisted state</a> steps by inserting a new step after 2:</p>
    <ol start="3">
@@ -2290,9 +2319,7 @@ persisted state</a> steps by inserting a new step after 2:</p>
      <p><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
 the document policy value</a> of the "force-load-at-top" feature for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑤">Document</a>. If
 the result is true, then the user agent should not restore the scroll
-position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑥">Document</a> or any of its scrollable regions. Scroll
-positions for <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#child-browsing-context" id="ref-for-child-browsing-context">child browsing contexts</a> should be restored based on the
-value of this policy in the child <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑦">Document</a>.</p>
+position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑥">Document</a> or any of its scrollable regions.</p>
    </ol>
    <h3 class="heading settled" data-level="3.8" id="feature-detectability"><span class="secno">3.8. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
@@ -2426,7 +2453,7 @@ match based on whether the element-id was scrolled.</p>
     However, for readability,
     these words do not appear in all uppercase letters in this specification. </p>
    <p>All of the text of this specification is normative
-    except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
+    except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">[RFC2119]</a> </p>
    <p>Examples in this specification are introduced with the words “for example”
     or are set apart from the normative text
     with <code>class="example"</code>,
@@ -2594,6 +2621,12 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-dictdef-scrollintoviewoptions">3.5.1. Scroll a DOMRect into view</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect">
+   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-element-getboundingclientrect">3.5.1. Scroll a DOMRect into view</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-dom-range-getboundingclientrect">
    <a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
@@ -2655,10 +2688,11 @@ match based on whether the element-id was scrolled.</p>
    <ul>
     <li><a href="#ref-for-concept-document">3.3. The Fragment Directive</a>
     <li><a href="#ref-for-concept-document①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a>
-    <li><a href="#ref-for-concept-document④">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document⑤">(2)</a> <a href="#ref-for-concept-document⑥">(3)</a> <a href="#ref-for-concept-document⑦">(4)</a> <a href="#ref-for-concept-document⑧">(5)</a> <a href="#ref-for-concept-document⑨">(6)</a> <a href="#ref-for-concept-document①⓪">(7)</a> <a href="#ref-for-concept-document①①">(8)</a>
+    <li><a href="#ref-for-concept-document④">3.4.3. Search Timing</a>
+    <li><a href="#ref-for-concept-document⑤">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document⑥">(2)</a> <a href="#ref-for-concept-document⑦">(3)</a> <a href="#ref-for-concept-document⑧">(4)</a> <a href="#ref-for-concept-document⑨">(5)</a> <a href="#ref-for-concept-document①⓪">(6)</a> <a href="#ref-for-concept-document①①">(7)</a>
     <li><a href="#ref-for-concept-document①②">3.5. Navigating to a Text Fragment</a>
     <li><a href="#ref-for-concept-document①③">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-document①④">(2)</a>
-    <li><a href="#ref-for-concept-document①⑤">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①⑥">(2)</a> <a href="#ref-for-concept-document①⑦">(3)</a>
+    <li><a href="#ref-for-concept-document①⑤">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document-element">
@@ -2670,9 +2704,9 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-concept-element">
    <a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-element">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-element①">(2)</a>
-    <li><a href="#ref-for-concept-element②">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-concept-element③">(2)</a> <a href="#ref-for-concept-element④">(3)</a>
-    <li><a href="#ref-for-concept-element⑤">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-element⑥">(2)</a>
+    <li><a href="#ref-for-concept-element">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-element①">(2)</a> <a href="#ref-for-concept-element②">(3)</a>
+    <li><a href="#ref-for-concept-element③">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-concept-element④">(2)</a> <a href="#ref-for-concept-element⑤">(3)</a>
+    <li><a href="#ref-for-concept-element⑥">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-element⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-range-end">
@@ -2704,6 +2738,12 @@ match based on whether the element-id was scrolled.</p>
    <a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-documentfragment-host">3.5. Navigating to a Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-html-document">
+   <a href="https://dom.spec.whatwg.org/#html-document">https://dom.spec.whatwg.org/#html-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-html-document">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-node-length">
@@ -2740,9 +2780,9 @@ match based on whether the element-id was scrolled.</p>
   <aside class="dfn-panel" data-for="term-for-concept-range">
    <a href="https://dom.spec.whatwg.org/#concept-range">https://dom.spec.whatwg.org/#concept-range</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-range①">(2)</a> <a href="#ref-for-concept-range②">(3)</a> <a href="#ref-for-concept-range③">(4)</a>
-    <li><a href="#ref-for-concept-range④">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-concept-range⑤">(2)</a>
-    <li><a href="#ref-for-concept-range⑥">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range⑦">(2)</a> <a href="#ref-for-concept-range⑧">(3)</a> <a href="#ref-for-concept-range⑨">(4)</a> <a href="#ref-for-concept-range①⓪">(5)</a> <a href="#ref-for-concept-range①①">(6)</a> <a href="#ref-for-concept-range①②">(7)</a> <a href="#ref-for-concept-range①③">(8)</a> <a href="#ref-for-concept-range①④">(9)</a> <a href="#ref-for-concept-range①⑤">(10)</a> <a href="#ref-for-concept-range①⑥">(11)</a> <a href="#ref-for-concept-range①⑦">(12)</a> <a href="#ref-for-concept-range①⑧">(13)</a> <a href="#ref-for-concept-range①⑨">(14)</a> <a href="#ref-for-concept-range②⓪">(15)</a> <a href="#ref-for-concept-range②①">(16)</a> <a href="#ref-for-concept-range②②">(17)</a> <a href="#ref-for-concept-range②③">(18)</a> <a href="#ref-for-concept-range②④">(19)</a>
+    <li><a href="#ref-for-concept-range">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-range①">(2)</a> <a href="#ref-for-concept-range②">(3)</a> <a href="#ref-for-concept-range③">(4)</a> <a href="#ref-for-concept-range④">(5)</a>
+    <li><a href="#ref-for-concept-range⑤">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-concept-range⑥">(2)</a>
+    <li><a href="#ref-for-concept-range⑦">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range⑧">(2)</a> <a href="#ref-for-concept-range⑨">(3)</a> <a href="#ref-for-concept-range①⓪">(4)</a> <a href="#ref-for-concept-range①①">(5)</a> <a href="#ref-for-concept-range①②">(6)</a> <a href="#ref-for-concept-range①③">(7)</a> <a href="#ref-for-concept-range①④">(8)</a> <a href="#ref-for-concept-range①⑤">(9)</a> <a href="#ref-for-concept-range①⑥">(10)</a> <a href="#ref-for-concept-range①⑦">(11)</a> <a href="#ref-for-concept-range①⑧">(12)</a> <a href="#ref-for-concept-range①⑨">(13)</a> <a href="#ref-for-concept-range②⓪">(14)</a> <a href="#ref-for-concept-range②①">(15)</a> <a href="#ref-for-concept-range②②">(16)</a> <a href="#ref-for-concept-range②③">(17)</a> <a href="#ref-for-concept-range②④">(18)</a> <a href="#ref-for-concept-range②⑤">(19)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-shadow-root">
@@ -2817,6 +2857,148 @@ match based on whether the element-id was scrolled.</p>
    <a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrect">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-domrect①">(2)</a> <a href="#ref-for-domrect②">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlaudioelement">
+   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement">https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlaudioelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmliframeelement">
+   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmliframeelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlimageelement">
+   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlimageelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlmeterelement">
+   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlmeterelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlobjectelement">
+   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlobjectelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlprogresselement">
+   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlprogresselement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlscriptelement">
+   <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlscriptelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlstyleelement">
+   <a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlstyleelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
+   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-htmlvideoelement">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-location">
+   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-location">3.3.1. Processing the fragment directive</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-nav-document">
+   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-nav-document">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-nav-document①">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-nav-document②">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-being-rendered">
+   <a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-being-rendered">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
+   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-bc">3.4.4. Restricting the Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-browsing-context-set">
+   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-browsing-context-set">3.4.4. Restricting the Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-language">
+   <a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-language">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-language①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-attr-select-multiple">
+   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple">https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-attr-select-multiple">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-restore-persisted-state">
+   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state">https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-restore-persisted-state">3.7. Document Policy Integration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-scroll-to-the-fragment-identifier">
+   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier">https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier">3.4.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier①">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier②">3.7. Document Policy Integration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-the-select-element">
+   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-the-select-element">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-serializes-as-void">
+   <a href="https://html.spec.whatwg.org/multipage/parsing.html#serializes-as-void">https://html.spec.whatwg.org/multipage/parsing.html#serializes-as-void</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-serializes-as-void">3.5.2. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-top-level-browsing-context">3.4.4. Restricting the Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-transient-activation">
+   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-transient-activation">3.4.4. Restricting the Text Fragment</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-try-to-scroll-to-the-fragment">
+   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-try-to-scroll-to-the-fragment">3.4.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-try-to-scroll-to-the-fragment①">3.6. Indicating The Text Match</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-list-append">
@@ -2982,6 +3164,7 @@ match based on whether the element-id was scrolled.</p>
     <a data-link-type="biblio">[CSSOM-VIEW]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-dictdef-scrollintoviewoptions">ScrollIntoViewOptions</span>
+     <li><span class="dfn-paneled" id="term-for-dom-element-getboundingclientrect">getBoundingClientRect() <small>(for Element)</small></span>
      <li><span class="dfn-paneled" id="term-for-dom-range-getboundingclientrect">getBoundingClientRect() <small>(for Range)</small></span>
      <li><span class="dfn-paneled" id="term-for-scroll-an-element-into-view">scroll an element into view</span>
     </ul>
@@ -3003,6 +3186,7 @@ match based on whether the element-id was scrolled.</p>
      <li><span class="dfn-paneled" id="term-for-concept-range-end-offset">end offset</span>
      <li><span class="dfn-paneled" id="term-for-concept-tree-following">following</span>
      <li><span class="dfn-paneled" id="term-for-concept-documentfragment-host">host</span>
+     <li><span class="dfn-paneled" id="term-for-html-document">html document</span>
      <li><span class="dfn-paneled" id="term-for-concept-node-length">length</span>
      <li><span class="dfn-paneled" id="term-for-boundary-point-node">node</span>
      <li><span class="dfn-paneled" id="term-for-concept-node-document">node document</span>
@@ -3029,6 +3213,33 @@ match based on whether the element-id was scrolled.</p>
     <a data-link-type="biblio">[GEOMETRY-1]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-domrect">DOMRect</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-htmlaudioelement">HTMLAudioElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmliframeelement">HTMLIFrameElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlimageelement">HTMLImageElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlmeterelement">HTMLMeterElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlobjectelement">HTMLObjectElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlprogresselement">HTMLProgressElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlscriptelement">HTMLScriptElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlstyleelement">HTMLStyleElement</span>
+     <li><span class="dfn-paneled" id="term-for-htmlvideoelement">HTMLVideoElement</span>
+     <li><span class="dfn-paneled" id="term-for-location">Location</span>
+     <li><span class="dfn-paneled" id="term-for-nav-document">active document</span>
+     <li><span class="dfn-paneled" id="term-for-being-rendered">being rendered</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-bc">browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-browsing-context-set">browsing context set</span>
+     <li><span class="dfn-paneled" id="term-for-language">language</span>
+     <li><span class="dfn-paneled" id="term-for-attr-select-multiple">multiple</span>
+     <li><span class="dfn-paneled" id="term-for-restore-persisted-state">restore persisted state</span>
+     <li><span class="dfn-paneled" id="term-for-scroll-to-the-fragment-identifier">scroll to the fragment</span>
+     <li><span class="dfn-paneled" id="term-for-the-select-element">select</span>
+     <li><span class="dfn-paneled" id="term-for-serializes-as-void">serializes as void</span>
+     <li><span class="dfn-paneled" id="term-for-top-level-browsing-context">top-level browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-transient-activation">transient activation</span>
+     <li><span class="dfn-paneled" id="term-for-try-to-scroll-to-the-fragment">try to scroll to the fragment</span>
     </ul>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
@@ -3089,11 +3300,11 @@ match based on whether the element-id was scrolled.</p>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-uax29">[UAX29]
-   <dd>Mark Davis; Christopher Chapman. <a href="https://www.unicode.org/reports/tr29/tr29-39.html"><cite>Unicode Text Segmentation</cite></a>. 24 August 2021. Unicode Standard Annex #29. URL: <a href="https://www.unicode.org/reports/tr29/tr29-39.html">https://www.unicode.org/reports/tr29/tr29-39.html</a>
+   <dd>Christopher Chapman. <a href="https://www.unicode.org/reports/tr29/tr29-41.html"><cite>Unicode Text Segmentation</cite></a>. 26 August 2022. Unicode Standard Annex #29. URL: <a href="https://www.unicode.org/reports/tr29/tr29-41.html">https://www.unicode.org/reports/tr29/tr29-41.html</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-uts10">[UTS10]
-   <dd>Ken Whistler; Markus Scherer. <a href="https://www.unicode.org/reports/tr10/tr10-45.html"><cite>Unicode Collation Algorithm</cite></a>. 27 August 2021. Unicode Technical Standard #10. URL: <a href="https://www.unicode.org/reports/tr10/tr10-45.html">https://www.unicode.org/reports/tr10/tr10-45.html</a>
+   <dd>Ken Whistler; Markus Scherer. <a href="https://www.unicode.org/reports/tr10/tr10-47.html"><cite>Unicode Collation Algorithm</cite></a>. 26 August 2022. Unicode Technical Standard #10. URL: <a href="https://www.unicode.org/reports/tr10/tr10-47.html">https://www.unicode.org/reports/tr10/tr10-47.html</a>
    <dt id="biblio-webidl">[WEBIDL]
    <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
   </dl>
@@ -3291,8 +3502,8 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
   <aside class="dfn-panel" data-for="document-allowtextfragmentdirective">
    <b><a href="#document-allowtextfragmentdirective">#document-allowtextfragmentdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-allowtextfragmentdirective">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allowtextfragmentdirective①">(2)</a> <a href="#ref-for-document-allowtextfragmentdirective②">(3)</a> <a href="#ref-for-document-allowtextfragmentdirective③">(4)</a> <a href="#ref-for-document-allowtextfragmentdirective④">(5)</a> <a href="#ref-for-document-allowtextfragmentdirective⑤">(6)</a> <a href="#ref-for-document-allowtextfragmentdirective⑥">(7)</a> <a href="#ref-for-document-allowtextfragmentdirective⑦">(8)</a> <a href="#ref-for-document-allowtextfragmentdirective⑧">(9)</a> <a href="#ref-for-document-allowtextfragmentdirective⑨">(10)</a> <a href="#ref-for-document-allowtextfragmentdirective①⓪">(11)</a>
-    <li><a href="#ref-for-document-allowtextfragmentdirective①①">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-document-allowtextfragmentdirective">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allowtextfragmentdirective①">(2)</a> <a href="#ref-for-document-allowtextfragmentdirective②">(3)</a> <a href="#ref-for-document-allowtextfragmentdirective③">(4)</a> <a href="#ref-for-document-allowtextfragmentdirective④">(5)</a> <a href="#ref-for-document-allowtextfragmentdirective⑤">(6)</a> <a href="#ref-for-document-allowtextfragmentdirective⑥">(7)</a> <a href="#ref-for-document-allowtextfragmentdirective⑦">(8)</a> <a href="#ref-for-document-allowtextfragmentdirective⑧">(9)</a> <a href="#ref-for-document-allowtextfragmentdirective⑨">(10)</a>
+    <li><a href="#ref-for-document-allowtextfragmentdirective①⓪">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="first-common-ancestor">
@@ -3477,12 +3688,13 @@ document.body.addEventListener("click", function(e) {
 </script>
 <script>/* script-var-click-highlighting */
 
-    document.addEventListener("click", e=>{
-        if(e.target.nodeName == "VAR") {
-            highlightSameAlgoVars(e.target);
-        }
-    });
+    "use strict";
     {
+        document.addEventListener("click", e=>{
+            if(e.target.nodeName == "VAR") {
+                highlightSameAlgoVars(e.target);
+            }
+        });
         const indexCounts = new Map();
         const indexNames = new Map();
         function highlightSameAlgoVars(v) {


### PR DESCRIPTION
Update the spec with upstream changes in HTML spec (revealed by Bikeshed errors).

In particular:

* "session history" is no longer a concept on browsing context. This patch removes the entire step referencing it in 'create and initialize a Document object' since it's checking for a same-document navigation. This doesn't make sense in the _create_ Document steps.
* "indicated part of the document" is now a Document's "indicated part". Also cleaned up the relevant sections as they were updated and made it clearer what's being replaced/removed/kept.
* "child browsing contexts" is also no longer a concept. The bit of prose referencing it is removed since the session history entry doesn't restore scrollable regions that are navigable containers (i.e. what we previously would have called a child browsing context).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/ScrollToTextFragment/pull/200.html" title="Last updated on Dec 20, 2022, 9:31 PM UTC (7bd2b82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/200/01abe25...bokand:7bd2b82.html" title="Last updated on Dec 20, 2022, 9:31 PM UTC (7bd2b82)">Diff</a>