### PR TITLE
[Spec] Fix naming of textFragmentActivationFlag

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -699,37 +699,35 @@ to find and set the [=Document=]'s indicated part.
 ### Restricting the Text Fragment ### {#restricting-the-text-fragment}
 
 Amend the definition of a [=/request=] and of a [=Document=] to include a new
-[=document/textFragmentActivationFlag=] field:
+boolean [=document/text fragment activation=] field:
 
 >   <strong>Monkeypatching [[FETCH]]:</strong>
 >
->   A [=/request=] has an associated <dfn for="request">textFragmentActivationFlag</dfn>.
+>   A [=/request=] has an associated boolean <dfn for="request">text fragment activation</dfn>,
+>   initially false.
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   A [=Document=] has a <dfn for="document">textFragmentActivationFlag</dfn> that is
->   consumed in order to allow a single activation of a text fragment. This flag is
->   set during document loading only if the navigation occurred as a result of a user
->   activation.
+>   Each [=Document=] has a <dfn for="document">text fragment activation</dfn>, which is a boolean,
+>   initially false.
 >
->   If the [=Document=]'s [=document/textFragmentActivationFlag=] isn't consumed to activate
->   a text fragment, it may be consumed to set the [=request/textFragmentActivationFlag=]
->   flag of a navigation [=/request=]. In this way, a [=document/textFragmentActivationFlag=]
->   can be propagated from one [=Document=] to another across a navigation.
+>   <div class="note">
+>     [=document/text fragment activation=] is consumed in order to allow a single activation of a
+>     text fragment. It is set during document loading only if the navigation occurred as a result
+>     of a user activation and can be propagated across client-side redirects.
 >
->   Reading either the [=Document=]'s [=document/textFragmentActivationFlag=] or the
->   [=/request=]'s [=request/textFragmentActivationFlag=] flag must always consume the value by
->   setting it to false, such that the flag cannot be reused.
+>     If a [=Document=]'s [=document/text fragment activation=] isn't consumed to activate
+>     a text fragment, it may be consumed to set the [=request/text fragment activation=]
+>     flag of a navigation [=/request=]. In this way, a [=document/text fragment activation=]
+>     can be propagated from one [=Document=] to another across a navigation.
+>
+>     Reading either the [=Document=]'s [=document/text fragment activation=] or the
+>     [=/request=]'s [=request/text fragment activation=] flag always consumes the value by
+>     setting it to false, such that a single activation cannot be reused to activate more than one
+>     text fragment.
+>   </div>
 
 <div class="note">
-  <p>
-    [=document/textFragmentActivationFlag=] is set to true when a [=Document=] is loaded
-    as a result of a user gesture. It grants permission (in terms of
-    user activation) to scroll a single text fragment. Alternatively, it may be
-    propagated through a navigation to allow a future document to scroll a text
-    fragment from this navigation's user gesture.
-  </p>
-
   <p>
     This mechanism allows text fragments to activate through a common redirect
     technique used by many popular web sites. Such sites redirect users to
@@ -740,7 +738,7 @@ Amend the definition of a [=/request=] and of a [=Document=] to include a new
   <p>
     Unlike real HTTP (<tt>status 3xx</tt>) redirects, these "client-side"
     redirects cannot propagate the fact that the navigation is the result of a
-    user gesture. The [=document/textFragmentActivationFlag=] mechanism allows passing
+    user gesture. The [=document/text fragment activation=] mechanism allows passing
     through this specifically scoped user-activation through such navigations.
     This means a page can programmatically navigate to a text fragment, a
     single time, as if it has a user gesture. However, further navigations
@@ -762,20 +760,23 @@ Amend the definition of a [=/request=] and of a [=Document=] to include a new
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   A [=Document=] has an <dfn for="document">allowTextFragmentDirective</dfn>
->   flag that is used to determine whether a text fragment directive should be
->   allowed to activate. If this flag is false, the text fragment must not
->   cause any observable effects.
+>   Each [=Document=] has an <dfn for="document">allow text fragment</dfn>, which is a
+>   boolean, initially false.
+>   <div class="note">
+>     [=document/allow text fragment=] is used to determine whether a text fragment
+>     should be allowed to activate. If it is false, the text fragment must not cause any
+>     observable effects.
+>   </div>
 
 <div class="note">
   <p>
-    [=document/textFragmentActivationFlag=] is analogous to a user-activation state
-    while [=allowTextFragmentDirective=] is more comprehensive, taking into
-    account various pieces of information, one of which is the existence of a
-    textFragmentActivationFlag.
+    [=document/text fragment activation=] is analogous to a user-activation state
+    while [=document/allow text fragment=] is more comprehensive, taking into
+    account various pieces of information, one of which is the value of
+    text fragment activation.
   </p>
   <p>
-    The reason we compute allowTextFragmentDirective and keep it as a flag,
+    The reason we compute and store allow text fragment,
     rather than performing the checks at the time of use, is that it relies on
     the properties of the navigation while the invocation will occur as part of
     the <a spec=HTML>scroll to the fragment</a> steps which can happen outside
@@ -795,7 +796,7 @@ and initialize a Document object</a> steps by adding the following steps before 
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   15. Set |document|'s [=document/textFragmentActivationFlag=] by following these sub-steps:
+>   15. Set |document|'s [=document/text fragment activation=] by following these sub-steps:
 >       1. Let |is user activated| be true if the current navigation was initiated from
 >           a window that had a <a spec="html">transient activation</a> at the time the
 >           navigation was initiated, or the UA has reason to believe it comes from a
@@ -806,25 +807,25 @@ and initialize a Document object</a> steps by adding the following steps before 
 >             <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a> in [[FETCH-METADATA]].
 >           </div>
 >       1. If <var ignore=''>browsing context</var> is a top-level browsing context and if either of |is
->           user activated| or the [=request/textFragmentActivationFlag=] of
+>           user activated| or the [=request/text fragment activation=] of
 >           |navigationParam|'s
 >           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
->           object is true, set the |document|'s [=document/textFragmentActivationFlag=]
+>           object is true, set the |document|'s [=document/text fragment activation=]
 >           to true. Otherwise, set it to false.
 >           <div class="note">
 >             It's important that the flag not be copyable so that only one text fragment can be
 >             activated per user-activated navigation.
 >           </div>
->   16. Set |document|'s [=document/allowTextFragmentDirective=] by following these sub-steps:
+>   16. Set |document|'s [=document/allow text fragment=] by following these sub-steps:
 >       1. If |document|'s [=fragment directive=] field is null or empty, set
->           [=document/allowTextFragmentDirective=] to false and abort these sub-steps.
->       1. Let |textFragmentActivationFlag| be the value of |document|'s
->           [=document/textFragmentActivationFlag=] and set |document|'s
->           [=document/textFragmentActivationFlag=] to false.
+>           [=document/allow text fragment=] to false and abort these sub-steps.
+>       1. Let |text fragment activation| be the value of |document|'s
+>           [=document/text fragment activation=] and set |document|'s
+>           [=document/text fragment activation=] to false.
 >       1. If the |navigationParam|'s
 >           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
 >           has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
->           header and its value is `"none"` set [=document/allowTextFragmentDirective=] to true and abort these sub-steps.
+>           header and its value is `"none"` set [=document/allow text fragment=] to true and abort these sub-steps.
 >           <div class="note">
 >             <p>
 >               If a navigation originates from browser UI, it's always ok to allow it
@@ -850,32 +851,32 @@ and initialize a Document object</a> steps by adding the following steps before 
 >               for a more detailed discussion of how this should apply.
 >             </p>
 >           </div>
->       1. If |textFragmentActivationFlag| is false, set
->           [=document/allowTextFragmentDirective=] to false and abort these sub-steps.
+>       1. If |text fragment activation| is false, set
+>           [=document/allow text fragment=] to false and abort these sub-steps.
 >       1. If the |navigationParam|'s
 >           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
 >           has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
 >           header and its value is `"same-origin"` set
->           [=document/allowTextFragmentDirective=] to true and abort these
+>           [=document/allow text fragment=] to true and abort these
 >           sub-steps.
 >       1. If |document|'s [=Document/browsing context=] is a [=top-level browsing
 >           context=] and its
 >           <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>'s
 >           <a spec=HTML>browsing context set</a> has length 1, set
->           [=document/allowTextFragmentDirective=] to true and abort these sub-steps.
+>           [=document/allow text fragment=] to true and abort these sub-steps.
 >           <div class="note">
 >             i.e. Only allow navigation from a cross-origin element/script if the
 >             document is loaded in a noopener context. That is, a new top level
 >             browsing context group to which the navigator does not have script access
 >             and which may be placed into a separate process.
 >           </div>
->       1. Otherwise, set [=document/allowTextFragmentDirective=] to false.
+>       1. Otherwise, set [=document/allow text fragment=] to false.
 
 Amend step 2 of the
 <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch">
 process a navigate fetch</a> steps to additionally set |request|'s
-[=request/textFragmentActivationFlag=] to the value of the [=active document=]'s
-[=document/textFragmentActivationFlag=] and set the [=active document=]'s value to
+[=request/text fragment activation=] to the value of the [=active document=]'s
+[=document/text fragment activation=] and set the [=active document=]'s value to
 false.
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
@@ -884,10 +885,10 @@ false.
 >       settings object, destination to "document", mode to "navigate", credentials
 >       mode to "include", use-URL-credentials flag, redirect mode to "manual",
 >       replaces client id to browsingContext's active document's relevant settings
->       object's id, and [=request/textFragmentActivationFlag=] to
+>       object's id, and [=request/text fragment activation=] to
 >       sourceBrowsingContext's active document's
->       [=document/textFragmentActivationFlag=]. Set sourceBrowsingContext's active
->       document's [=document/textFragmentActivationFlag=] to false.
+>       [=document/text fragment activation=]. Set sourceBrowsingContext's active
+>       document's [=document/text fragment activation=] to false.
 
 
 Amend the <a spec=HTML>try to scroll to the fragment</a> steps by replacing the
@@ -897,12 +898,12 @@ steps of the task queued in step 2:
 >
 >   1. If document has no parser, or its parser has stopped parsing, or the user
 >       agent has reason to believe the user is no longer interested in scrolling to
->       the fragment, then clear <em>document</em>'s
->       [=allowTextFragmentDirective=] flag and abort these steps.
+>       the fragment, then set <em>document</em>'s
+>       [=document/allow text fragment=] to false and abort these steps.
 >   2. Scroll to the fragment given in document's URL. If this does not find an
 >       indicated part, then try to scroll to the fragment for
 >       document.
->   3. Clear <em>document</em>'s [=allowTextFragmentDirective=] flag
+>   3. Set <em>document</em>'s [=document/allow text fragment=] to false.
 
 
 ## Navigating to a Text Fragment ## {#navigating-to-text-fragment}
@@ -988,7 +989,7 @@ so that the indicated part is a [=range=]:
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
 >   1. Let |fragment directive string| be the document's [=fragment directive=].
->   1. If the document's [=allowTextFragmentDirective=] flag is true then:
+>   1. If the document's [=document/allow text fragment=] is true then:
 >       1. Let |ranges| be a <a spec=infra>list</a> that is the result of running
 >           the [=process a fragment directive=] steps with |fragment directive
 >           string| and the document.

--- a/index.bs
+++ b/index.bs
@@ -712,19 +712,19 @@ boolean [=document/text fragment activation=] field:
 >   initially false.
 >
 >   <div class="note">
->     [=document/text fragment activation=] is consumed in order to allow a single activation of a
->     text fragment. It is set during document loading only if the navigation occurred as a result
->     of a user activation and can be propagated across client-side redirects.
+>     [=document/text fragment activation=] provides the necessary user gesture signal to allow a
+>     single activation of a text fragment. It is set to true during document loading only if the
+>     navigation occurred as a result of a user activation and can be propagated across client-side
+>     redirects.
 >
->     If a [=Document=]'s [=document/text fragment activation=] isn't consumed to activate
->     a text fragment, it may be consumed to set the [=request/text fragment activation=]
->     flag of a navigation [=/request=]. In this way, a [=document/text fragment activation=]
->     can be propagated from one [=Document=] to another across a navigation.
+>     If a [=Document=]'s [=document/text fragment activation=] isn't used to activate a text
+>     fragment, it may instead be used to set a navigation [=/request=]'s [=request/text fragment
+>     activation=] to true. In this way, a [=document/text fragment activation=] can be propagated
+>     from one [=Document=] to another across a navigation.
 >
->     Reading either the [=Document=]'s [=document/text fragment activation=] or the
->     [=/request=]'s [=request/text fragment activation=] flag always consumes the value by
->     setting it to false, such that a single activation cannot be reused to activate more than one
->     text fragment.
+>     Reading either the [=Document=]'s [=document/text fragment activation=] or the [=/request=]'s
+>     [=request/text fragment activation=] flag always resets the value to false, such that a single
+>     user activation cannot be reused to activate more than one text fragment.
 >   </div>
 
 <div class="note">
@@ -760,10 +760,10 @@ boolean [=document/text fragment activation=] field:
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   Each [=Document=] has an <dfn for="document">allow text fragment</dfn>, which is a
+>   Each [=Document=] has an <dfn for="document">allow observable text fragment effects</dfn>, which is a
 >   boolean, initially false.
 >   <div class="note">
->     [=document/allow text fragment=] is used to determine whether a text fragment
+>     [=document/allow observable text fragment effects=] is used to determine whether a text fragment
 >     should be allowed to activate. If it is false, the text fragment must not cause any
 >     observable effects.
 >   </div>
@@ -771,12 +771,12 @@ boolean [=document/text fragment activation=] field:
 <div class="note">
   <p>
     [=document/text fragment activation=] is analogous to a user-activation state
-    while [=document/allow text fragment=] is more comprehensive, taking into
+    while [=document/allow observable text fragment effects=] is more comprehensive, taking into
     account various pieces of information, one of which is the value of
     text fragment activation.
   </p>
   <p>
-    The reason we compute and store allow text fragment,
+    The reason we compute and store allow observable text fragment effects,
     rather than performing the checks at the time of use, is that it relies on
     the properties of the navigation while the invocation will occur as part of
     the <a spec=HTML>scroll to the fragment</a> steps which can happen outside
@@ -816,16 +816,16 @@ and initialize a Document object</a> steps by adding the following steps before 
 >             It's important that the flag not be copyable so that only one text fragment can be
 >             activated per user-activated navigation.
 >           </div>
->   16. Set |document|'s [=document/allow text fragment=] by following these sub-steps:
+>   16. Set |document|'s [=document/allow observable text fragment effects=] by following these sub-steps:
 >       1. If |document|'s [=fragment directive=] field is null or empty, set
->           [=document/allow text fragment=] to false and abort these sub-steps.
+>           [=document/allow observable text fragment effects=] to false and abort these sub-steps.
 >       1. Let |text fragment activation| be the value of |document|'s
 >           [=document/text fragment activation=] and set |document|'s
 >           [=document/text fragment activation=] to false.
 >       1. If the |navigationParam|'s
 >           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
 >           has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
->           header and its value is `"none"` set [=document/allow text fragment=] to true and abort these sub-steps.
+>           header and its value is `"none"` set [=document/allow observable text fragment effects=] to true and abort these sub-steps.
 >           <div class="note">
 >             <p>
 >               If a navigation originates from browser UI, it's always ok to allow it
@@ -852,25 +852,25 @@ and initialize a Document object</a> steps by adding the following steps before 
 >             </p>
 >           </div>
 >       1. If |text fragment activation| is false, set
->           [=document/allow text fragment=] to false and abort these sub-steps.
+>           [=document/allow observable text fragment effects=] to false and abort these sub-steps.
 >       1. If the |navigationParam|'s
 >           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
 >           has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
 >           header and its value is `"same-origin"` set
->           [=document/allow text fragment=] to true and abort these
+>           [=document/allow observable text fragment effects=] to true and abort these
 >           sub-steps.
 >       1. If |document|'s [=Document/browsing context=] is a [=top-level browsing
 >           context=] and its
 >           <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>'s
 >           <a spec=HTML>browsing context set</a> has length 1, set
->           [=document/allow text fragment=] to true and abort these sub-steps.
+>           [=document/allow observable text fragment effects=] to true and abort these sub-steps.
 >           <div class="note">
 >             i.e. Only allow navigation from a cross-origin element/script if the
 >             document is loaded in a noopener context. That is, a new top level
 >             browsing context group to which the navigator does not have script access
 >             and which may be placed into a separate process.
 >           </div>
->       1. Otherwise, set [=document/allow text fragment=] to false.
+>       1. Otherwise, set [=document/allow observable text fragment effects=] to false.
 
 Amend step 2 of the
 <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch">
@@ -899,11 +899,11 @@ steps of the task queued in step 2:
 >   1. If document has no parser, or its parser has stopped parsing, or the user
 >       agent has reason to believe the user is no longer interested in scrolling to
 >       the fragment, then set <em>document</em>'s
->       [=document/allow text fragment=] to false and abort these steps.
+>       [=document/allow observable text fragment effects=] to false and abort these steps.
 >   2. Scroll to the fragment given in document's URL. If this does not find an
 >       indicated part, then try to scroll to the fragment for
 >       document.
->   3. Set <em>document</em>'s [=document/allow text fragment=] to false.
+>   3. Set <em>document</em>'s [=document/allow observable text fragment effects=] to false.
 
 
 ## Navigating to a Text Fragment ## {#navigating-to-text-fragment}
@@ -989,7 +989,7 @@ so that the indicated part is a [=range=]:
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
 >   1. Let |fragment directive string| be the document's [=fragment directive=].
->   1. If the document's [=document/allow text fragment=] is true then:
+>   1. If the document's [=document/allow observable text fragment effects=] is true then:
 >       1. Let |ranges| be a <a spec=infra>list</a> that is the result of running
 >           the [=process a fragment directive=] steps with |fragment directive
 >           string| and the document.

--- a/index.bs
+++ b/index.bs
@@ -87,10 +87,9 @@ loses the context of the page.
 
 <div class='note'>This section is non-normative</div>
 
-This specification intentionally doesn't define what actions a user agent
-should or could take to "indicate" a text match. There are different
-experiences and trade-offs a user agent could make. Some examples of possible
-actions:
+This specification intentionally doesn't define what actions a user agent takes
+to "indicate" a text match. There are different experiences and trade-offs a
+user agent could make. Some examples of possible actions:
 
 * Providing visual emphasis or highlight of the text passage
 * Automatically scrolling the passage into view when the page is navigated
@@ -116,8 +115,8 @@ A [=text fragment directive=] is specified in the [=fragment directive=] (see
 <em>(Square brackets indicate an optional parameter)</em>
 
 The text parameters are percent-decoded before matching. Dash (-), ampersand
-(&), and comma (,) characters in text parameters must be percent-encoded to
-avoid being interpreted as part of the text directive syntax.
+(&), and comma (,) characters in text parameters are percent-encoded to avoid
+being interpreted as part of the text directive syntax.
 
 The only required parameter is textStart. If only textStart is specified, the
 first instance of this exact text string is the target text.
@@ -147,21 +146,21 @@ is the target text.
 The other two optional parameters are context terms. They are specified by the
 dash (-) character succeeding the prefix and preceding the suffix, to
 differentiate them from the textStart and textEnd parameters, as any
-combination of optional parameters may be specified.
+combination of optional parameters can be specified.
 
 Context terms are used to disambiguate the target text fragment. The context
 terms can specify the text immediately before (prefix) and immediately after
 (suffix) the text fragment, allowing for whitespace.
 
 <div class="note">
-While the context terms must be the immediate text surrounding the target text
-fragment, any amount of whitespace is allowed between context terms and the
-text fragment. This helps allow context terms to be across element boundaries,
-for example if the target text fragment is at the beginning of a paragraph and
-it must be disambiguated by the previous element's text as a prefix.
+While a match succeeds only if the context terms surround the target text
+fragment, any amount of whitespace is allowed between context terms and the text
+fragment. This allows context terms to cross element boundaries, for example if
+the target text fragment is at the beginning of a paragraph and needs
+disambiguation by the previous element's text as a prefix.
 </div>
 
-The context terms are not part of the targeted text fragment and must not be
+The context terms are not part of the targeted text fragment and are not
 visually indicated.
 
 <div class="example">
@@ -182,7 +181,7 @@ example" in "here is an example text".
 </div>
 
 Since URL strings are ASCII encoded, they provide no built-in support for
-bi-directional text. However, the content that we wish to target on a page may
+bi-directional text. However, the content that we wish to target on a page can
 be LTR (left-to-right), RTL (right-to-left) or both (Bidirectional/BiDi). This
 section provides an intuitive description the behavior implicitly described by
 the normative sections further in this spec.
@@ -195,7 +194,7 @@ Similarly, the <code>prefix</code> and <code>textStart</code> terms identify
 text coming before another term in logical order, while <code>suffix</code> and
 <code>textEnd</code> follow other terms in logical order.
 
-Note: user agents may visually render URLs in a manner friendlier to a native
+Note: user agents can visually render URLs in a manner friendlier to a native
 reader, for example, by converting the displayed string to Unicode. However, the
 string representation of a URL remains plain ASCII characters.
 
@@ -215,7 +214,7 @@ string representation of a URL remains plain ASCII characters.
     :~:text=%D8%A7%D9%84%D8%A8%D8%AD%D8%B1%D9%8A%D9%86-,%D9%85%D8%B5%D8%B1
   </code>
 
-  When displayed in a browser's address bar, the browser may visually render the
+  When displayed in a browser's address bar, the browser can visually render the
   text in its natural RTL direction, appearing to the user:
 
   <code>
@@ -233,13 +232,13 @@ The <dfn>fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).
 
 <div class="note">
-  The [=fragment directive=] is part of the URL fragment. This means it must
-  always appear after a U+0023 (#) code point in a URL.
+  The [=fragment directive=] is part of the URL fragment. This means it
+  always appears after a U+0023 (#) code point in a URL.
 </div>
 
 <div class="example">
   To add a [=fragment directive=] to a URL like https://example.com, a fragment
-  must first be appended to the URL: https://example.com#:~:text=foo.
+  is first appended to the URL: https://example.com#:~:text=foo.
 </div>
 
 The fragment directive is meant to carry instructions, such as
@@ -344,7 +343,7 @@ step 6).
   </p>
 
   <p>
-    Some examples should help clarify various edge cases.
+    Some examples are provided to help clarify various edge cases.
   </p>
 </div>
 
@@ -538,7 +537,7 @@ in the [=fragment directive=] that matches the production:
 </dl>
 
 <div class="note">
-  The [=FragmentDirective=] may contain multiple directives split by the "&"
+  The [=FragmentDirective=] can contain multiple directives split by the "&"
   character. Currently this means we allow multiple text directives to enable
   multiple indicated strings in the page, but this also allows for future
   directive types to be added and combined. For extensibility, we do not fail to
@@ -571,9 +570,10 @@ enables specifying a piece of text on the page, that matches the production:
     ";" | "=" | "?" | "@" | "_" | "~"
     </code>
   <div class = "note">
-    A [=TextDirectiveExplicitChar=] may be any [=URL code point=] that is not
-    explicitly used in the [=TextDirective=] syntax, that is "&", "-", and ",",
-    which must be percent-encoded.
+    A [=TextDirectiveExplicitChar=] is any [=URL code point=] that is not
+    explicitly used in the [=TextDirective=] syntax, that is "&", "-", and ",".
+    If a text fragment refers to a "&", "-", or "," character in the document,
+    it will be percent-encoded in the fragment.
   </div>
   </dd>
   <dt><dfn>`PercentEncodedChar`</dfn> `::=`</dt>
@@ -604,7 +604,7 @@ such that the destination page is known to be sufficiently isolated.
 
 A UA may choose to automatically scroll a matched text passage into view. This
 can be a convenient experience for the user but does present some risks that
-implementing UAs should be aware of.
+implementing UAs need to be aware of.
 
 There are known (and potentially unknown) ways a scroll on navigation might be
 detectable and distinguished from natural user scrolls.
@@ -643,7 +643,7 @@ All known cases like this rely on specific circumstances about the target page
 so don't apply generally. With additional restrictions about when the text
 fragment can invoke an attacker is further restricted. Nonetheless, different
 UAs can come to different conclusions about whether these risks are acceptable.
-UAs should consider these factors when determining whether to scroll as part of
+UAs need to consider these factors when determining whether to scroll as part of
 navigating to a text fragment.
 
 Conforming UAs may choose not to scroll automatically on navigation. Such UAs
@@ -651,9 +651,9 @@ may, instead, provide UI to initiate the scroll ("click to scroll") or none
 at all. In these cases UA should provide some indication to the user that an
 indicated passage exists further down on the page.
 
-The examples above illustrate that in specific circumstances, it may be
+The examples above illustrate that in specific circumstances, it can be
 possible for an attacker to extract 1 bit of information about content on the
-page.  However, care must be taken so that such opportunities cannot be
+page. However, care must be taken so that such opportunities cannot be
 exploited to extract arbitrary content from the page by repeating the attack.
 For this reason, restrictions based on user activation and browsing context
 isolation are very important and must be implemented.
@@ -663,7 +663,7 @@ isolation are very important and must be implemented.
   target document which helps reduce the attack surface.
 
   However, it also ensures any malicious use is difficult to hide. A browsing
-  context that's the only one in a group must be a top level browsing context
+  context that's the only one in a group will be a top level browsing context
   (i.e. a full tab/window).
 </div>
 
@@ -671,6 +671,11 @@ If a UA does choose to scroll automatically, it must ensure no scrolling is
 performed while the document is in the background (for example, in an inactive
 tab). This ensures any malicious usage is visible to the user and prevents
 attackers from trying to secretly automate a search in background documents.
+
+If a UA chooses not to scroll automatically, it must scroll a fallback
+element-id into view, if provided, regardless of whether a text fragment was
+matched. Not doing so would allow detecting the text fragment match based on
+whether the element-id was scrolled.
 
 ### Search Timing ### {#search-timing}
 
@@ -681,7 +686,7 @@ to a [=text fragment directive=]-invoking URL, they would be able to determine
 the existence of a text snippet by measuring how long the navigation call takes.
 
 <div class="note">
-  The restrictions in [[#restricting-the-text-fragment]] should prevent this
+  The restrictions in [[#restricting-the-text-fragment]] prevent this
   specific case; in particular, the no-same-document-navigation restriction.
   However, these restrictions are provided as multiple layers of defence.
 </div>
@@ -712,19 +717,19 @@ boolean [=document/text fragment user activation=] field:
 >   initially false.
 >
 >   <div class="note">
->     [=document/text fragment user activation=] provides the necessary user gesture signal to allow a
->     single activation of a text fragment. It is set to true during document loading only if the
->     navigation occurred as a result of a user activation and can be propagated across client-side
+>     [=document/text fragment user activation=] provides the necessary user gesture signal to allow
+>     a single activation of a text fragment. It is set to true during document loading only if the
+>     navigation occurred as a result of a user activation and is propagated across client-side
 >     redirects.
 >
 >     If a [=Document=]'s [=document/text fragment user activation=] isn't used to activate a text
->     fragment, it may instead be used to set a navigation [=/request=]'s [=request/text fragment user activation=]
+>     fragment, it is instead used to set a new navigation [=/request=]'s [=request/text fragment user activation=]
 >     to true. In this way, a [=document/text fragment user activation=] can be propagated
 >     from one [=Document=] to another across a navigation.
 >
->     Reading either the [=Document=]'s [=document/text fragment user activation=] or the [=/request=]'s
->     [=request/text fragment user activation=] flag always resets the value to false, such that a single
->     user activation cannot be reused to activate more than one text fragment.
+>     Both [=Document=]'s [=document/text fragment user activation=] and [=/request=]'s
+>     [=request/text fragment user activation=] are always set to false when used, such that a
+>     single user activation cannot be reused to activate more than one text fragment.
 >   </div>
 
 <div class="note">
@@ -740,9 +745,9 @@ boolean [=document/text fragment user activation=] field:
     redirects cannot propagate the fact that the navigation is the result of a
     user gesture. The [=document/text fragment user activation=] mechanism allows passing
     through this specifically scoped user-activation through such navigations.
-    This means a page can programmatically navigate to a text fragment, a
-    single time, as if it has a user gesture. However, further navigations
-    require a new user gesture.
+    This means a page is able to programmatically navigate to a text fragment, a
+    single time, as if it has a user gesture. However, since this resets <code>text fragment user
+    activation</code>, further text fragment navigations will not activation without a new user gesture.
   </p>
   <p>
     The following diagram demonstrates how the flag is used to activate a text
@@ -765,7 +770,7 @@ boolean [=document/text fragment user activation=] field:
 >   <div class="note">
 >     <p>
 >       [=document/allow text fragment scroll=] is used to determine whether a text fragment will
->       perform scrolling when the document is loaded. If it is false, the text fragment may be
+>       perform scrolling when the document is loaded. If it is false, the text fragment can be
 >       visually indicated but will not be scrolled to. This implements the mitigations discussed in
 >       [[#scroll-on-navigation]].
 >     </p>
@@ -826,13 +831,13 @@ and initialize a Document object</a> steps by adding the following steps before 
 >               text snippet.
 >             </p>
 >             <p>
->               Note: Depending on the UA, there may be cases where the <var
+>               Note: Depending on the UA, there can be cases where the <var
 >               ignore=''>incumbentNavigationOrigin</var> parameter is null but
->               it's not clear that the navigation should be considered as
+>               it's not clear that the navigation is to be considered as
 >               initiated from browser UI. E.g. an "open in new window" context
->               menu item when right clicking on a link.  The intent in this item
+>               menu item when right clicking on a link. The intent in this item
 >               is to distinguish cases where the app/page is able to set the URL
->               from those that are fully under the user's control.  In the former
+>               from those that are fully under the user's control. In the former
 >               we want to prevent activation of the text fragment unless the
 >               destination is loaded in a separate browsing context group (so that
 >               the source cannot both control the text snippet and observe
@@ -841,7 +846,7 @@ and initialize a Document object</a> steps by adding the following steps before 
 >             <p>
 >               See <a
 >               href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a>
->               for a more detailed discussion of how this should apply.
+>               for a more detailed discussion of how this applies.
 >             </p>
 >           </div>
 >       1. If |text fragment user activation| is false, set
@@ -861,7 +866,7 @@ and initialize a Document object</a> steps by adding the following steps before 
 >             i.e. Only allow navigation from a cross-origin element/script if the
 >             document is loaded in a noopener context. That is, a new top level
 >             browsing context group to which the navigator does not have script access
->             and which may be placed into a separate process.
+>             and which can be placed into a separate process.
 >           </div>
 >       1. Otherwise, set [=document/allow text fragment scroll=] to false.
 
@@ -906,8 +911,8 @@ The text fragment specification proposes an amendment to
 [[html#scroll-to-fragid]]. In summary, if a [=text fragment directive=] is
 present and a match is found in the page, the text fragment takes precedent over
 the element fragment as the indicated part. We amend the HTML Document's
-indicated part processing model to return a [=range=], rather than an [=element=] that
-may be scrolled into view.
+indicated part processing model to return a [=range=], rather than an
+[=element=], that will be scrolled into view.
 </div>
 
 To enable the <a spec=HTML>scroll to the fragment</a> algorithm to operate on a
@@ -1166,7 +1171,7 @@ spec=infra>ASCII string</a> |fragment directive input| and a [=Document=]
   This algorithm takes as input a |fragment directive input|, that is the
   raw text of the fragment directive and the |document| over which it operates.
   It returns a <a spec=infra>list</a> of [=ranges=] that are to be visually
-  indicated, the first of which may be scrolled into view (if the UA scrolls
+  indicated, the first of which will be scrolled into view (if the UA scrolls
   automatically).
 </div>
 
@@ -1201,10 +1206,10 @@ following steps:
   text passage within the document that matches the searched-for text and
   satisfies the surrounding context. Returns null if no such passage exists.
 
-  [=ParsedTextDirective/textEnd=] may be null. If omitted, this is an "exact"
-  search and the returned [=range=] must contain a string exactly matching
+  [=ParsedTextDirective/textEnd=] can be null. If omitted, this is an "exact"
+  search and the returned [=range=] will contain a string exactly matching
   [=ParsedTextDirective/textStart=]. If [=ParsedTextDirective/textEnd=] is
-  provided, this is a "range" search; the returned [=range=] must start with
+  provided, this is a "range" search; the returned [=range=] will start with
   [=ParsedTextDirective/textStart=] and end with
   [=ParsedTextDirective/textEnd=]. In the normative text below, we'll call a
   text passage that matches the provided [=ParsedTextDirective/textStart=] and
@@ -1212,7 +1217,7 @@ following steps:
   "matching text".
 
   Either or both of [=ParsedTextDirective/prefix=] and
-  [=ParsedTextDirective/suffix=] may be null, in which case context on that
+  [=ParsedTextDirective/suffix=] can be null, in which case context on that
   side of a match is not checked. E.g. If [=ParsedTextDirective/prefix=] is
   null, text is matched without any requirement on what text precedes it.
 </div>
@@ -1345,7 +1350,7 @@ following steps:
                   start searching for the next range start by breaking out
                   of this loop without |rangeEndSearchRange| being collapsed.
                   If we're looking for a range match, we'll continue iterating
-                  this inner loop since the range start must already be correct.
+                  this inner loop since the range start will already be correct.
                 </div>
             1. Set |rangeEndSearchRange|'s [=range/start=] to |potentialMatch|'s
                 [=range/end=].
@@ -1631,7 +1636,7 @@ of {{Text}} nodes |nodes|, and a boolean |isEnd|, follow these steps:
   See <a
   href="https://github.com/tc39/proposal-intl-segmenter">Intl.Segmenter</a>, a
   proposal to specify unicode segmentation, including word segmentation. Once
-  specified, this algorithm may be improved by making use of the Intl.Segmenter
+  specified, this algorithm can be improved by making use of the Intl.Segmenter
   API for word boundary matching.
 </div>
 
@@ -1680,11 +1685,12 @@ is more than 0 and |position| equals either 0 or |text|'s length.
 <div class="example">
   <p>
     Text fragments are restricted such that match terms, when combined with
-    their adjacent context terms, must be word bounded. For example, in an
+    their adjacent context terms, are word bounded. For example, in an
     exact search like <code>prefix,textStart,suffix</code>,
-    <code>"prefix+textStart+suffix"</code> must be word bounded. However, in a
-    range search like <code>prefix,textStart,textEnd,suffix</code>, both
-    <code>"prefix+textStart"</code> and <code>"textEnd+suffix"</code> must be
+    <code>"prefix+textStart+suffix"</code> will match only if the entire result is word bounded. However, in a
+    range search like <code>prefix,textStart,textEnd,suffix</code>, a match is
+    found only if both
+    <code>"prefix+textStart"</code> and <code>"textEnd+suffix"</code> are
     word bounded.
   </p>
 
@@ -1744,10 +1750,6 @@ ways to differentiate it from the page's content as perceived by the user.
 
 ### URLs in UA features ### {#urls-in-ua-features}
 
-<div class='note'>
-  This section is non-normative.
-</div>
-
 UAs provide a number of consumers for a document's URL (outside of programmatic
 APIs like <code>window.location</code>). Examples include a location bar
 indicating the URL of the currently visible document, or the URL used when a
@@ -1755,7 +1757,7 @@ user requests to create a bookmark for the current page.
 
 To avoid user confusion, UAs should be consistent in whether such URLs include
 the [=fragment directive=]. This section provides a default set of
-recommendations for how UAs should handle these cases.
+recommendations for how UAs can handle these cases.
 
 <div class='note'>
   <p>
@@ -1765,28 +1767,29 @@ recommendations for how UAs should handle these cases.
   </p>
 
   <p>
-  Exact behavior is left up to the implementing UA which may have differing
-  constraints or reasons for modifying the behavior. e.g. UAs may allow users
+  Exact behavior is left up to the implementing UA which can have differing
+  constraints or reasons for modifying the behavior. e.g. UAs can allow users
   to configure defaults or expose UI options so users can choose whether they
   prefer to include fragment directives in these URLs.
 
   It's also useful to allow UAs to experiment with providing a better
-  experience. E.g. perhaps a URL should elide the text fragment if the user
-  scrolls it out of view?
+  experience. E.g. perhaps the UA's displayed URL can elide the text fragment if
+  the user scrolls it out of view?
   </p>
 </div>
 
 The general principle is that a URL should include the [=fragment directive=]
 only while the visual indicator is visible (i.e. not dismissed). If the user
-dismisses the indicator, the URL should not include the [=fragment directive=].
+dismisses the indicator, the URL should reflect that by also removing the the
+[=fragment directive=].
 
 If the URL includes a text fragment but a match wasn't found in the current
 page, the UA may choose to omit it from the exposed URL.
 
 <div class='note'>
   <p>
-  A text fragment that isn't found on the page may be useful information to
-  surface to a user to indicate that the page may have changed since the link
+  A text fragment that isn't found on the page can be useful information to
+  surface to a user to indicate that the page has changed since the link
   was created.
   </p>
 
@@ -1799,8 +1802,8 @@ A few common examples are provided below.
 
 <div class='note'>
   We use "text fragment" and "fragment directive" interchangeably here as text
-  fragments are assumed to be the only kind of directive. Should additional
-  directives be added in the future, the UX in these cases may have to be
+  fragments are assumed to be the only kind of directive. If additional
+  directives are added in the future, the UX in these cases will have to be
   re-evaluated separately for new directive types.
 </div>
 
@@ -1916,9 +1919,9 @@ URLs.
 The match text can be provided either as an exact string "text=foo%20bar%20baz"
 or as a range "text=foo,bar".
 
-UAs should prefer to specify the entire string where practical. This ensures
-that if the destination page is removed or changed, the intended destination can
-still be derived from the URL itself.
+Prefer to specify the entire string where practical. This ensures that if the
+destination page is removed or changed, the intended destination can still be
+derived from the URL itself.
 
 <div class='example'>
   Suppose we wish to craft a URL to
@@ -1953,9 +1956,9 @@ still be derived from the URL itself.
 Range-based matches can be helpful when the quoted text is excessively long
 and encoding the entire string would produce an unwieldy URL.
 
-It is recommended that text snippets shorter than 300 characters always be
-encoded using an exact match. Above this limit, the UA should encode the string
-as a range-based match.
+Text snippets shorter than 300 characters are encouraged to be encoded using an
+exact match. Above this limit, the UA can encode the string as a range-based
+match.
 
 <div class='note'>
   TODO:  Can we determine the above limit in some less arbitrary way?
@@ -1968,7 +1971,7 @@ snippets on a page. However, their use can make the URL more brittle in some
 cases. Often, the desired string will start or end at an element boundary. The
 context will therefore exist in an adjacent element. Changes to the page
 structure could invalidate the [=text fragment directive=] since the context and
-match text may no longer appear to be adjacent.
+match text will no longer appear to be adjacent.
 
 <div class='example'>
   Suppose we wish to craft a URL for the following text:
@@ -1988,11 +1991,10 @@ match text may no longer appear to be adjacent.
   headers. This would now break the URL.
 </div>
 
-Where a text snippet is long enough and unique, a UA should prefer to avoid
+Where a text snippet is long enough and unique, a UAs are encouraged to avoid
 adding superfluous context terms.
 
-It is recommended that context should be used only if one of the following is
-true:
+Use context only if one of the following is true:
 <ul>
   <li>The UA determines the quoted text is ambiguous</li>
   <li>The quoted text contains 3 or fewer words</li>
@@ -2041,7 +2043,7 @@ correct one:
     manipulations
   </pre>
 
-  The UA should note that, even though the current URL of the page is:
+  Even though the current URL of the page is:
   https://en.wikipedia.org/wiki/History_of_computing#Early_computation, using
   #Early_computation as a fallback is inappropriate. If the above sentence is
   changed or removed, the page will load in the #Early_computation section
@@ -2053,9 +2055,3 @@ correct one:
   <a href="https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations">
   https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations</a>
 </div>
-
-If a UA chooses not to scroll text fragments into view on navigation (reasons
-why a UA may make this choice are discussed in [[#security-and-privacy]]), it
-must scroll the element-id into view, if provided, regardless of whether a text
-fragment was matched. Not doing so would allow detecting the text fragment
-match based on whether the element-id was scrolled.

--- a/index.bs
+++ b/index.bs
@@ -699,31 +699,31 @@ to find and set the [=Document=]'s indicated part.
 ### Restricting the Text Fragment ### {#restricting-the-text-fragment}
 
 Amend the definition of a [=/request=] and of a [=Document=] to include a new
-boolean [=document/text fragment activation=] field:
+boolean [=document/text fragment user activation=] field:
 
 >   <strong>Monkeypatching [[FETCH]]:</strong>
 >
->   A [=/request=] has an associated boolean <dfn for="request">text fragment activation</dfn>,
+>   A [=/request=] has an associated boolean <dfn for="request">text fragment user activation</dfn>,
 >   initially false.
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   Each [=Document=] has a <dfn for="document">text fragment activation</dfn>, which is a boolean,
+>   Each [=Document=] has a <dfn for="document">text fragment user activation</dfn>, which is a boolean,
 >   initially false.
 >
 >   <div class="note">
->     [=document/text fragment activation=] provides the necessary user gesture signal to allow a
+>     [=document/text fragment user activation=] provides the necessary user gesture signal to allow a
 >     single activation of a text fragment. It is set to true during document loading only if the
 >     navigation occurred as a result of a user activation and can be propagated across client-side
 >     redirects.
 >
->     If a [=Document=]'s [=document/text fragment activation=] isn't used to activate a text
->     fragment, it may instead be used to set a navigation [=/request=]'s [=request/text fragment
->     activation=] to true. In this way, a [=document/text fragment activation=] can be propagated
+>     If a [=Document=]'s [=document/text fragment user activation=] isn't used to activate a text
+>     fragment, it may instead be used to set a navigation [=/request=]'s [=request/text fragment user activation=]
+>     to true. In this way, a [=document/text fragment user activation=] can be propagated
 >     from one [=Document=] to another across a navigation.
 >
->     Reading either the [=Document=]'s [=document/text fragment activation=] or the [=/request=]'s
->     [=request/text fragment activation=] flag always resets the value to false, such that a single
+>     Reading either the [=Document=]'s [=document/text fragment user activation=] or the [=/request=]'s
+>     [=request/text fragment user activation=] flag always resets the value to false, such that a single
 >     user activation cannot be reused to activate more than one text fragment.
 >   </div>
 
@@ -738,7 +738,7 @@ boolean [=document/text fragment activation=] field:
   <p>
     Unlike real HTTP (<tt>status 3xx</tt>) redirects, these "client-side"
     redirects cannot propagate the fact that the navigation is the result of a
-    user gesture. The [=document/text fragment activation=] mechanism allows passing
+    user gesture. The [=document/text fragment user activation=] mechanism allows passing
     through this specifically scoped user-activation through such navigations.
     This means a page can programmatically navigate to a text fragment, a
     single time, as if it has a user gesture. However, further navigations
@@ -760,29 +760,22 @@ boolean [=document/text fragment activation=] field:
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   Each [=Document=] has an <dfn for="document">allow observable text fragment effects</dfn>, which is a
+>   Each [=Document=] has an <dfn for="document">allow text fragment scroll</dfn>, which is a
 >   boolean, initially false.
 >   <div class="note">
->     [=document/allow observable text fragment effects=] is used to determine whether a text fragment
->     should be allowed to activate. If it is false, the text fragment must not cause any
->     observable effects.
+>     <p>
+>       [=document/allow text fragment scroll=] is used to determine whether a text fragment will
+>       perform scrolling when the document is loaded. If it is false, the text fragment may be
+>       visually indicated but will not be scrolled to. This implements the mitigations discussed in
+>       [[#scroll-on-navigation]].
+>     </p>
+>     <p>
+>       The reason we compute and store allow text fragment scroll, rather than performing these
+>       checks at the time of use, is that it relies on the properties of the navigation while the
+>       invocation will occur as part of the <a spec=HTML>scroll to the fragment</a> steps which can
+>       happen outside the context of a navigation.
+>     </p>
 >   </div>
-
-<div class="note">
-  <p>
-    [=document/text fragment activation=] is analogous to a user-activation state
-    while [=document/allow observable text fragment effects=] is more comprehensive, taking into
-    account various pieces of information, one of which is the value of
-    text fragment activation.
-  </p>
-  <p>
-    The reason we compute and store allow observable text fragment effects,
-    rather than performing the checks at the time of use, is that it relies on
-    the properties of the navigation while the invocation will occur as part of
-    the <a spec=HTML>scroll to the fragment</a> steps which can happen outside
-    the context of a navigation.
-  </p>
-</div>
 
 <div class="note">
   TODO: This should really only prevent potentially observable side-effects like
@@ -796,7 +789,7 @@ and initialize a Document object</a> steps by adding the following steps before 
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   15. Set |document|'s [=document/text fragment activation=] by following these sub-steps:
+>   15. Set |document|'s [=document/text fragment user activation=] by following these sub-steps:
 >       1. Let |is user activated| be true if the current navigation was initiated from
 >           a window that had a <a spec="html">transient activation</a> at the time the
 >           navigation was initiated, or the UA has reason to believe it comes from a
@@ -807,25 +800,25 @@ and initialize a Document object</a> steps by adding the following steps before 
 >             <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a> in [[FETCH-METADATA]].
 >           </div>
 >       1. If <var ignore=''>browsing context</var> is a top-level browsing context and if either of |is
->           user activated| or the [=request/text fragment activation=] of
+>           user activated| or the [=request/text fragment user activation=] of
 >           |navigationParam|'s
 >           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
->           object is true, set the |document|'s [=document/text fragment activation=]
+>           object is true, set the |document|'s [=document/text fragment user activation=]
 >           to true. Otherwise, set it to false.
 >           <div class="note">
 >             It's important that the flag not be copyable so that only one text fragment can be
 >             activated per user-activated navigation.
 >           </div>
->   16. Set |document|'s [=document/allow observable text fragment effects=] by following these sub-steps:
+>   16. Set |document|'s [=document/allow text fragment scroll=] by following these sub-steps:
 >       1. If |document|'s [=fragment directive=] field is null or empty, set
->           [=document/allow observable text fragment effects=] to false and abort these sub-steps.
->       1. Let |text fragment activation| be the value of |document|'s
->           [=document/text fragment activation=] and set |document|'s
->           [=document/text fragment activation=] to false.
+>           [=document/allow text fragment scroll=] to false and abort these sub-steps.
+>       1. Let |text fragment user activation| be the value of |document|'s
+>           [=document/text fragment user activation=] and set |document|'s
+>           [=document/text fragment user activation=] to false.
 >       1. If the |navigationParam|'s
 >           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
 >           has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
->           header and its value is `"none"` set [=document/allow observable text fragment effects=] to true and abort these sub-steps.
+>           header and its value is `"none"` set [=document/allow text fragment scroll=] to true and abort these sub-steps.
 >           <div class="note">
 >             <p>
 >               If a navigation originates from browser UI, it's always ok to allow it
@@ -851,32 +844,32 @@ and initialize a Document object</a> steps by adding the following steps before 
 >               for a more detailed discussion of how this should apply.
 >             </p>
 >           </div>
->       1. If |text fragment activation| is false, set
->           [=document/allow observable text fragment effects=] to false and abort these sub-steps.
+>       1. If |text fragment user activation| is false, set
+>           [=document/allow text fragment scroll=] to false and abort these sub-steps.
 >       1. If the |navigationParam|'s
 >           <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a>
 >           has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a>
 >           header and its value is `"same-origin"` set
->           [=document/allow observable text fragment effects=] to true and abort these
+>           [=document/allow text fragment scroll=] to true and abort these
 >           sub-steps.
 >       1. If |document|'s [=Document/browsing context=] is a [=top-level browsing
 >           context=] and its
 >           <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>'s
 >           <a spec=HTML>browsing context set</a> has length 1, set
->           [=document/allow observable text fragment effects=] to true and abort these sub-steps.
+>           [=document/allow text fragment scroll=] to true and abort these sub-steps.
 >           <div class="note">
 >             i.e. Only allow navigation from a cross-origin element/script if the
 >             document is loaded in a noopener context. That is, a new top level
 >             browsing context group to which the navigator does not have script access
 >             and which may be placed into a separate process.
 >           </div>
->       1. Otherwise, set [=document/allow observable text fragment effects=] to false.
+>       1. Otherwise, set [=document/allow text fragment scroll=] to false.
 
 Amend step 2 of the
 <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch">
 process a navigate fetch</a> steps to additionally set |request|'s
-[=request/text fragment activation=] to the value of the [=active document=]'s
-[=document/text fragment activation=] and set the [=active document=]'s value to
+[=request/text fragment user activation=] to the value of the [=active document=]'s
+[=document/text fragment user activation=] and set the [=active document=]'s value to
 false.
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
@@ -885,10 +878,10 @@ false.
 >       settings object, destination to "document", mode to "navigate", credentials
 >       mode to "include", use-URL-credentials flag, redirect mode to "manual",
 >       replaces client id to browsingContext's active document's relevant settings
->       object's id, and [=request/text fragment activation=] to
+>       object's id, and [=request/text fragment user activation=] to
 >       sourceBrowsingContext's active document's
->       [=document/text fragment activation=]. Set sourceBrowsingContext's active
->       document's [=document/text fragment activation=] to false.
+>       [=document/text fragment user activation=]. Set sourceBrowsingContext's active
+>       document's [=document/text fragment user activation=] to false.
 
 
 Amend the <a spec=HTML>try to scroll to the fragment</a> steps by replacing the
@@ -899,11 +892,11 @@ steps of the task queued in step 2:
 >   1. If document has no parser, or its parser has stopped parsing, or the user
 >       agent has reason to believe the user is no longer interested in scrolling to
 >       the fragment, then set <em>document</em>'s
->       [=document/allow observable text fragment effects=] to false and abort these steps.
+>       [=document/allow text fragment scroll=] to false and abort these steps.
 >   2. Scroll to the fragment given in document's URL. If this does not find an
 >       indicated part, then try to scroll to the fragment for
 >       document.
->   3. Set <em>document</em>'s [=document/allow observable text fragment effects=] to false.
+>   3. Set <em>document</em>'s [=document/allow text fragment scroll=] to false.
 
 
 ## Navigating to a Text Fragment ## {#navigating-to-text-fragment}
@@ -989,7 +982,7 @@ so that the indicated part is a [=range=]:
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
 >   1. Let |fragment directive string| be the document's [=fragment directive=].
->   1. If the document's [=document/allow observable text fragment effects=] is true then:
+>   1. If the document's [=document/allow text fragment scroll=] is true then:
 >       1. Let |ranges| be a <a spec=infra>list</a> that is the result of running
 >           the [=process a fragment directive=] steps with |fragment directive
 >           string| and the document.

--- a/index.html
+++ b/index.html
@@ -1326,28 +1326,29 @@ multiple solutions with differing tradeoffs. For example, a UA <em>may</em> cont
 text directive</a>.  Alternatively, it <em>may</em> schedule an asynchronous task
 to find and set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a>'s indicated part.</p>
    <h4 class="heading settled" data-level="3.4.4" id="restricting-the-text-fragment"><span class="secno">3.4.4. </span><span class="content">Restricting the Text Fragment</span><a class="self-link" href="#restricting-the-text-fragment"></a></h4>
-   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a> to include a new <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag">textFragmentActivationFlag</a> field:</p>
+   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a> to include a new
+boolean <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation">text fragment activation</a> field:</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a>:</strong></p>
-    <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> has an associated <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport id="request-textfragmentactivationflag">textFragmentActivationFlag</dfn>.</p>
+    <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> has an associated boolean <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport id="request-text-fragment-activation">text fragment activation</dfn>,
+  initially false.</p>
    </blockquote>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-textfragmentactivationflag">textFragmentActivationFlag</dfn> that is
-  consumed in order to allow a single activation of a text fragment. This flag is
-  set during document loading only if the navigation occurred as a result of a user
-  activation.</p>
-    <p>If the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>'s <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag①">textFragmentActivationFlag</a> isn’t consumed to activate
-  a text fragment, it may be consumed to set the <a data-link-type="dfn" href="#request-textfragmentactivationflag" id="ref-for-request-textfragmentactivationflag">textFragmentActivationFlag</a> flag of a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>. In this way, a <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag②">textFragmentActivationFlag</a> can be propagated from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> to another across a navigation.</p>
-    <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag③">textFragmentActivationFlag</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-textfragmentactivationflag" id="ref-for-request-textfragmentactivationflag①">textFragmentActivationFlag</a> flag must always consume the value by
-  setting it to false, such that the flag cannot be reused.</p>
+    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-text-fragment-activation">text fragment activation</dfn>, which is a boolean,
+  initially false.</p>
+    <div class="note" role="note">
+      <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①">text fragment activation</a> is consumed in order to allow a single activation of a
+    text fragment. It is set during document loading only if the navigation occurred as a result
+    of a user activation and can be propagated across client-side redirects. 
+     <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation②">text fragment activation</a> isn’t consumed to activate
+    a text fragment, it may be consumed to set the <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation">text fragment activation</a> flag of a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>. In this way, a <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation③">text fragment activation</a> can be propagated from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> to another across a navigation.</p>
+     <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation④">text fragment activation</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation①">text fragment activation</a> flag always consumes the value by
+    setting it to false, such that a single activation cannot be reused to activate more than one
+    text fragment.</p>
+    </div>
    </blockquote>
    <div class="note" role="note">
-    <p> <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag④">textFragmentActivationFlag</a> is set to true when a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> is loaded
-    as a result of a user gesture. It grants permission (in terms of
-    user activation) to scroll a single text fragment. Alternatively, it may be
-    propagated through a navigation to allow a future document to scroll a text
-    fragment from this navigation’s user gesture. </p>
     <p>
       This mechanism allows text fragments to activate through a common redirect
     technique used by many popular web sites. Such sites redirect users to
@@ -1361,7 +1362,7 @@ to find and set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#c
      <tt>status 3xx</tt>
      ) redirects, these "client-side"
     redirects cannot propagate the fact that the navigation is the result of a
-    user gesture. The <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag⑤">textFragmentActivationFlag</a> mechanism allows passing
+    user gesture. The <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑤">text fragment activation</a> mechanism allows passing
     through this specifically scoped user-activation through such navigations.
     This means a page can programmatically navigate to a text fragment, a
     single time, as if it has a user gesture. However, further navigations
@@ -1374,16 +1375,18 @@ to find and set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#c
    </div>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>A <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allowtextfragmentdirective">allowTextFragmentDirective</dfn> flag that is used to determine whether a text fragment directive should be
-  allowed to activate. If this flag is false, the text fragment must not
-  cause any observable effects.</p>
+    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allow-text-fragment">allow text fragment</dfn>, which is a
+  boolean, initially false.</p>
+    <div class="note" role="note"> <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment">allow text fragment</a> is used to determine whether a text fragment
+    should be allowed to activate. If it is false, the text fragment must not cause any
+    observable effects. </div>
    </blockquote>
    <div class="note" role="note">
-    <p> <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag⑥">textFragmentActivationFlag</a> is analogous to a user-activation state
-    while <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective">allowTextFragmentDirective</a> is more comprehensive, taking into
-    account various pieces of information, one of which is the existence of a
-    textFragmentActivationFlag. </p>
-    <p> The reason we compute allowTextFragmentDirective and keep it as a flag,
+    <p> <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑥">text fragment activation</a> is analogous to a user-activation state
+    while <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment①">allow text fragment</a> is more comprehensive, taking into
+    account various pieces of information, one of which is the value of
+    text fragment activation. </p>
+    <p> The reason we compute and store allow text fragment,
     rather than performing the checks at the time of use, is that it relies on
     the properties of the navigation while the invocation will occur as part of
     the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier">scroll to the fragment</a> steps which can happen outside
@@ -1398,7 +1401,7 @@ and initialize a Document object</a> steps by adding the following steps before 
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
     <ol start="15">
      <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag⑦">textFragmentActivationFlag</a> by following these sub-steps:</p>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑦">text fragment activation</a> by following these sub-steps:</p>
       <ol>
        <li data-md>
         <p>Let <var>is user activated</var> be true if the current navigation was initiated from
@@ -1408,19 +1411,19 @@ and initialize a Document object</a> steps by adding the following steps before 
         <div class="note" role="note"> TODO: it’d be better to refer to the userActivationFlag on the <var>request</var>. See <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a> in <a data-link-type="biblio" href="#biblio-fetch-metadata" title="Fetch Metadata Request Headers">[FETCH-METADATA]</a>. </div>
        <li data-md>
         <p>If <var>browsing context</var> is a top-level browsing context and if either of <var>is
-  user activated</var> or the <a data-link-type="dfn" href="#request-textfragmentactivationflag" id="ref-for-request-textfragmentactivationflag②">textFragmentActivationFlag</a> of <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> object is true, set the <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag⑧">textFragmentActivationFlag</a> to true. Otherwise, set it to false.</p>
+  user activated</var> or the <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation②">text fragment activation</a> of <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> object is true, set the <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑧">text fragment activation</a> to true. Otherwise, set it to false.</p>
         <div class="note" role="note"> It’s important that the flag not be copyable so that only one text fragment can be
     activated per user-activated navigation. </div>
       </ol>
      <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①">allowTextFragmentDirective</a> by following these sub-steps:</p>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment②">allow text fragment</a> by following these sub-steps:</p>
       <ol>
        <li data-md>
-        <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective②">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
+        <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment③">allow text fragment</a> to false and abort these sub-steps.</p>
        <li data-md>
-        <p>Let <var>textFragmentActivationFlag</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag⑨">textFragmentActivationFlag</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag①⓪">textFragmentActivationFlag</a> to false.</p>
+        <p>Let <var>text fragment activation</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑨">text fragment activation</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①⓪">text fragment activation</a> to false.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective③">allowTextFragmentDirective</a> to true and abort these sub-steps.</p>
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment④">allow text fragment</a> to true and abort these sub-steps.</p>
         <div class="note" role="note">
          <p> If a navigation originates from browser UI, it’s always ok to allow it
       since it’ll be user triggered and the page/script isn’t providing the
@@ -1438,23 +1441,23 @@ and initialize a Document object</a> steps by adding the following steps before 
          <p> See <a href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a> for a more detailed discussion of how this should apply. </p>
         </div>
        <li data-md>
-        <p>If <var>textFragmentActivationFlag</var> is false, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective④">allowTextFragmentDirective</a> to false and abort these sub-steps.</p>
+        <p>If <var>text fragment activation</var> is false, set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑤">allow text fragment</a> to false and abort these sub-steps.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑤">allowTextFragmentDirective</a> to true and abort these
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑥">allow text fragment</a> to true and abort these
   sub-steps.</p>
        <li data-md>
         <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing
-  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑥">allowTextFragmentDirective</a> to true and abort these sub-steps.</p>
+  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑦">allow text fragment</a> to true and abort these sub-steps.</p>
         <div class="note" role="note"> i.e. Only allow navigation from a cross-origin element/script if the
     document is loaded in a noopener context. That is, a new top level
     browsing context group to which the navigator does not have script access
     and which may be placed into a separate process. </div>
        <li data-md>
-        <p>Otherwise, set <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑦">allowTextFragmentDirective</a> to false.</p>
+        <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑧">allow text fragment</a> to false.</p>
       </ol>
     </ol>
    </blockquote>
-   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-textfragmentactivationflag" id="ref-for-request-textfragmentactivationflag③">textFragmentActivationFlag</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document①">active document</a>'s <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag①①">textFragmentActivationFlag</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document②">active document</a>'s value to
+   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation③">text fragment activation</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document①">active document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①①">text fragment activation</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document②">active document</a>'s value to
 false.</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
@@ -1464,9 +1467,9 @@ false.</p>
   settings object, destination to "document", mode to "navigate", credentials
   mode to "include", use-URL-credentials flag, redirect mode to "manual",
   replaces client id to browsingContext’s active document’s relevant settings
-  object’s id, and <a data-link-type="dfn" href="#request-textfragmentactivationflag" id="ref-for-request-textfragmentactivationflag④">textFragmentActivationFlag</a> to
-  sourceBrowsingContext’s active document’s <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag①②">textFragmentActivationFlag</a>. Set sourceBrowsingContext’s active
-  document’s <a data-link-type="dfn" href="#document-textfragmentactivationflag" id="ref-for-document-textfragmentactivationflag①③">textFragmentActivationFlag</a> to false.</p>
+  object’s id, and <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation④">text fragment activation</a> to
+  sourceBrowsingContext’s active document’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①②">text fragment activation</a>. Set sourceBrowsingContext’s active
+  document’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①③">text fragment activation</a> to false.</p>
     </ol>
    </blockquote>
    <p>Amend the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment">try to scroll to the fragment</a> steps by replacing the
@@ -1477,13 +1480,13 @@ steps of the task queued in step 2:</p>
      <li data-md>
       <p>If document has no parser, or its parser has stopped parsing, or the user
   agent has reason to believe the user is no longer interested in scrolling to
-  the fragment, then clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑧">allowTextFragmentDirective</a> flag and abort these steps.</p>
+  the fragment, then set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑨">allow text fragment</a> to false and abort these steps.</p>
      <li data-md>
       <p>Scroll to the fragment given in document’s URL. If this does not find an
   indicated part, then try to scroll to the fragment for
   document.</p>
      <li data-md>
-      <p>Clear <em>document</em>’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective⑨">allowTextFragmentDirective</a> flag</p>
+      <p>Set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment①⓪">allow text fragment</a> to false.</p>
     </ol>
    </blockquote>
    <h3 class="heading settled" data-level="3.5" id="navigating-to-text-fragment"><span class="secno">3.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
@@ -1535,7 +1538,7 @@ may be scrolled into view. </div>
     would resolve this problem. </div>
      <li data-md>
       <p><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
-  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①②">Document</a>. If the result is false:</p>
+  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">Document</a>. If the result is false:</p>
       <ol>
        <li data-md>
         <p>If <var>range</var> wasn’t produced as a result of a text fragment, or if the
@@ -1563,7 +1566,7 @@ beginning of the processing model for the <a data-link-type="dfn" href="https://
      <li data-md>
       <p>Let <var>fragment directive string</var> be the document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment directive</a>.</p>
      <li data-md>
-      <p>If the document’s <a data-link-type="dfn" href="#document-allowtextfragmentdirective" id="ref-for-document-allowtextfragmentdirective①⓪">allowTextFragmentDirective</a> flag is true then:</p>
+      <p>If the document’s <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment①①">allow text fragment</a> is true then:</p>
       <ol>
        <li data-md>
         <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
@@ -1722,7 +1725,7 @@ text=bar,baz
   list.</p>
    </div>
    <div class="algorithm" data-algorithm="process a fragment directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a> <var>document</var>, run these steps: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①②">Document</a> <var>document</var>, run these steps: 
     <div class="note" role="note"> This algorithm takes as input a <var>fragment directive input</var>, that is the
   raw text of the fragment directive and the <var>document</var> over which it operates.
   It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①④">ranges</a> that are to be visually
@@ -1757,7 +1760,7 @@ directive</a> steps on <var>directive</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="find a range from a text directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#parsedtextdirective" id="ref-for-parsedtextdirective②">ParsedTextDirective</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①④">Document</a> <var>document</var>, run the
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#parsedtextdirective" id="ref-for-parsedtextdirective②">ParsedTextDirective</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a> <var>document</var>, run the
 following steps: 
     <div class="note" role="note">
       This algorithm takes as input a successfully parsed text directive and a
@@ -2350,9 +2353,9 @@ persisted state</a> steps by inserting a new step after 2:</p>
    <ol start="3">
     <li data-md>
      <p><a href="https://w3c.github.io/webappsec-permissions-policy/document-policy.html#algo-get-policy-value">Get
-the document policy value</a> of the "force-load-at-top" feature for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑤">Document</a>. If
+the document policy value</a> of the "force-load-at-top" feature for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①④">Document</a>. If
 the result is true, then the user agent should not restore the scroll
-position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑥">Document</a> or any of its scrollable regions.</p>
+position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑤">Document</a> or any of its scrollable regions.</p>
    </ol>
    <h3 class="heading settled" data-level="3.8" id="feature-detectability"><span class="secno">3.8. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
@@ -2527,7 +2530,7 @@ match based on whether the element-id was scrolled.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#document-allowtextfragmentdirective">allowTextFragmentDirective</a><span>, in § 3.4.4</span>
+   <li><a href="#document-allow-text-fragment">allow text fragment</a><span>, in § 3.4.4</span>
    <li><a href="#characterstring">CharacterString</a><span>, in § 3.3.3</span>
    <li><a href="#explicitchar">ExplicitChar</a><span>, in § 3.3.3</span>
    <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in § 3.5.2</span>
@@ -2569,10 +2572,10 @@ match based on whether the element-id was scrolled.</p>
    <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in § 3.3.3</span>
    <li><a href="#parsedtextdirective-textend">textEnd</a><span>, in § 3.3.2</span>
    <li>
-    textFragmentActivationFlag
+    text fragment activation
     <ul>
-     <li><a href="#document-textfragmentactivationflag">dfn for document</a><span>, in § 3.4.4</span>
-     <li><a href="#request-textfragmentactivationflag">dfn for request</a><span>, in § 3.4.4</span>
+     <li><a href="#document-text-fragment-activation">dfn for document</a><span>, in § 3.4.4</span>
+     <li><a href="#request-text-fragment-activation">dfn for request</a><span>, in § 3.4.4</span>
     </ul>
    <li><a href="#text-fragment-directive">text fragment directive</a><span>, in § 3.3.3</span>
    <li><a href="#parsedtextdirective-textstart">textStart</a><span>, in § 3.3.2</span>
@@ -2721,10 +2724,10 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-concept-document">3.3. The Fragment Directive</a>
     <li><a href="#ref-for-concept-document①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a>
     <li><a href="#ref-for-concept-document④">3.4.3. Search Timing</a>
-    <li><a href="#ref-for-concept-document⑤">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document⑥">(2)</a> <a href="#ref-for-concept-document⑦">(3)</a> <a href="#ref-for-concept-document⑧">(4)</a> <a href="#ref-for-concept-document⑨">(5)</a> <a href="#ref-for-concept-document①⓪">(6)</a> <a href="#ref-for-concept-document①①">(7)</a>
-    <li><a href="#ref-for-concept-document①②">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-concept-document①③">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-document①④">(2)</a>
-    <li><a href="#ref-for-concept-document①⑤">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①⑥">(2)</a>
+    <li><a href="#ref-for-concept-document⑤">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document⑥">(2)</a> <a href="#ref-for-concept-document⑦">(3)</a> <a href="#ref-for-concept-document⑧">(4)</a> <a href="#ref-for-concept-document⑨">(5)</a> <a href="#ref-for-concept-document①⓪">(6)</a>
+    <li><a href="#ref-for-concept-document①①">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-document①②">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-document①③">(2)</a>
+    <li><a href="#ref-for-concept-document①④">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-document-element">
@@ -3542,23 +3545,23 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
     <li><a href="#ref-for-percentencodedchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-percentencodedchar①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-textfragmentactivationflag">
-   <b><a href="#request-textfragmentactivationflag">#request-textfragmentactivationflag</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="request-text-fragment-activation">
+   <b><a href="#request-text-fragment-activation">#request-text-fragment-activation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-textfragmentactivationflag">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-request-textfragmentactivationflag①">(2)</a> <a href="#ref-for-request-textfragmentactivationflag②">(3)</a> <a href="#ref-for-request-textfragmentactivationflag③">(4)</a> <a href="#ref-for-request-textfragmentactivationflag④">(5)</a>
+    <li><a href="#ref-for-request-text-fragment-activation">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-request-text-fragment-activation①">(2)</a> <a href="#ref-for-request-text-fragment-activation②">(3)</a> <a href="#ref-for-request-text-fragment-activation③">(4)</a> <a href="#ref-for-request-text-fragment-activation④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-textfragmentactivationflag">
-   <b><a href="#document-textfragmentactivationflag">#document-textfragmentactivationflag</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="document-text-fragment-activation">
+   <b><a href="#document-text-fragment-activation">#document-text-fragment-activation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-textfragmentactivationflag">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-textfragmentactivationflag①">(2)</a> <a href="#ref-for-document-textfragmentactivationflag②">(3)</a> <a href="#ref-for-document-textfragmentactivationflag③">(4)</a> <a href="#ref-for-document-textfragmentactivationflag④">(5)</a> <a href="#ref-for-document-textfragmentactivationflag⑤">(6)</a> <a href="#ref-for-document-textfragmentactivationflag⑥">(7)</a> <a href="#ref-for-document-textfragmentactivationflag⑦">(8)</a> <a href="#ref-for-document-textfragmentactivationflag⑧">(9)</a> <a href="#ref-for-document-textfragmentactivationflag⑨">(10)</a> <a href="#ref-for-document-textfragmentactivationflag①⓪">(11)</a> <a href="#ref-for-document-textfragmentactivationflag①①">(12)</a> <a href="#ref-for-document-textfragmentactivationflag①②">(13)</a> <a href="#ref-for-document-textfragmentactivationflag①③">(14)</a>
+    <li><a href="#ref-for-document-text-fragment-activation">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-text-fragment-activation①">(2)</a> <a href="#ref-for-document-text-fragment-activation②">(3)</a> <a href="#ref-for-document-text-fragment-activation③">(4)</a> <a href="#ref-for-document-text-fragment-activation④">(5)</a> <a href="#ref-for-document-text-fragment-activation⑤">(6)</a> <a href="#ref-for-document-text-fragment-activation⑥">(7)</a> <a href="#ref-for-document-text-fragment-activation⑦">(8)</a> <a href="#ref-for-document-text-fragment-activation⑧">(9)</a> <a href="#ref-for-document-text-fragment-activation⑨">(10)</a> <a href="#ref-for-document-text-fragment-activation①⓪">(11)</a> <a href="#ref-for-document-text-fragment-activation①①">(12)</a> <a href="#ref-for-document-text-fragment-activation①②">(13)</a> <a href="#ref-for-document-text-fragment-activation①③">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-allowtextfragmentdirective">
-   <b><a href="#document-allowtextfragmentdirective">#document-allowtextfragmentdirective</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="document-allow-text-fragment">
+   <b><a href="#document-allow-text-fragment">#document-allow-text-fragment</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-allowtextfragmentdirective">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allowtextfragmentdirective①">(2)</a> <a href="#ref-for-document-allowtextfragmentdirective②">(3)</a> <a href="#ref-for-document-allowtextfragmentdirective③">(4)</a> <a href="#ref-for-document-allowtextfragmentdirective④">(5)</a> <a href="#ref-for-document-allowtextfragmentdirective⑤">(6)</a> <a href="#ref-for-document-allowtextfragmentdirective⑥">(7)</a> <a href="#ref-for-document-allowtextfragmentdirective⑦">(8)</a> <a href="#ref-for-document-allowtextfragmentdirective⑧">(9)</a> <a href="#ref-for-document-allowtextfragmentdirective⑨">(10)</a>
-    <li><a href="#ref-for-document-allowtextfragmentdirective①⓪">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-document-allow-text-fragment">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allow-text-fragment①">(2)</a> <a href="#ref-for-document-allow-text-fragment②">(3)</a> <a href="#ref-for-document-allow-text-fragment③">(4)</a> <a href="#ref-for-document-allow-text-fragment④">(5)</a> <a href="#ref-for-document-allow-text-fragment⑤">(6)</a> <a href="#ref-for-document-allow-text-fragment⑥">(7)</a> <a href="#ref-for-document-allow-text-fragment⑦">(8)</a> <a href="#ref-for-document-allow-text-fragment⑧">(9)</a> <a href="#ref-for-document-allow-text-fragment⑨">(10)</a> <a href="#ref-for-document-allow-text-fragment①⓪">(11)</a>
+    <li><a href="#ref-for-document-allow-text-fragment①①">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="first-common-ancestor">

--- a/index.html
+++ b/index.html
@@ -884,10 +884,9 @@ loses the context of the page.
    <h2 class="heading settled" data-level="3" id="description"><span class="secno">3. </span><span class="content">Description</span><a class="self-link" href="#description"></a></h2>
    <h3 class="heading settled" data-level="3.1" id="indication"><span class="secno">3.1. </span><span class="content">Indication</span><a class="self-link" href="#indication"></a></h3>
    <div class="note" role="note">This section is non-normative</div>
-   <p>This specification intentionally doesn’t define what actions a user agent
-should or could take to "indicate" a text match. There are different
-experiences and trade-offs a user agent could make. Some examples of possible
-actions:</p>
+   <p>This specification intentionally doesn’t define what actions a user agent takes
+to "indicate" a text match. There are different experiences and trade-offs a
+user agent could make. Some examples of possible actions:</p>
    <ul>
     <li data-md>
      <p>Providing visual emphasis or highlight of the text passage</p>
@@ -910,8 +909,8 @@ the <a href="#security-and-privacy">§ 3.4 Security and Privacy</a> section fo
 </pre>
    <p><em>(Square brackets indicate an optional parameter)</em></p>
    <p>The text parameters are percent-decoded before matching. Dash (-), ampersand
-(&amp;), and comma (,) characters in text parameters must be percent-encoded to
-avoid being interpreted as part of the text directive syntax.</p>
+(&amp;), and comma (,) characters in text parameters are percent-encoded to avoid
+being interpreted as part of the text directive syntax.</p>
    <p>The only required parameter is textStart. If only textStart is specified, the
 first instance of this exact text string is the target text.</p>
    <div class="example" id="example-4e85550d"><a class="self-link" href="#example-4e85550d"></a> <code>#:~:text=an%20example%20text%20fragment</code> indicates that the
@@ -930,16 +929,16 @@ is the target text. </div>
    <p>The other two optional parameters are context terms. They are specified by the
 dash (-) character succeeding the prefix and preceding the suffix, to
 differentiate them from the textStart and textEnd parameters, as any
-combination of optional parameters may be specified.</p>
+combination of optional parameters can be specified.</p>
    <p>Context terms are used to disambiguate the target text fragment. The context
 terms can specify the text immediately before (prefix) and immediately after
 (suffix) the text fragment, allowing for whitespace.</p>
-   <div class="note" role="note"> While the context terms must be the immediate text surrounding the target text
-fragment, any amount of whitespace is allowed between context terms and the
-text fragment. This helps allow context terms to be across element boundaries,
-for example if the target text fragment is at the beginning of a paragraph and
-it must be disambiguated by the previous element’s text as a prefix. </div>
-   <p>The context terms are not part of the targeted text fragment and must not be
+   <div class="note" role="note"> While a match succeeds only if the context terms surround the target text
+fragment, any amount of whitespace is allowed between context terms and the text
+fragment. This allows context terms to cross element boundaries, for example if
+the target text fragment is at the beginning of a paragraph and needs
+disambiguation by the previous element’s text as a prefix. </div>
+   <p>The context terms are not part of the targeted text fragment and are not
 visually indicated.</p>
    <div class="example" id="example-5c87b699"><a class="self-link" href="#example-5c87b699"></a> <code>#:~:text=this%20is-,an%20example,-text%20fragment</code> would match
 to "an example" in "this is an example text fragment", but not match to "an
@@ -950,7 +949,7 @@ example" in "here is an example text". </div>
   Bidirectional Algorithm basics</a> for a good overview of how Bidirectional
   text works. </div>
    <p>Since URL strings are ASCII encoded, they provide no built-in support for
-bi-directional text. However, the content that we wish to target on a page may
+bi-directional text. However, the content that we wish to target on a page can
 be LTR (left-to-right), RTL (right-to-left) or both (Bidirectional/BiDi). This
 section provides an intuitive description the behavior implicitly described by
 the normative sections further in this spec.</p>
@@ -959,11 +958,11 @@ that is, the order in which a native reader would read them in (and also the
 order in which characters are stored in memory).</p>
    <p>Similarly, the <code>prefix</code> and <code>textStart</code> terms identify
 text coming before another term in logical order, while <code>suffix</code> and <code>textEnd</code> follow other terms in logical order.</p>
-   <p class="note" role="note"><span>Note:</span> user agents may visually render URLs in a manner friendlier to a native
+   <p class="note" role="note"><span>Note:</span> user agents can visually render URLs in a manner friendlier to a native
 reader, for example, by converting the displayed string to Unicode. However, the
 string representation of a URL remains plain ASCII characters.</p>
-   <div class="example" id="example-9f4a4e2f">
-    <a class="self-link" href="#example-9f4a4e2f"></a> Suppose we want to select the text <code>مِصر‎</code> (Egypt, in Arabic),
+   <div class="example" id="example-b17c0d6b">
+    <a class="self-link" href="#example-b17c0d6b"></a> Suppose we want to select the text <code>مِصر‎</code> (Egypt, in Arabic),
   that’s preceeded by <code>البحرين‎</code> (Bahrain, in Arabic). We would
   first percent encode each term: 
     <p><code>مِصر‎</code> becomes "%D9%85%D8%B5%D8%B1" (Note: UTF-8 character
@@ -971,7 +970,7 @@ string representation of a URL remains plain ASCII characters.</p>
     <p><code>البحرين‎</code> becomes "%D8%A7%D9%84%D8%A8%D8%AD%D8%B1%D9%8A%D9%86"</p>
     <p>The text fragment would then become:</p>
     <p><code> :~:text=%D8%A7%D9%84%D8%A8%D8%AD%D8%B1%D9%8A%D9%86-,%D9%85%D8%B5%D8%B1 </code></p>
-    <p>When displayed in a browser’s address bar, the browser may visually render the
+    <p>When displayed in a browser’s address bar, the browser can visually render the
   text in its natural RTL direction, appearing to the user:</p>
     <p><code> :~:text=البحرين-,مِصر </code></p>
    </div>
@@ -981,10 +980,10 @@ introduces the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fr
 of the URL <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment">fragment</a> that follows the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter">fragment directive delimiter</a>.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragment-directive-delimiter">fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).</p>
-   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive③">fragment directive</a> is part of the URL fragment. This means it must
-  always appear after a U+0023 (#) code point in a URL. </div>
-   <div class="example" id="example-aa58e32d"><a class="self-link" href="#example-aa58e32d"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> to a URL like https://example.com, a fragment
-  must first be appended to the URL: https://example.com#:~:text=foo. </div>
+   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive③">fragment directive</a> is part of the URL fragment. This means it
+  always appears after a U+0023 (#) code point in a URL. </div>
+   <div class="example" id="example-6998d91f"><a class="self-link" href="#example-6998d91f"></a> To add a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> to a URL like https://example.com, a fragment
+  is first appended to the URL: https://example.com#:~:text=foo. </div>
    <p>The fragment directive is meant to carry instructions, such as <code>text=</code>, for the UA rather than for the document.</p>
    <p>To prevent impacting page operation, it is stripped from a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url">URL</a> so that author scripts can’t directly interact with it. This
 also ensures future directives could be added without introducing breaking
@@ -1069,7 +1068,7 @@ setting <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.w
     directive when it is set on a Document. Notably, since a window’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location" id="ref-for-location">Location</a></code> object is a representation of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①">URL</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document">active
     document</a>, all getters on it will show a fragment-directive-stripped
     version of the URL. </p>
-    <p> Some examples should help clarify various edge cases. </p>
+    <p> Some examples are provided to help clarify various edge cases. </p>
    </div>
    <div class="example" id="example-609a3312">
     <a class="self-link" href="#example-609a3312"></a> 
@@ -1216,7 +1215,7 @@ in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-d
     ";" | "=" | "?" | "@" | "_" | "~" | "&amp;" | "," | "-"</code> 
      <div class="note" role="note"> An <a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar①">ExplicitChar</a> may be any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points">URL code point</a>. </div>
    </dl>
-   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirectiveproduction" id="ref-for-fragmentdirectiveproduction①">FragmentDirective</a> may contain multiple directives split by the "&amp;"
+   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirectiveproduction" id="ref-for-fragmentdirectiveproduction①">FragmentDirective</a> can contain multiple directives split by the "&amp;"
   character. Currently this means we allow multiple text directives to enable
   multiple indicated strings in the page, but this also allows for future
   directive types to be added and combined. For extensibility, we do not fail to
@@ -1238,9 +1237,10 @@ enables specifying a piece of text on the page, that matches the production:</p>
     <dd>
       <code> [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
     ";" | "=" | "?" | "@" | "_" | "~" </code> 
-     <div class="note" role="note"> A <a data-link-type="dfn" href="#textdirectiveexplicitchar" id="ref-for-textdirectiveexplicitchar①">TextDirectiveExplicitChar</a> may be any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points①">URL code point</a> that is not
-    explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a> syntax, that is "&amp;", "-", and ",",
-    which must be percent-encoded. </div>
+     <div class="note" role="note"> A <a data-link-type="dfn" href="#textdirectiveexplicitchar" id="ref-for-textdirectiveexplicitchar①">TextDirectiveExplicitChar</a> is any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points①">URL code point</a> that is not
+    explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a> syntax, that is "&amp;", "-", and ",".
+    If a text fragment refers to a "&amp;", "-", or "," character in the document,
+    it will be percent-encoded in the fragment. </div>
     <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar"><code>PercentEncodedChar</code></dfn> <code>::=</code>
     <dd><code>"%" [a-zA-Z0-9]+</code>
    </dl>
@@ -1262,7 +1262,7 @@ such that the destination page is known to be sufficiently isolated.</p>
    <h4 class="heading settled" data-level="3.4.2" id="scroll-on-navigation"><span class="secno">3.4.2. </span><span class="content">Scroll On Navigation</span><a class="self-link" href="#scroll-on-navigation"></a></h4>
    <p>A UA may choose to automatically scroll a matched text passage into view. This
 can be a convenient experience for the user but does present some risks that
-implementing UAs should be aware of.</p>
+implementing UAs need to be aware of.</p>
    <p>There are known (and potentially unknown) ways a scroll on navigation might be
 detectable and distinguished from natural user scrolls.</p>
    <div class="example" id="example-fe268bc5"><a class="self-link" href="#example-fe268bc5"></a> An origin embedded in an iframe in the target page registers an
@@ -1287,15 +1287,15 @@ detectable and distinguished from natural user scrolls.</p>
 so don’t apply generally. With additional restrictions about when the text
 fragment can invoke an attacker is further restricted. Nonetheless, different
 UAs can come to different conclusions about whether these risks are acceptable.
-UAs should consider these factors when determining whether to scroll as part of
+UAs need to consider these factors when determining whether to scroll as part of
 navigating to a text fragment.</p>
    <p>Conforming UAs may choose not to scroll automatically on navigation. Such UAs
 may, instead, provide UI to initiate the scroll ("click to scroll") or none
 at all. In these cases UA should provide some indication to the user that an
 indicated passage exists further down on the page.</p>
-   <p>The examples above illustrate that in specific circumstances, it may be
+   <p>The examples above illustrate that in specific circumstances, it can be
 possible for an attacker to extract 1 bit of information about content on the
-page.  However, care must be taken so that such opportunities cannot be
+page. However, care must be taken so that such opportunities cannot be
 exploited to extract arbitrary content from the page by repeating the attack.
 For this reason, restrictions based on user activation and browsing context
 isolation are very important and must be implemented.</p>
@@ -1303,20 +1303,24 @@ isolation are very important and must be implemented.</p>
      Browsing context isolation ensures that no other document can script the
   target document which helps reduce the attack surface. 
     <p>However, it also ensures any malicious use is difficult to hide. A browsing
-  context that’s the only one in a group must be a top level browsing context
+  context that’s the only one in a group will be a top level browsing context
   (i.e. a full tab/window).</p>
    </div>
    <p>If a UA does choose to scroll automatically, it must ensure no scrolling is
 performed while the document is in the background (for example, in an inactive
 tab). This ensures any malicious usage is visible to the user and prevents
 attackers from trying to secretly automate a search in background documents.</p>
+   <p>If a UA chooses not to scroll automatically, it must scroll a fallback
+element-id into view, if provided, regardless of whether a text fragment was
+matched. Not doing so would allow detecting the text fragment match based on
+whether the element-id was scrolled.</p>
    <h4 class="heading settled" data-level="3.4.3" id="search-timing"><span class="secno">3.4.3. </span><span class="content">Search Timing</span><a class="self-link" href="#search-timing"></a></h4>
    <p>A naive implementation of the text search algorithm could allow information
 exfiltration based on runtime duration differences between a matching and non-
 matching query. If an attacker could find a way to synchronously navigate
 to a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive③">text fragment directive</a>-invoking URL, they would be able to determine
 the existence of a text snippet by measuring how long the navigation call takes.</p>
-   <div class="note" role="note"> The restrictions in <a href="#restricting-the-text-fragment">§ 3.4.4 Restricting the Text Fragment</a> should prevent this
+   <div class="note" role="note"> The restrictions in <a href="#restricting-the-text-fragment">§ 3.4.4 Restricting the Text Fragment</a> prevent this
   specific case; in particular, the no-same-document-navigation restriction.
   However, these restrictions are provided as multiple layers of defence. </div>
    <p>For this reason, the implementation <em>must ensure the runtime of <a href="#navigating-to-text-fragment">§ 3.5 Navigating to a Text Fragment</a> steps does not differ based on whether a match
@@ -1338,15 +1342,15 @@ boolean <a data-link-type="dfn" href="#document-text-fragment-user-activation" i
     <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-text-fragment-user-activation">text fragment user activation</dfn>, which is a boolean,
   initially false.</p>
     <div class="note" role="note">
-      <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation①">text fragment user activation</a> provides the necessary user gesture signal to allow a
-    single activation of a text fragment. It is set to true during document loading only if the
-    navigation occurred as a result of a user activation and can be propagated across client-side
+      <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation①">text fragment user activation</a> provides the necessary user gesture signal to allow
+    a single activation of a text fragment. It is set to true during document loading only if the
+    navigation occurred as a result of a user activation and is propagated across client-side
     redirects. 
      <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation②">text fragment user activation</a> isn’t used to activate a text
-    fragment, it may instead be used to set a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-user-activation" id="ref-for-request-text-fragment-user-activation">text fragment user activation</a> to true. In this way, a <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation③">text fragment user activation</a> can be propagated
+    fragment, it is instead used to set a new navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-user-activation" id="ref-for-request-text-fragment-user-activation">text fragment user activation</a> to true. In this way, a <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation③">text fragment user activation</a> can be propagated
     from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> to another across a navigation.</p>
-     <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation④">text fragment user activation</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-user-activation" id="ref-for-request-text-fragment-user-activation①">text fragment user activation</a> flag always resets the value to false, such that a single
-    user activation cannot be reused to activate more than one text fragment.</p>
+     <p>Both <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation④">text fragment user activation</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-user-activation" id="ref-for-request-text-fragment-user-activation①">text fragment user activation</a> are always set to false when used, such that a
+    single user activation cannot be reused to activate more than one text fragment.</p>
     </div>
    </blockquote>
    <div class="note" role="note">
@@ -1365,9 +1369,9 @@ boolean <a data-link-type="dfn" href="#document-text-fragment-user-activation" i
     redirects cannot propagate the fact that the navigation is the result of a
     user gesture. The <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation⑤">text fragment user activation</a> mechanism allows passing
     through this specifically scoped user-activation through such navigations.
-    This means a page can programmatically navigate to a text fragment, a
-    single time, as if it has a user gesture. However, further navigations
-    require a new user gesture. 
+    This means a page is able to programmatically navigate to a text fragment, a
+    single time, as if it has a user gesture. However, since this resets <code>text fragment user
+    activation</code>, further text fragment navigations will not activation without a new user gesture. 
     </p>
     <p> The following diagram demonstrates how the flag is used to activate a text
     fragment through a client-side redirect service: </p>
@@ -1380,7 +1384,7 @@ boolean <a data-link-type="dfn" href="#document-text-fragment-user-activation" i
   boolean, initially false.</p>
     <div class="note" role="note">
      <p> <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll">allow text fragment scroll</a> is used to determine whether a text fragment will
-      perform scrolling when the document is loaded. If it is false, the text fragment may be
+      perform scrolling when the document is loaded. If it is false, the text fragment can be
       visually indicated but will not be scrolled to. This implements the mitigations discussed in <a href="#scroll-on-navigation">§ 3.4.2 Scroll On Navigation</a>. </p>
      <p> The reason we compute and store allow text fragment scroll, rather than performing these
       checks at the time of use, is that it relies on the properties of the navigation while the
@@ -1424,17 +1428,17 @@ and initialize a Document object</a> steps by adding the following steps before 
          <p> If a navigation originates from browser UI, it’s always ok to allow it
       since it’ll be user triggered and the page/script isn’t providing the
       text snippet. </p>
-         <p> Note: Depending on the UA, there may be cases where the <var>incumbentNavigationOrigin</var> parameter is null but
-      it’s not clear that the navigation should be considered as
+         <p> Note: Depending on the UA, there can be cases where the <var>incumbentNavigationOrigin</var> parameter is null but
+      it’s not clear that the navigation is to be considered as
       initiated from browser UI. E.g. an "open in new window" context
-      menu item when right clicking on a link.  The intent in this item
+      menu item when right clicking on a link. The intent in this item
       is to distinguish cases where the app/page is able to set the URL
-      from those that are fully under the user’s control.  In the former
+      from those that are fully under the user’s control. In the former
       we want to prevent activation of the text fragment unless the
       destination is loaded in a separate browsing context group (so that
       the source cannot both control the text snippet and observe
       side-effects in the navigation). </p>
-         <p> See <a href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a> for a more detailed discussion of how this should apply. </p>
+         <p> See <a href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a> for a more detailed discussion of how this applies. </p>
         </div>
        <li data-md>
         <p>If <var>text fragment user activation</var> is false, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll④">allow text fragment scroll</a> to false and abort these sub-steps.</p>
@@ -1447,7 +1451,7 @@ and initialize a Document object</a> steps by adding the following steps before 
         <div class="note" role="note"> i.e. Only allow navigation from a cross-origin element/script if the
     document is loaded in a noopener context. That is, a new top level
     browsing context group to which the navigator does not have script access
-    and which may be placed into a separate process. </div>
+    and which can be placed into a separate process. </div>
        <li data-md>
         <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑦">allow text fragment scroll</a> to false.</p>
       </ol>
@@ -1489,8 +1493,7 @@ steps of the task queued in step 2:</p>
    <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.4.2.3.3 Fragment navigations</a>. In summary, if a <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive④">text fragment directive</a> is
 present and a match is found in the page, the text fragment takes precedent over
 the element fragment as the indicated part. We amend the HTML Document’s
-indicated part processing model to return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range">range</a>, rather than an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element">element</a> that
-may be scrolled into view. </div>
+indicated part processing model to return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range">range</a>, rather than an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element">element</a>, that will be scrolled into view. </div>
    <p>To enable the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier①">scroll to the fragment</a> algorithm to operate on a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①">range</a> indicated part, replace step 3 of this algorithm as follows:</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
@@ -1725,7 +1728,7 @@ text=bar,baz
     <div class="note" role="note"> This algorithm takes as input a <var>fragment directive input</var>, that is the
   raw text of the fragment directive and the <var>document</var> over which it operates.
   It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①④">ranges</a> that are to be visually
-  indicated, the first of which may be scrolled into view (if the UA scrolls
+  indicated, the first of which will be scrolled into view (if the UA scrolls
   automatically). </div>
     <ol class="algorithm">
      <li data-md>
@@ -1763,12 +1766,12 @@ following steps:
   document in which to search. It returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑥">range</a> that points to the first
   text passage within the document that matches the searched-for text and
   satisfies the surrounding context. Returns null if no such passage exists. 
-     <p><a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend①">textEnd</a> may be null. If omitted, this is an "exact"
-  search and the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> must contain a string exactly matching <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart②">textStart</a>. If <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend②">textEnd</a> is
-  provided, this is a "range" search; the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑧">range</a> must start with <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart③">textStart</a> and end with <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend③">textEnd</a>. In the normative text below, we’ll call a
+     <p><a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend①">textEnd</a> can be null. If omitted, this is an "exact"
+  search and the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> will contain a string exactly matching <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart②">textStart</a>. If <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend②">textEnd</a> is
+  provided, this is a "range" search; the returned <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑧">range</a> will start with <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart③">textStart</a> and end with <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend③">textEnd</a>. In the normative text below, we’ll call a
   text passage that matches the provided <a data-link-type="dfn" href="#parsedtextdirective-textstart" id="ref-for-parsedtextdirective-textstart④">textStart</a> and <a data-link-type="dfn" href="#parsedtextdirective-textend" id="ref-for-parsedtextdirective-textend④">textEnd</a>, regardless of which mode we’re in, the
   "matching text".</p>
-     <p>Either or both of <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix①">prefix</a> and <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix①">suffix</a> may be null, in which case context on that
+     <p>Either or both of <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix①">prefix</a> and <a data-link-type="dfn" href="#parsedtextdirective-suffix" id="ref-for-parsedtextdirective-suffix①">suffix</a> can be null, in which case context on that
   side of a match is not checked. E.g. If <a data-link-type="dfn" href="#parsedtextdirective-prefix" id="ref-for-parsedtextdirective-prefix②">prefix</a> is
   null, text is matched without any requirement on what text precedes it.</p>
     </div>
@@ -1896,7 +1899,7 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-brea
   start searching for the next range start by breaking out
   of this loop without <var>rangeEndSearchRange</var> being collapsed.
   If we’re looking for a range match, we’ll continue iterating
-  this inner loop since the range start must already be correct. </div>
+  this inner loop since the range start will already be correct. </div>
          <li data-md>
           <p>Set <var>rangeEndSearchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑥">start</a> to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①④">end</a>.</p>
           <div class="note" role="note"> Otherwise, it is possible that we found the correct range
@@ -2210,7 +2213,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
   cross-origin information leakage. </div>
    <div class="note" role="note"> See <a href="https://github.com/tc39/proposal-intl-segmenter">Intl.Segmenter</a>, a
   proposal to specify unicode segmentation, including word segmentation. Once
-  specified, this algorithm may be improved by making use of the Intl.Segmenter
+  specified, this algorithm can be improved by making use of the Intl.Segmenter
   API for word boundary matching. </div>
    <p> A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="word-boundary">word boundary</dfn> is defined in <a data-link-type="biblio" href="#biblio-uax29" title="Unicode Text Segmentation">[UAX29]</a> in <a href="https://www.unicode.org/reports/tr29/tr29-41.html#Word_Boundaries">Unicode Text Segmentation § Word_Boundaries</a>. <a href="https://www.unicode.org/reports/tr29/tr29-41.html#Default_Word_Boundaries">Unicode Text Segmentation § Default_Word_Boundaries</a> defines a
   default set of what constitutes a word boundary, but as the specification
@@ -2240,12 +2243,13 @@ is more than 0 and <var>position</var> equals either 0 or <var>text</var>’s le
   Chinese/Japanese/Korean). Languages such as these requires dictionaries to
   determine what a valid word in the given locale is.</p>
    </div>
-   <div class="example" id="example-1c1d8c25">
-    <a class="self-link" href="#example-1c1d8c25"></a> 
+   <div class="example" id="example-a9f4cbc5">
+    <a class="self-link" href="#example-a9f4cbc5"></a> 
     <p> Text fragments are restricted such that match terms, when combined with
-    their adjacent context terms, must be word bounded. For example, in an
-    exact search like <code>prefix,textStart,suffix</code>, <code>"prefix+textStart+suffix"</code> must be word bounded. However, in a
-    range search like <code>prefix,textStart,textEnd,suffix</code>, both <code>"prefix+textStart"</code> and <code>"textEnd+suffix"</code> must be
+    their adjacent context terms, are word bounded. For example, in an
+    exact search like <code>prefix,textStart,suffix</code>, <code>"prefix+textStart+suffix"</code> will match only if the entire result is word bounded. However, in a
+    range search like <code>prefix,textStart,textEnd,suffix</code>, a match is
+    found only if both <code>"prefix+textStart"</code> and <code>"textEnd+suffix"</code> are
     word bounded. </p>
     <p> The goal is that a third-party must already know the full tokens they are
     matching against. A range match like <code>textStart,textEnd</code> must be
@@ -2275,41 +2279,40 @@ ways to differentiate it from the page’s content as perceived by the user.</p>
   indicator appears to help train the user that it comes from the linking page
   and is provided by the UA. </div>
    <h4 class="heading settled" data-level="3.6.1" id="urls-in-ua-features"><span class="secno">3.6.1. </span><span class="content">URLs in UA features</span><a class="self-link" href="#urls-in-ua-features"></a></h4>
-   <div class="note" role="note"> This section is non-normative. </div>
    <p>UAs provide a number of consumers for a document’s URL (outside of programmatic
 APIs like <code>window.location</code>). Examples include a location bar
 indicating the URL of the currently visible document, or the URL used when a
 user requests to create a bookmark for the current page.</p>
    <p>To avoid user confusion, UAs should be consistent in whether such URLs include
 the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑤">fragment directive</a>. This section provides a default set of
-recommendations for how UAs should handle these cases.</p>
+recommendations for how UAs can handle these cases.</p>
    <div class="note" role="note">
     <p> We provide these as a baseline for consistent behavior; however, as these
   features don’t affect cross-UA interoperability, they are not strict
   conformance requirements. </p>
-    <p> Exact behavior is left up to the implementing UA which may have differing
-  constraints or reasons for modifying the behavior. e.g. UAs may allow users
+    <p> Exact behavior is left up to the implementing UA which can have differing
+  constraints or reasons for modifying the behavior. e.g. UAs can allow users
   to configure defaults or expose UI options so users can choose whether they
   prefer to include fragment directives in these URLs. </p>
     <p>It’s also useful to allow UAs to experiment with providing a better
-  experience. E.g. perhaps a URL should elide the text fragment if the user
-  scrolls it out of view?</p>
+  experience. E.g. perhaps the UA’s displayed URL can elide the text fragment if
+  the user scrolls it out of view?</p>
     <p></p>
    </div>
    <p>The general principle is that a URL should include the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑥">fragment directive</a> only while the visual indicator is visible (i.e. not dismissed). If the user
-dismisses the indicator, the URL should not include the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑦">fragment directive</a>.</p>
+dismisses the indicator, the URL should reflect that by also removing the the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①⑦">fragment directive</a>.</p>
    <p>If the URL includes a text fragment but a match wasn’t found in the current
 page, the UA may choose to omit it from the exposed URL.</p>
    <div class="note" role="note">
-    <p> A text fragment that isn’t found on the page may be useful information to
-  surface to a user to indicate that the page may have changed since the link
+    <p> A text fragment that isn’t found on the page can be useful information to
+  surface to a user to indicate that the page has changed since the link
   was created. </p>
     <p> However, it’s unlikely to be useful to the user in a bookmark. </p>
    </div>
    <p>A few common examples are provided below.</p>
    <div class="note" role="note"> We use "text fragment" and "fragment directive" interchangeably here as text
-  fragments are assumed to be the only kind of directive. Should additional
-  directives be added in the future, the UX in these cases may have to be
+  fragments are assumed to be the only kind of directive. If additional
+  directives are added in the future, the UX in these cases will have to be
   re-evaluated separately for new directive types. </div>
    <h5 class="heading settled" data-level="3.6.1.1" id="urls-in-location-bar"><span class="secno">3.6.1.1. </span><span class="content">Location Bar</span><a class="self-link" href="#urls-in-location-bar"></a></h5>
    <p>The location bar’s URL should include a text fragment while it is visually
@@ -2377,9 +2380,9 @@ URLs.</p>
    <h3 class="heading settled" data-level="4.1" id="prefer-exact-matching-to-range-based"><span class="secno">4.1. </span><span class="content">Prefer Exact Matching To Range-based</span><a class="self-link" href="#prefer-exact-matching-to-range-based"></a></h3>
    <p>The match text can be provided either as an exact string "text=foo%20bar%20baz"
 or as a range "text=foo,bar".</p>
-   <p>UAs should prefer to specify the entire string where practical. This ensures
-that if the destination page is removed or changed, the intended destination can
-still be derived from the URL itself.</p>
+   <p>Prefer to specify the entire string where practical. This ensures that if the
+destination page is removed or changed, the intended destination can still be
+derived from the URL itself.</p>
    <div class="example" id="example-53e82e58">
     <a class="self-link" href="#example-53e82e58"></a> Suppose we wish to craft a URL to
   https://en.wikipedia.org/wiki/History_of_computing quoting the sentence: 
@@ -2401,9 +2404,9 @@ Physical Phenomena" by C. E. Wynn-Williams.
    </div>
    <p>Range-based matches can be helpful when the quoted text is excessively long
 and encoding the entire string would produce an unwieldy URL.</p>
-   <p>It is recommended that text snippets shorter than 300 characters always be
-encoded using an exact match. Above this limit, the UA should encode the string
-as a range-based match.</p>
+   <p>Text snippets shorter than 300 characters are encouraged to be encoded using an
+exact match. Above this limit, the UA can encode the string as a range-based
+match.</p>
    <div class="note" role="note"> TODO:  Can we determine the above limit in some less arbitrary way? </div>
    <h3 class="heading settled" data-level="4.2" id="use-context-only-when-necessary"><span class="secno">4.2. </span><span class="content">Use Context Only When Necessary</span><a class="self-link" href="#use-context-only-when-necessary"></a></h3>
    <p>Context terms allow the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑥">text fragment directive</a> to disambiguate text
@@ -2411,7 +2414,7 @@ snippets on a page. However, their use can make the URL more brittle in some
 cases. Often, the desired string will start or end at an element boundary. The
 context will therefore exist in an adjacent element. Changes to the page
 structure could invalidate the <a data-link-type="dfn" href="#text-fragment-directive" id="ref-for-text-fragment-directive⑦">text fragment directive</a> since the context and
-match text may no longer appear to be adjacent.</p>
+match text will no longer appear to be adjacent.</p>
    <div class="example" id="example-735b40dc">
     <a class="self-link" href="#example-735b40dc"></a> Suppose we wish to craft a URL for the following text: 
 <pre>&lt;div class="section">HEADER&lt;/div>
@@ -2423,10 +2426,9 @@ match text may no longer appear to be adjacent.</p>
     <p>However, suppose the page changes to add a "[edit]" link beside all section
   headers. This would now break the URL.</p>
    </div>
-   <p>Where a text snippet is long enough and unique, a UA should prefer to avoid
+   <p>Where a text snippet is long enough and unique, a UAs are encouraged to avoid
 adding superfluous context terms.</p>
-   <p>It is recommended that context should be used only if one of the following is
-true:</p>
+   <p>Use context only if one of the following is true:</p>
    <ul>
     <li>The UA determines the quoted text is ambiguous
     <li>The quoted text contains 3 or fewer words
@@ -2450,15 +2452,15 @@ changes, invalidating the <a data-link-type="dfn" href="#text-fragment-directive
    </div>
    <p>However, UAs should take care that the fallback element-id fragment is the
 correct one:</p>
-   <div class="example" id="example-0ae51dec">
-    <a class="self-link" href="#example-0ae51dec"></a> Suppose the user navigates to
+   <div class="example" id="example-3c4e565c">
+    <a class="self-link" href="#example-3c4e565c"></a> Suppose the user navigates to
   https://en.wikipedia.org/wiki/History_of_computing#Early_computation. They
   now scroll down to the Symbolic Computations section. There, they select a
   text snippet and choose to create a URL to it: 
 <pre>By the late 1960s, computer systems could perform symbolic algebraic
 manipulations
 </pre>
-    <p>The UA should note that, even though the current URL of the page is:
+    <p>Even though the current URL of the page is:
   https://en.wikipedia.org/wiki/History_of_computing#Early_computation, using
   #Early_computation as a fallback is inappropriate. If the above sentence is
   changed or removed, the page will load in the #Early_computation section
@@ -2467,11 +2469,6 @@ manipulations
   it should remove the fragment id from the URL:</p>
     <p><a href="https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations"> https://en.wikipedia.org/wiki/History_of_computing#:~:text=By%20the%20late%201960s,%20computer%20systems%20could%20perform%20symbolic%20algebraic%20manipulations</a></p>
    </div>
-   <p>If a UA chooses not to scroll text fragments into view on navigation (reasons
-why a UA may make this choice are discussed in <a href="#security-and-privacy">§ 3.4 Security and Privacy</a>), it
-must scroll the element-id into view, if provided, regardless of whether a text
-fragment was matched. Not doing so would allow detecting the text fragment
-match based on whether the element-id was scrolled.</p>
   </main>
   <div data-fill-with="conformance">
    <h2 class="no-ref no-num heading settled" id="w3c-conformance"><span class="content">Conformance</span><a class="self-link" href="#w3c-conformance"></a></h2>

--- a/index.html
+++ b/index.html
@@ -1327,26 +1327,25 @@ text directive</a>.  Alternatively, it <em>may</em> schedule an asynchronous tas
 to find and set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a>'s indicated part.</p>
    <h4 class="heading settled" data-level="3.4.4" id="restricting-the-text-fragment"><span class="secno">3.4.4. </span><span class="content">Restricting the Text Fragment</span><a class="self-link" href="#restricting-the-text-fragment"></a></h4>
    <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a> to include a new
-boolean <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation">text fragment activation</a> field:</p>
+boolean <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation">text fragment user activation</a> field:</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a>:</strong></p>
-    <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> has an associated boolean <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport id="request-text-fragment-activation">text fragment activation</dfn>,
+    <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> has an associated boolean <dfn class="dfn-paneled" data-dfn-for="request" data-dfn-type="dfn" data-noexport id="request-text-fragment-user-activation">text fragment user activation</dfn>,
   initially false.</p>
    </blockquote>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-text-fragment-activation">text fragment activation</dfn>, which is a boolean,
+    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-text-fragment-user-activation">text fragment user activation</dfn>, which is a boolean,
   initially false.</p>
     <div class="note" role="note">
-      <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①">text fragment activation</a> provides the necessary user gesture signal to allow a
+      <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation①">text fragment user activation</a> provides the necessary user gesture signal to allow a
     single activation of a text fragment. It is set to true during document loading only if the
     navigation occurred as a result of a user activation and can be propagated across client-side
     redirects. 
-     <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation②">text fragment activation</a> isn’t used to activate a text
-    fragment, it may instead be used to set a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation">text fragment
-    activation</a> to true. In this way, a <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation③">text fragment activation</a> can be propagated
+     <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation②">text fragment user activation</a> isn’t used to activate a text
+    fragment, it may instead be used to set a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-user-activation" id="ref-for-request-text-fragment-user-activation">text fragment user activation</a> to true. In this way, a <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation③">text fragment user activation</a> can be propagated
     from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> to another across a navigation.</p>
-     <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation④">text fragment activation</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation①">text fragment activation</a> flag always resets the value to false, such that a single
+     <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation④">text fragment user activation</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-user-activation" id="ref-for-request-text-fragment-user-activation①">text fragment user activation</a> flag always resets the value to false, such that a single
     user activation cannot be reused to activate more than one text fragment.</p>
     </div>
    </blockquote>
@@ -1364,7 +1363,7 @@ boolean <a data-link-type="dfn" href="#document-text-fragment-activation" id="re
      <tt>status 3xx</tt>
      ) redirects, these "client-side"
     redirects cannot propagate the fact that the navigation is the result of a
-    user gesture. The <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑤">text fragment activation</a> mechanism allows passing
+    user gesture. The <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation⑤">text fragment user activation</a> mechanism allows passing
     through this specifically scoped user-activation through such navigations.
     This means a page can programmatically navigate to a text fragment, a
     single time, as if it has a user gesture. However, further navigations
@@ -1377,23 +1376,18 @@ boolean <a data-link-type="dfn" href="#document-text-fragment-activation" id="re
    </div>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allow-observable-text-fragment-effects">allow observable text fragment effects</dfn>, which is a
+    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allow-text-fragment-scroll">allow text fragment scroll</dfn>, which is a
   boolean, initially false.</p>
-    <div class="note" role="note"> <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects">allow observable text fragment effects</a> is used to determine whether a text fragment
-    should be allowed to activate. If it is false, the text fragment must not cause any
-    observable effects. </div>
+    <div class="note" role="note">
+     <p> <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll">allow text fragment scroll</a> is used to determine whether a text fragment will
+      perform scrolling when the document is loaded. If it is false, the text fragment may be
+      visually indicated but will not be scrolled to. This implements the mitigations discussed in <a href="#scroll-on-navigation">§ 3.4.2 Scroll On Navigation</a>. </p>
+     <p> The reason we compute and store allow text fragment scroll, rather than performing these
+      checks at the time of use, is that it relies on the properties of the navigation while the
+      invocation will occur as part of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier">scroll to the fragment</a> steps which can
+      happen outside the context of a navigation. </p>
+    </div>
    </blockquote>
-   <div class="note" role="note">
-    <p> <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑥">text fragment activation</a> is analogous to a user-activation state
-    while <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects①">allow observable text fragment effects</a> is more comprehensive, taking into
-    account various pieces of information, one of which is the value of
-    text fragment activation. </p>
-    <p> The reason we compute and store allow observable text fragment effects,
-    rather than performing the checks at the time of use, is that it relies on
-    the properties of the navigation while the invocation will occur as part of
-    the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier">scroll to the fragment</a> steps which can happen outside
-    the context of a navigation. </p>
-   </div>
    <div class="note" role="note"> TODO: This should really only prevent potentially observable side-effects like
   automatic scrolling. Unobservable effects like a highlight could be safely
   allowed in all cases. </div>
@@ -1403,7 +1397,7 @@ and initialize a Document object</a> steps by adding the following steps before 
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
     <ol start="15">
      <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑦">text fragment activation</a> by following these sub-steps:</p>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation⑥">text fragment user activation</a> by following these sub-steps:</p>
       <ol>
        <li data-md>
         <p>Let <var>is user activated</var> be true if the current navigation was initiated from
@@ -1413,19 +1407,19 @@ and initialize a Document object</a> steps by adding the following steps before 
         <div class="note" role="note"> TODO: it’d be better to refer to the userActivationFlag on the <var>request</var>. See <a href="https://w3c.github.io/webappsec-fetch-metadata/#request-user-activation-flag">Sec-Fetch-User</a> in <a data-link-type="biblio" href="#biblio-fetch-metadata" title="Fetch Metadata Request Headers">[FETCH-METADATA]</a>. </div>
        <li data-md>
         <p>If <var>browsing context</var> is a top-level browsing context and if either of <var>is
-  user activated</var> or the <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation②">text fragment activation</a> of <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> object is true, set the <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑧">text fragment activation</a> to true. Otherwise, set it to false.</p>
+  user activated</var> or the <a data-link-type="dfn" href="#request-text-fragment-user-activation" id="ref-for-request-text-fragment-user-activation②">text fragment user activation</a> of <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> object is true, set the <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation⑦">text fragment user activation</a> to true. Otherwise, set it to false.</p>
         <div class="note" role="note"> It’s important that the flag not be copyable so that only one text fragment can be
     activated per user-activated navigation. </div>
       </ol>
      <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects②">allow observable text fragment effects</a> by following these sub-steps:</p>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll①">allow text fragment scroll</a> by following these sub-steps:</p>
       <ol>
        <li data-md>
-        <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects③">allow observable text fragment effects</a> to false and abort these sub-steps.</p>
+        <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll②">allow text fragment scroll</a> to false and abort these sub-steps.</p>
        <li data-md>
-        <p>Let <var>text fragment activation</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑨">text fragment activation</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①⓪">text fragment activation</a> to false.</p>
+        <p>Let <var>text fragment user activation</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation⑧">text fragment user activation</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation⑨">text fragment user activation</a> to false.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects④">allow observable text fragment effects</a> to true and abort these sub-steps.</p>
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll③">allow text fragment scroll</a> to true and abort these sub-steps.</p>
         <div class="note" role="note">
          <p> If a navigation originates from browser UI, it’s always ok to allow it
       since it’ll be user triggered and the page/script isn’t providing the
@@ -1443,23 +1437,23 @@ and initialize a Document object</a> steps by adding the following steps before 
          <p> See <a href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a> for a more detailed discussion of how this should apply. </p>
         </div>
        <li data-md>
-        <p>If <var>text fragment activation</var> is false, set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑤">allow observable text fragment effects</a> to false and abort these sub-steps.</p>
+        <p>If <var>text fragment user activation</var> is false, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll④">allow text fragment scroll</a> to false and abort these sub-steps.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑥">allow observable text fragment effects</a> to true and abort these
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑤">allow text fragment scroll</a> to true and abort these
   sub-steps.</p>
        <li data-md>
         <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing
-  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑦">allow observable text fragment effects</a> to true and abort these sub-steps.</p>
+  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑥">allow text fragment scroll</a> to true and abort these sub-steps.</p>
         <div class="note" role="note"> i.e. Only allow navigation from a cross-origin element/script if the
     document is loaded in a noopener context. That is, a new top level
     browsing context group to which the navigator does not have script access
     and which may be placed into a separate process. </div>
        <li data-md>
-        <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑧">allow observable text fragment effects</a> to false.</p>
+        <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑦">allow text fragment scroll</a> to false.</p>
       </ol>
     </ol>
    </blockquote>
-   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation③">text fragment activation</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document①">active document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①①">text fragment activation</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document②">active document</a>'s value to
+   <p>Amend step 2 of the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch"> process a navigate fetch</a> steps to additionally set <var>request</var>’s <a data-link-type="dfn" href="#request-text-fragment-user-activation" id="ref-for-request-text-fragment-user-activation③">text fragment user activation</a> to the value of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document①">active document</a>'s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation①⓪">text fragment user activation</a> and set the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document②">active document</a>'s value to
 false.</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
@@ -1469,9 +1463,9 @@ false.</p>
   settings object, destination to "document", mode to "navigate", credentials
   mode to "include", use-URL-credentials flag, redirect mode to "manual",
   replaces client id to browsingContext’s active document’s relevant settings
-  object’s id, and <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation④">text fragment activation</a> to
-  sourceBrowsingContext’s active document’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①②">text fragment activation</a>. Set sourceBrowsingContext’s active
-  document’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①③">text fragment activation</a> to false.</p>
+  object’s id, and <a data-link-type="dfn" href="#request-text-fragment-user-activation" id="ref-for-request-text-fragment-user-activation④">text fragment user activation</a> to
+  sourceBrowsingContext’s active document’s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation①①">text fragment user activation</a>. Set sourceBrowsingContext’s active
+  document’s <a data-link-type="dfn" href="#document-text-fragment-user-activation" id="ref-for-document-text-fragment-user-activation①②">text fragment user activation</a> to false.</p>
     </ol>
    </blockquote>
    <p>Amend the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment">try to scroll to the fragment</a> steps by replacing the
@@ -1482,13 +1476,13 @@ steps of the task queued in step 2:</p>
      <li data-md>
       <p>If document has no parser, or its parser has stopped parsing, or the user
   agent has reason to believe the user is no longer interested in scrolling to
-  the fragment, then set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑨">allow observable text fragment effects</a> to false and abort these steps.</p>
+  the fragment, then set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑧">allow text fragment scroll</a> to false and abort these steps.</p>
      <li data-md>
       <p>Scroll to the fragment given in document’s URL. If this does not find an
   indicated part, then try to scroll to the fragment for
   document.</p>
      <li data-md>
-      <p>Set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects①⓪">allow observable text fragment effects</a> to false.</p>
+      <p>Set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑨">allow text fragment scroll</a> to false.</p>
     </ol>
    </blockquote>
    <h3 class="heading settled" data-level="3.5" id="navigating-to-text-fragment"><span class="secno">3.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
@@ -1568,7 +1562,7 @@ beginning of the processing model for the <a data-link-type="dfn" href="https://
      <li data-md>
       <p>Let <var>fragment directive string</var> be the document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment directive</a>.</p>
      <li data-md>
-      <p>If the document’s <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects①①">allow observable text fragment effects</a> is true then:</p>
+      <p>If the document’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll①⓪">allow text fragment scroll</a> is true then:</p>
       <ol>
        <li data-md>
         <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
@@ -2532,7 +2526,7 @@ match based on whether the element-id was scrolled.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#document-allow-observable-text-fragment-effects">allow observable text fragment effects</a><span>, in § 3.4.4</span>
+   <li><a href="#document-allow-text-fragment-scroll">allow text fragment scroll</a><span>, in § 3.4.4</span>
    <li><a href="#characterstring">CharacterString</a><span>, in § 3.3.3</span>
    <li><a href="#explicitchar">ExplicitChar</a><span>, in § 3.3.3</span>
    <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in § 3.5.2</span>
@@ -2573,13 +2567,13 @@ match based on whether the element-id was scrolled.</p>
    <li><a href="#textdirectivestring">TextDirectiveString</a><span>, in § 3.3.3</span>
    <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in § 3.3.3</span>
    <li><a href="#parsedtextdirective-textend">textEnd</a><span>, in § 3.3.2</span>
-   <li>
-    text fragment activation
-    <ul>
-     <li><a href="#document-text-fragment-activation">dfn for document</a><span>, in § 3.4.4</span>
-     <li><a href="#request-text-fragment-activation">dfn for request</a><span>, in § 3.4.4</span>
-    </ul>
    <li><a href="#text-fragment-directive">text fragment directive</a><span>, in § 3.3.3</span>
+   <li>
+    text fragment user activation
+    <ul>
+     <li><a href="#document-text-fragment-user-activation">dfn for document</a><span>, in § 3.4.4</span>
+     <li><a href="#request-text-fragment-user-activation">dfn for request</a><span>, in § 3.4.4</span>
+    </ul>
    <li><a href="#parsedtextdirective-textstart">textStart</a><span>, in § 3.3.2</span>
    <li><a href="#unknowndirective">UnknownDirective</a><span>, in § 3.3.3</span>
    <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in § 3.3.3</span>
@@ -3547,23 +3541,23 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
     <li><a href="#ref-for-percentencodedchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-percentencodedchar①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-text-fragment-activation">
-   <b><a href="#request-text-fragment-activation">#request-text-fragment-activation</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="request-text-fragment-user-activation">
+   <b><a href="#request-text-fragment-user-activation">#request-text-fragment-user-activation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-text-fragment-activation">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-request-text-fragment-activation①">(2)</a> <a href="#ref-for-request-text-fragment-activation②">(3)</a> <a href="#ref-for-request-text-fragment-activation③">(4)</a> <a href="#ref-for-request-text-fragment-activation④">(5)</a>
+    <li><a href="#ref-for-request-text-fragment-user-activation">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-request-text-fragment-user-activation①">(2)</a> <a href="#ref-for-request-text-fragment-user-activation②">(3)</a> <a href="#ref-for-request-text-fragment-user-activation③">(4)</a> <a href="#ref-for-request-text-fragment-user-activation④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-text-fragment-activation">
-   <b><a href="#document-text-fragment-activation">#document-text-fragment-activation</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="document-text-fragment-user-activation">
+   <b><a href="#document-text-fragment-user-activation">#document-text-fragment-user-activation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-text-fragment-activation">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-text-fragment-activation①">(2)</a> <a href="#ref-for-document-text-fragment-activation②">(3)</a> <a href="#ref-for-document-text-fragment-activation③">(4)</a> <a href="#ref-for-document-text-fragment-activation④">(5)</a> <a href="#ref-for-document-text-fragment-activation⑤">(6)</a> <a href="#ref-for-document-text-fragment-activation⑥">(7)</a> <a href="#ref-for-document-text-fragment-activation⑦">(8)</a> <a href="#ref-for-document-text-fragment-activation⑧">(9)</a> <a href="#ref-for-document-text-fragment-activation⑨">(10)</a> <a href="#ref-for-document-text-fragment-activation①⓪">(11)</a> <a href="#ref-for-document-text-fragment-activation①①">(12)</a> <a href="#ref-for-document-text-fragment-activation①②">(13)</a> <a href="#ref-for-document-text-fragment-activation①③">(14)</a>
+    <li><a href="#ref-for-document-text-fragment-user-activation">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-text-fragment-user-activation①">(2)</a> <a href="#ref-for-document-text-fragment-user-activation②">(3)</a> <a href="#ref-for-document-text-fragment-user-activation③">(4)</a> <a href="#ref-for-document-text-fragment-user-activation④">(5)</a> <a href="#ref-for-document-text-fragment-user-activation⑤">(6)</a> <a href="#ref-for-document-text-fragment-user-activation⑥">(7)</a> <a href="#ref-for-document-text-fragment-user-activation⑦">(8)</a> <a href="#ref-for-document-text-fragment-user-activation⑧">(9)</a> <a href="#ref-for-document-text-fragment-user-activation⑨">(10)</a> <a href="#ref-for-document-text-fragment-user-activation①⓪">(11)</a> <a href="#ref-for-document-text-fragment-user-activation①①">(12)</a> <a href="#ref-for-document-text-fragment-user-activation①②">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-allow-observable-text-fragment-effects">
-   <b><a href="#document-allow-observable-text-fragment-effects">#document-allow-observable-text-fragment-effects</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="document-allow-text-fragment-scroll">
+   <b><a href="#document-allow-text-fragment-scroll">#document-allow-text-fragment-scroll</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-allow-observable-text-fragment-effects">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allow-observable-text-fragment-effects①">(2)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects②">(3)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects③">(4)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects④">(5)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑤">(6)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑥">(7)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑦">(8)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑧">(9)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑨">(10)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects①⓪">(11)</a>
-    <li><a href="#ref-for-document-allow-observable-text-fragment-effects①①">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-document-allow-text-fragment-scroll">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allow-text-fragment-scroll①">(2)</a> <a href="#ref-for-document-allow-text-fragment-scroll②">(3)</a> <a href="#ref-for-document-allow-text-fragment-scroll③">(4)</a> <a href="#ref-for-document-allow-text-fragment-scroll④">(5)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑤">(6)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑥">(7)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑦">(8)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑧">(9)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑨">(10)</a>
+    <li><a href="#ref-for-document-allow-text-fragment-scroll①⓪">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="first-common-ancestor">

--- a/index.html
+++ b/index.html
@@ -733,7 +733,7 @@ dd:not(:last-child) > .wpt-tests-block:not([open]):last-child {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-12-21">21 December 2022</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-12-22">22 December 2022</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1338,14 +1338,16 @@ boolean <a data-link-type="dfn" href="#document-text-fragment-activation" id="re
     <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-text-fragment-activation">text fragment activation</dfn>, which is a boolean,
   initially false.</p>
     <div class="note" role="note">
-      <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①">text fragment activation</a> is consumed in order to allow a single activation of a
-    text fragment. It is set during document loading only if the navigation occurred as a result
-    of a user activation and can be propagated across client-side redirects. 
-     <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation②">text fragment activation</a> isn’t consumed to activate
-    a text fragment, it may be consumed to set the <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation">text fragment activation</a> flag of a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>. In this way, a <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation③">text fragment activation</a> can be propagated from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> to another across a navigation.</p>
-     <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation④">text fragment activation</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation①">text fragment activation</a> flag always consumes the value by
-    setting it to false, such that a single activation cannot be reused to activate more than one
-    text fragment.</p>
+      <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①">text fragment activation</a> provides the necessary user gesture signal to allow a
+    single activation of a text fragment. It is set to true during document loading only if the
+    navigation occurred as a result of a user activation and can be propagated across client-side
+    redirects. 
+     <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation②">text fragment activation</a> isn’t used to activate a text
+    fragment, it may instead be used to set a navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation">text fragment
+    activation</a> to true. In this way, a <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation③">text fragment activation</a> can be propagated
+    from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> to another across a navigation.</p>
+     <p>Reading either the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation④">text fragment activation</a> or the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-fragment-activation" id="ref-for-request-text-fragment-activation①">text fragment activation</a> flag always resets the value to false, such that a single
+    user activation cannot be reused to activate more than one text fragment.</p>
     </div>
    </blockquote>
    <div class="note" role="note">
@@ -1375,18 +1377,18 @@ boolean <a data-link-type="dfn" href="#document-text-fragment-activation" id="re
    </div>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allow-text-fragment">allow text fragment</dfn>, which is a
+    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allow-observable-text-fragment-effects">allow observable text fragment effects</dfn>, which is a
   boolean, initially false.</p>
-    <div class="note" role="note"> <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment">allow text fragment</a> is used to determine whether a text fragment
+    <div class="note" role="note"> <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects">allow observable text fragment effects</a> is used to determine whether a text fragment
     should be allowed to activate. If it is false, the text fragment must not cause any
     observable effects. </div>
    </blockquote>
    <div class="note" role="note">
     <p> <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑥">text fragment activation</a> is analogous to a user-activation state
-    while <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment①">allow text fragment</a> is more comprehensive, taking into
+    while <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects①">allow observable text fragment effects</a> is more comprehensive, taking into
     account various pieces of information, one of which is the value of
     text fragment activation. </p>
-    <p> The reason we compute and store allow text fragment,
+    <p> The reason we compute and store allow observable text fragment effects,
     rather than performing the checks at the time of use, is that it relies on
     the properties of the navigation while the invocation will occur as part of
     the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier">scroll to the fragment</a> steps which can happen outside
@@ -1416,14 +1418,14 @@ and initialize a Document object</a> steps by adding the following steps before 
     activated per user-activated navigation. </div>
       </ol>
      <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment②">allow text fragment</a> by following these sub-steps:</p>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects②">allow observable text fragment effects</a> by following these sub-steps:</p>
       <ol>
        <li data-md>
-        <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment③">allow text fragment</a> to false and abort these sub-steps.</p>
+        <p>If <var>document</var>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects③">allow observable text fragment effects</a> to false and abort these sub-steps.</p>
        <li data-md>
         <p>Let <var>text fragment activation</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation⑨">text fragment activation</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-text-fragment-activation" id="ref-for-document-text-fragment-activation①⓪">text fragment activation</a> to false.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment④">allow text fragment</a> to true and abort these sub-steps.</p>
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects④">allow observable text fragment effects</a> to true and abort these sub-steps.</p>
         <div class="note" role="note">
          <p> If a navigation originates from browser UI, it’s always ok to allow it
       since it’ll be user triggered and the page/script isn’t providing the
@@ -1441,19 +1443,19 @@ and initialize a Document object</a> steps by adding the following steps before 
          <p> See <a href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a> for a more detailed discussion of how this should apply. </p>
         </div>
        <li data-md>
-        <p>If <var>text fragment activation</var> is false, set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑤">allow text fragment</a> to false and abort these sub-steps.</p>
+        <p>If <var>text fragment activation</var> is false, set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑤">allow observable text fragment effects</a> to false and abort these sub-steps.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑥">allow text fragment</a> to true and abort these
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑥">allow observable text fragment effects</a> to true and abort these
   sub-steps.</p>
        <li data-md>
         <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing
-  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑦">allow text fragment</a> to true and abort these sub-steps.</p>
+  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑦">allow observable text fragment effects</a> to true and abort these sub-steps.</p>
         <div class="note" role="note"> i.e. Only allow navigation from a cross-origin element/script if the
     document is loaded in a noopener context. That is, a new top level
     browsing context group to which the navigator does not have script access
     and which may be placed into a separate process. </div>
        <li data-md>
-        <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑧">allow text fragment</a> to false.</p>
+        <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑧">allow observable text fragment effects</a> to false.</p>
       </ol>
     </ol>
    </blockquote>
@@ -1480,13 +1482,13 @@ steps of the task queued in step 2:</p>
      <li data-md>
       <p>If document has no parser, or its parser has stopped parsing, or the user
   agent has reason to believe the user is no longer interested in scrolling to
-  the fragment, then set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment⑨">allow text fragment</a> to false and abort these steps.</p>
+  the fragment, then set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects⑨">allow observable text fragment effects</a> to false and abort these steps.</p>
      <li data-md>
       <p>Scroll to the fragment given in document’s URL. If this does not find an
   indicated part, then try to scroll to the fragment for
   document.</p>
      <li data-md>
-      <p>Set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment①⓪">allow text fragment</a> to false.</p>
+      <p>Set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects①⓪">allow observable text fragment effects</a> to false.</p>
     </ol>
    </blockquote>
    <h3 class="heading settled" data-level="3.5" id="navigating-to-text-fragment"><span class="secno">3.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
@@ -1566,7 +1568,7 @@ beginning of the processing model for the <a data-link-type="dfn" href="https://
      <li data-md>
       <p>Let <var>fragment directive string</var> be the document’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment directive</a>.</p>
      <li data-md>
-      <p>If the document’s <a data-link-type="dfn" href="#document-allow-text-fragment" id="ref-for-document-allow-text-fragment①①">allow text fragment</a> is true then:</p>
+      <p>If the document’s <a data-link-type="dfn" href="#document-allow-observable-text-fragment-effects" id="ref-for-document-allow-observable-text-fragment-effects①①">allow observable text fragment effects</a> is true then:</p>
       <ol>
        <li data-md>
         <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
@@ -2530,7 +2532,7 @@ match based on whether the element-id was scrolled.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#document-allow-text-fragment">allow text fragment</a><span>, in § 3.4.4</span>
+   <li><a href="#document-allow-observable-text-fragment-effects">allow observable text fragment effects</a><span>, in § 3.4.4</span>
    <li><a href="#characterstring">CharacterString</a><span>, in § 3.3.3</span>
    <li><a href="#explicitchar">ExplicitChar</a><span>, in § 3.3.3</span>
    <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in § 3.5.2</span>
@@ -3557,11 +3559,11 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
     <li><a href="#ref-for-document-text-fragment-activation">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-text-fragment-activation①">(2)</a> <a href="#ref-for-document-text-fragment-activation②">(3)</a> <a href="#ref-for-document-text-fragment-activation③">(4)</a> <a href="#ref-for-document-text-fragment-activation④">(5)</a> <a href="#ref-for-document-text-fragment-activation⑤">(6)</a> <a href="#ref-for-document-text-fragment-activation⑥">(7)</a> <a href="#ref-for-document-text-fragment-activation⑦">(8)</a> <a href="#ref-for-document-text-fragment-activation⑧">(9)</a> <a href="#ref-for-document-text-fragment-activation⑨">(10)</a> <a href="#ref-for-document-text-fragment-activation①⓪">(11)</a> <a href="#ref-for-document-text-fragment-activation①①">(12)</a> <a href="#ref-for-document-text-fragment-activation①②">(13)</a> <a href="#ref-for-document-text-fragment-activation①③">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-allow-text-fragment">
-   <b><a href="#document-allow-text-fragment">#document-allow-text-fragment</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="document-allow-observable-text-fragment-effects">
+   <b><a href="#document-allow-observable-text-fragment-effects">#document-allow-observable-text-fragment-effects</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-allow-text-fragment">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allow-text-fragment①">(2)</a> <a href="#ref-for-document-allow-text-fragment②">(3)</a> <a href="#ref-for-document-allow-text-fragment③">(4)</a> <a href="#ref-for-document-allow-text-fragment④">(5)</a> <a href="#ref-for-document-allow-text-fragment⑤">(6)</a> <a href="#ref-for-document-allow-text-fragment⑥">(7)</a> <a href="#ref-for-document-allow-text-fragment⑦">(8)</a> <a href="#ref-for-document-allow-text-fragment⑧">(9)</a> <a href="#ref-for-document-allow-text-fragment⑨">(10)</a> <a href="#ref-for-document-allow-text-fragment①⓪">(11)</a>
-    <li><a href="#ref-for-document-allow-text-fragment①①">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-document-allow-observable-text-fragment-effects">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allow-observable-text-fragment-effects①">(2)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects②">(3)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects③">(4)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects④">(5)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑤">(6)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑥">(7)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑦">(8)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑧">(9)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects⑨">(10)</a> <a href="#ref-for-document-allow-observable-text-fragment-effects①⓪">(11)</a>
+    <li><a href="#ref-for-document-allow-observable-text-fragment-effects①①">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="first-common-ancestor">


### PR DESCRIPTION
As per #178, spec text now typically uses space-separated names and "flag" is discouraged so this PR fixes #202 by changing `textFragmentActivationFlag` to `text fragment activation` and `allowTextFragmentDirective` to `allow text fragment directive` and fixes up some surrounding prose.

Fixes #178


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/ScrollToTextFragment/pull/203.html" title="Last updated on Dec 22, 2022, 8:53 PM UTC (eceafd7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/203/b0837c5...bokand:eceafd7.html" title="Last updated on Dec 22, 2022, 8:53 PM UTC (eceafd7)">Diff</a>