### PR TITLE
Fix a few bikeshed errors and warnings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -16,9 +16,13 @@ WPT Display: inline
 </pre>
 
 <pre class='link-defaults'>
+spec:css-cascade-5; type:dfn; text:computed value
 spec:css-display-3; type:value; for:display; text:flex
 spec:css-display-3; type:value; for:display; text:grid
+spec:css-display-4; type:property; text:display
+spec:css-display-4; type:property; text:visibility
 spec:dom; type:dfn; for:/; text:element
+spec:dom; type:dfn; text:range
 spec:html; type:element; text:link
 spec:html; type:dfn; for:/; text:origin
 spec:html; type:element; text:script
@@ -768,10 +772,8 @@ boolean [=document/text fragment user activation=] field:
     The following diagram demonstrates how the flag is used to activate a text
     fragment through a client-side redirect service:
   </p>
-  <img style="margin-left:auto;margin-right:auto;display:block"
-       width="745" height="671"
-       src="https://raw.githubusercontent.com/WICG/scroll-to-text-fragment/master/text_fragment_activation_flag.png"
-       alt="Diagram showing how a text fragment flag is set and used">
+
+  <img style="margin-left:auto;margin-right:auto;display:block" width="745" height="671" src="https://raw.githubusercontent.com/WICG/scroll-to-text-fragment/master/text_fragment_activation_flag.png" alt="Diagram showing how a text fragment flag is set and used">
 
   <p>
     See [redirects.md](redirects.md) for a more in-depth discussion.


### PR DESCRIPTION
Fix ambiguous references.

Bikeshed complained about an unclosed `<img>` if the attributes are separated by newline.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 17, 2023, 6:40 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fscroll-to-text-fragment%2Fbfc924d88f460991eff446be3b34a07dcc67d0a1%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Tag &lt;img> wasn't closed at end of file.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/scroll-to-text-fragment%23212.)._
</details>
