### PR TITLE
Disambiguate UnknownDirective grammar

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -548,9 +548,9 @@ in the [=fragment directive=] that matches the production:
   </dt>
   <dd>
     <code>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
-    ";" | "=" | "?" | "@" | "_" | "~" | "&" | "," | "-"</code>
+    ";" | "=" | "?" | "@" | "_" | "~" | "," | "-"</code>
   <div class = "note">
-    An [=ExplicitChar=] may be any [=URL code point=].
+    An [=ExplicitChar=] may be any [=URL code point=] other than "&".
   </div>
   </dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@ dd:not(:last-child) > .wpt-tests-block:not([open]):last-child {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Text Fragments</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2023-03-24">24 March 2023</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2023-03-27">27 March 2023</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1228,8 +1228,8 @@ in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-d
     <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="explicitchar"><code>ExplicitChar</code></dfn> <code>::=</code> 
     <dd>
       <code>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
-    ";" | "=" | "?" | "@" | "_" | "~" | "&amp;" | "," | "-"</code> 
-     <div class="note" role="note"> An <a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar①">ExplicitChar</a> may be any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points">URL code point</a>. </div>
+    ";" | "=" | "?" | "@" | "_" | "~" | "," | "-"</code> 
+     <div class="note" role="note"> An <a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar①">ExplicitChar</a> may be any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points">URL code point</a> other than "&amp;". </div>
    </dl>
    <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirectiveproduction" id="ref-for-fragmentdirectiveproduction①">FragmentDirective</a> can contain multiple directives split by the "&amp;"
   character. Currently this means we allow multiple text directives to enable


### PR DESCRIPTION
The grammar for an `UnknownDirective` accidentally allows `&` which would make it ambiguous, since directives are separated by `&`. Remove `&` from the set of allowed characters.