### PR TITLE
Improve integration with navigation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -59,6 +59,16 @@ spec:url; type:dfn; text:fragment
   }
 </pre>
 
+<style>
+  .monkeypatch {
+    color: grey;
+  }
+
+  .monkeypatch .diff {
+    color: black;
+  }
+</style>
+
 <h2 id=infrastructure>Infrastructure</h2>
 
 <p>This specification depends on the Infra Standard. [[!INFRA]]
@@ -237,12 +247,12 @@ The <dfn>fragment directive delimiter</dfn> is the string ":~:", that is the
 three consecutive code points U+003A (:), U+007E (~), U+003A (:).
 
 <div class="note">
-  The [=/fragment directive=] is part of the URL fragment. This means it
+  The [=fragment directive=] is part of the URL fragment. This means it
   always appears after a U+0023 (#) code point in a URL.
 </div>
 
 <div class="example">
-  To add a [=/fragment directive=] to a URL like https://example.com, a fragment
+  To add a [=fragment directive=] to a URL like https://example.com, a fragment
   is first appended to the URL: https://example.com#:~:text=foo.
 </div>
 
@@ -260,115 +270,225 @@ action. Multiple directives may appear in the fragment directive.
   <p>Contains 2 text directives and one unknown directive.</p>
 </div>
 
-
-To prevent impacting page operation, it is stripped from a [=Document=]'s
-[=Document/URL=] to prevent interaction with author script. This also ensures
-future directives can be added without web compatibility risk.
+To prevent impacting page operation, it is stripped from script-accessible APIs to prevent
+interaction with author script. This also ensures future directives can be added without web
+compatibility risk.
 
 ### Processing the fragment directive ### {#processing-the-fragment-directive}
 
-The [=/fragment directive=] is processed and removed from the fragment whenever the
-UA sets the [=Document/URL=] on a [=Document=]. This is defined with the
-following additions and changes.
-
-To the definition of [=Document=], add:
-
->   <strong>Monkeypatching [[DOM]]:</strong>
->
->   <em>
->     Each document has an associated <dfn for="Document">fragment
->     directive</dfn> which is either null or an ASCII string holding data used
->     by the UA to process the resource. It is initially null.
->   </em>
-
-<div algorithm="split the fragment from the fragment directive">
-  To <dfn export>split the fragment from the fragment directive</dfn>, given an ASCII string
-  |raw fragment| and returning a [=/tuple=] consisting of a <code>fragment</code> and a
-  <code>fragment directive</code> (both ASCII strings), run these steps:
-
-  <ol class="algorithm">
-    1. Let |position| be the [=string/position variable=] pointing to the first code
-        point of the first instance, if one exists, of the [=fragment directive delimiter=] in |raw
-        fragment|, or past the end of |raw fragment| otherwise.
-    1. Let |fragment| be the [=code point substring by positions=] of |raw fragment| from the
-        start of |raw fragment| to |position|.
-    1. Let |fragmentDirective| be an ASCII string, initially empty.
-    1. Advance |position| by the [=string/code point length=] of the [=fragment directive
-        delimiter=].
-    1. If |position| does not point past the end of |raw fragment|:
-        1. Set |fragmentDirective| to the [=code point substring to the end of the string=]
-            |raw fragment| starting from |position|
-    1. Return the [=/tuple=] (|fragment|, |fragmentDirective|).
-  </ol>
-</div>
-
-
-Whenever the fragment directive is stripped from the URL, the
-Document's [=Document/fragment directive=] is set to the content of the fragment directive.
-
-Add a series of steps that will process a fragment directive on a [=Document/URL=]:
-
->   <strong>Monkeypatching [[DOM]]:</strong>
->
->   To <dfn>process and consume fragment directive</dfn> from a [=/URL=]
->   |url| and [=Document=] |document|, run these steps:
->   1. Let |raw fragment| be equal to |url|'s [=url/fragment=].
->   1. If |raw fragment| is non-null and contains the [=fragment directive
->       delimiter=] as a substring:
->       1. Let |components| be the result of running [=split the fragment from the fragment
->           directive=] on |raw fragment|.
->       1. Set |url|'s [=url/fragment=] to |components|' <code>fragment</code>.
->       1. Set |document|'s [=Document/fragment directive=] to |components|' <code>fragment directive</code>.
->           <div class="note">This is stored on the document but currently not web-exposed</div>
+This section describes the mechanism by which the fragment directive is hidden
+from script and how it fits into [[HTML#navigation-and-session-history]].
 
 <div class="note">
-  These changes make a URL's fragment end at the [=fragment directive
-  delimiter=]. The [=/fragment directive=] includes all characters that follow,
-  but not including, the delimiter.
+  The summarized changes in this section:
+
+  * Session history entries now include a new "directive state" item
+  * All new entries are created with a directive state with an empty value. If the new URL includes
+      a fragment directive it will be written to the state's value (otherwise it remains null).
+  * Any time a URL potentially including a fragment directive is written to a session history entry,
+      extract the fragment directive from the URL and store it in a directive state item of the
+      entry. There are three such points where a URL can potentially include a directive:
+      * In the "navigate" steps for typical cross-document navigations
+      * In the "navigate to a fragment" steps for fragment based same-document navigations
+      * In the "URL and history update steps" for synchronous updates such as
+          pushState/replaceState.
+  * Same-document navigations that change only the fragment, and the new URL doesn't specify a
+      directive, will create an entry whose directive state refers to the previous entry's directive
+      state.
+
 </div>
 
-<div class="example">
-<code>https://example.org/#test:~:text=foo</code> will be parsed such that
-the fragment is the string "test" and the [=/fragment directive=] is the string
-"text=foo".
+<div class="issue">
+    The <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching:~:text=Set%20entry%27s%20URL%20to%20currentURL">
+    create navigation params by fetching</a> steps also write a URL to an entry. As written, that URL always
+    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching:~:text=Set%20locationURL%20to%20response%27s%20location%20URL%20given%20currentURL%27s%20fragment.">
+    uses the fragment from an existing entry</a> so the directive would already be removed. However,
+    I think that's wrong. If the redirect URL includes a fragment it should be used, see
+    <a href="https://www.rfc-editor.org/rfc/rfc7231#section-7.1.2">RFC7231</a>. Browsers all
+    <a href="https://wpt.fyi/results/fetch/redirect-navigate/preserve-fragment.html">implement the
+    RFC behavior</a> so it seems like this is a spec bug in HTML. If fixed, this is a fourth place
+    where the directive would have to be removed.
 </div>
 
+In [[HTML#session-history-infrastructure]], define [=/directive state=]:
 
-Amend the
-<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">
-create and initialize a Document object</a> steps to parse and remove the
-[=/fragment directive=] by inserting the following steps right before the
-setting |document|'s [=Document/URL=]
-(<a href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#initialise-the-document-object">currently</a>
-step 9):
+>   <strong>Monkeypatching [[HTML#session-history-infrastructure]]:</strong>
+>
+>   <dfn>directive state</dfn> holds the value of the [=fragment directive=] at the time the session
+>   history entry was created and is used to invoke directives, such as text highlighting, whenever
+>   the entry is traversed. It has:
+>   * <dfn for="directive state">value</dfn>, the [=fragment directive=] ASCII string or null,
+>       initially null.
+>
+>   A [=/directive state=] may be shared across contiguous session history entries.
+>
+>   <div class="note">
+>       <p>The fragment directive is removed from the URL before the URL is set to the session
+>       history entry. It is instead stored in the directive state. This prevents it from being
+>       visible to script APIs so that a directive can be specified without interfering with a
+>       page's operation.</p>
+>
+>       <p>The fragment directive is stored in the directive state object, rather than a raw string,
+>       since the same directive state can be shared across multiple contiguous session history
+>       entries. On a traversal, the directive is only processed (i.e. search text and highlight) if
+>       the directive state has changed between two entries.</p>
+>   </div>
+
+To the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-entry">session history entry</a>, add:
+
+>   <strong>Monkeypatching [[HTML#session-history-entries]]:</strong>
+>
+>   <div class="monkeypatch">A session history entry is a struct with the following items:
+>     * ...
+>     * persisted user state, which is implementation-defined, initially null
+>     * <span class="diff"><dfn for=she>directive state</dfn>, a [=/directive state=],
+>         initially a new [=/directive state=]</span>
+>   </div>
+
+Add a helper algorithm for removing and returning a fragment directive string from a [=/URL=]:
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   9. Run the [=process and consume fragment directive=] steps on
->     |creationURL| and |document|.
->   10. Set |document|'s [=Document/URL=] to be |creationURL|.
-
-Amend the
-<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history">
-traverse the history</a> steps to process the [=/fragment directive=]
-during a history navigation by inserting steps before setting the |newDocument|'s URL (<a
-href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#traverse-the-history">currently</a>
-step 6).
-
->   <strong>Monkeypatching [[HTML]]:</strong>
+>   <div class="note">
+>     This algorithm makes a URL's fragment end at the [=fragment directive
+>     delimiter=]. The returned [=/fragment directive=] includes all characters that follow the
+>     delimiter but does not include the delimiter.
+>   </div>
 >
->   6. Let |processedURL| be a copy of <var ignore="">entry</var>'s URL.
->   7. Run the [=process and consume fragment directive=] steps on
->       |processedURL| and |document|.
->   8. Set |newDocument|'s URL to |processedURL|.
+>   <div class="issue">
+>     If a URL's fragment ends with ':~:' (i.e. empty directive), this will return null which is
+>     treated as the URL not specifying an explicit directive (and avoids clobbering an existing
+>     one. But maybe in this case we should return the empty string? That way a page can explicitly
+>     clear directives/highlights by navigating/pushState to '#:~:'.
+>   </div>
+>
+>   To <dfn>remove the fragment directive</dfn> from a [=/URL=] |url|, run these steps:
+>   1. Let |raw fragment| be equal to |url|'s [=url/fragment=].
+>   1. Let |fragment directive| be null.
+>   1. If |raw fragment| is non-null and contains the [=fragment directive delimiter=] as a
+>       substring:
+>       1. Let |position| be the [=string/position variable=] pointing to the first code
+>           point of the first instance, if one exists, of the [=fragment directive delimiter=] in
+>           |raw fragment|, or past the end of |raw fragment| otherwise.
+>       1. Let |new fragment| be the [=code point substring by positions=] of |raw fragment| from
+>           the start of |raw fragment| to |position|.
+>       1. Advance |position| by the [=string/code point length=] of the [=fragment directive
+>           delimiter=].
+>       1. If |position| does not point past the end of |raw fragment|:
+>           1. Set |fragment directive| to the [=code point substring to the end of the string=]
+>               |raw fragment| starting from |position|
+>       1. Set |url|'s [=url/fragment=] to |new fragment|.
+>   1. Return |fragment directive|.
+>
+>   <div class="example">
+>      <code>https://example.org/#test:~:text=foo</code> will be parsed such that
+>      the fragment is the string "test" and the [=/fragment directive=] is the string
+>      "text=foo".
+>   </div>
+
+The next three monkeypatches modify the creation of a session history entry, where the URL might
+contain a fragment directive, to remove the fragment directive and store it in the [=/directive
+state=].
+
+In the definition of [=navigate=]:
+
+>   <strong>Monkeypatching [[HTML#beginning-navigation]]:</strong>
+>
+>   <div class="monkeypatch">To navigate a navigable navigable to a URL |url|...:
+>     1. ...
+>         <li value="14">Set navigable's ongoing navigation to navigationId.</li>
+>     15. If url's scheme is "javascript", then...
+>     16. In parallel, run these steps:
+>         1. ...
+>             <li value="5">If url is about:blank, then set documentState's origin to documentState's initiator origin.</li>
+>         6. Otherwise, if url is about:srcdoc, then set documentState's origin to navigable's parent's active document's origin.
+>         7. <strike>Let historyEntry be a new session history entry, with its URL set to url and
+>             its document state set to documentState.</strike>
+>             <li value="7"><span class="diff">Let |fragment directive| be the result of running [=remove the
+>             fragment directive=] on |url|.</span></li>
+>         8. <span class="diff">Let |directive state| be a new [=/directive
+>             state=] with [=directive state/value=] set to |fragment directive|.</span>
+>         9. <span class="diff">Let historyEntry be a new session history entry, with its URL
+>             set to |url|, its document state set to documentState, and its [=she/directive state=]
+>             set to |directive state|.</span>
+>         10. Let navigationParams be null.
+>         11. ...
+>   </div>
+
+In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid">navigate to a fragment</a>:
+
+>   <strong>Monkeypatching [[HTML#scroll-to-fragid]]:</strong>
+>
+>   <div class="monkeypatch">To navigate to a fragment given navigable |navigable|, ...:
+>     1. <span class="diff">Let |directive state| be navigable's active session history
+>         entry's [=she/directive state=].</span>
+>     1. <span class="diff">Let |fragment directive| be the result of running
+>         [=remove the fragment directive=] on |url|.</span>
+>     1. <span class="diff">If |url| does not equal |navigable|'s active session history
+>         entry's URL with exclude fragments set to true OR |fragment directive| is not null:</span>
+>         <div class="note">Otherwise, when only the fragment has changed and it did not specify
+>         a directive, the active entry's directive state is reused. This prevents a fragment
+>         change from clobbering highlights.</div>
+>         1. <span class="diff">Let |directive state| be a new [=/directive state=] with
+>             [=directive state/value=] set to |fragment directive|.
+>     2. Let historyEntry be a new session history entry, with
+>         * URL url
+>         * document state navigable's active session history entry's document state
+>         * scroll restoration mode navigable's active session history entry's scroll restoration
+>             mode
+>         * <span class="diff">[=she/directive state=] |directive state|</span>
+>     2. Let entryToReplace be navigable's active session history entry if historyHandling is
+>         "replace", otherwise null.
+>     3. ...
+>   </div>
+
+In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps">URL and history update steps</a>:
+
+>   <strong>Monkeypatching [[HTML#navigate-non-frag-sync]]:</strong>
+>
+>   <div class="monkeypatch">The URL and history update steps, given a Document |document|, ...:
+>     1. Let |navigable| be |document|'s node navigable.
+>     2. Let |activeEntry| be |navigable|'s active session history entry.
+>     3. <span class="diff">Let |fragment directive| be the result of running [=remove the
+>         fragment directive=] on |newUrl|.</span>
+>     5. Let |historyEntry| be a new session history entry, with
+>         * URL |newUrl|
+>         * ...
+>         * <span class="diff">[=she/directive state=] |activeEntry|'s [=she/directive
+>             state=]</span>
+>     6. If |document|'s is initial about:blank is true, then set historyHandling to "replace".
+>     7. If historyHandling is "push", then:
+>         1. Increment document's history object's index.
+>         2. Set document's history object's length to its index + 1.
+>         3. <span class="diff">If |newUrl| does not equal |activeEntry|'s URL with exclude
+>             fragments set to true OR |fragment directive| is not null, then:</span>
+>             <div class="note">Otherwise, when only the fragment has changed and it did not specify
+>             a directive, the active entry's directive state is reused. This prevents a fragment
+>             change from clobbering highlights.</div>
+>             1. <span class="diff">Let |historyEntry|'s [=she/directive state=] be a new
+>                 [=/directive state=] with [=directive state/value=] set to |fragment
+>                 directive|.</span>
+>     8. <span class="diff">Otherwise, if |fragment directive| is not null, set
+>         |historyEntry|'s [=she/directive state=]'s [=directive state/value=] to |fragment
+>         directive|.</span>
+>     9. If serializedData is not null, then restore the history object state given document and
+>         newEntry.
+>   </div>
 
 <div class="note">
   <p>
-    The changes in this section imply that a URL is only stripped of its fragment
-    directive when it is set on a Document. Notably, since a window's
-    {{Location}} object is a representation of the [=/URL=] of the [=active
-    document=], all getters on it will show a fragment-directive-stripped
+    Since a Document is populated from a history entry, its [=Document/URL=] will not include the
+    fragment directive. Similarly, since a window's {{Location}} object is a representation of the
+    [=/URL=] of the [=active document=], all getters on it will show a fragment-directive-stripped
     version of the URL.
+  </p>
+
+  <p>
+    Additionally, since the {{HashChangeEvent}} is
+    <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-document">
+    fired in response to a changed fragment</a> between URLs of session history entries,
+    <code>hashchange</code> will not be fired if a navigation or traversal changes only the fragment
+    directive.
   </p>
 
   <p>
@@ -378,41 +498,52 @@ step 6).
 
 <div class="example">
   ```
-  window.location = 'https://example.com#foo:~:bar';
+  window.location = "https://example.com#page1:~:hello";
+  console.log(window.location.href); // 'https://example.com#page1'
+  console.log(window.location.hash); // '#page1'
   ```
 
-  The page loads and when the document's URL is set the fragment directive is
-  stripped out during the "create and initialize a Document object" steps.
+  The initial navigation created a new session history entry. The entry's URL is stripped of the
+  fragment directive: "https://example.com#page1". The entry's directive state value is set to
+  "hello". Since the document is populated from the entry, web APIs don't include the fragment
+  directive in URLs.
 
   ```
-  console.log(window.location.href); // 'https://example.com#foo'
-  console.log(window.location.hash); // '#foo'
+  location.hash = "page2";
+  console.log(location.href); // 'https://example.com#page2'
   ```
 
-  Since same document navigations are made by adding a new session history
-  entry and using the "traverse the history" steps, the the fragment directive
-  will be stripped here as well.
+  A same document navigation changed only the fragment. This adds a new session history entry in the
+  <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid">navigate to
+  a fragment</a> steps. However, since only the fragment changed, the new entry's directive state
+  points to the same state as the first entry, with a value of "bar".
 
   ```
-  window.location.hash = 'fizz:~:buzz';
-  console.log(window.location.href); // 'https://example.com#fizz'
-  console.log(window.location.hash); // '#fizz'
+  onhashchange = () => console.assert(false, "hashchange doesn't fire.");
+  location.hash = "page2:~:world";
+  console.log(location.href); // 'https://example.com#page2'
+  onhashchange = null;
   ```
 
-  The hashchange event is dispatched when only the fragment directive changes
-  because the comparison for it is done on the URLs in the session history
-  entries, where the fragment directive hasn't been removed.
+  A same document navigation changes only the fragment but includes a fragment directive. Since an
+  explicit directive was provided, the new entry includes its own directive state with a value of
+  "fizz".
+
+  The hashchange event is not fired since the page-visible fragment is unchanged; only the fragment
+  directive changed. This is because the comparison for hashchange is done on the URLs in the
+  session history entries, where the fragment directive has been removed.
 
   ```
-  onhashchange = () => {console.log('HASHCHANGE');};
-  window.location.hash = 'fizz:~:zillch'; // 'HASHCHANGE'
-  console.log(window.location.href); // 'https://example.com#fizz'
-  console.log(window.location.hash); // '#fizz'
+  history.pushState("", "", "page3");
+  console.log(location.href); // 'https://example.com/page3'
   ```
+
+  pushState creates a new session history entry for the same document. However, since the
+  non-fragment URL has changed, this entry has its own directive state with value currently null.
 </div>
 
 <div class="example">
-  In other cases where a Document's URL is not set by the UA, there is no
+  In other cases where a URL is not set to a session history entry, there is no
   fragment directive stripping.
 
   For URL objects:
@@ -438,25 +569,6 @@ step 6).
   </script>
   ```
 </div>
-
-<div class="example">
-  History pushState will create a session history entry where the URL's
-  fragment directive isn't stripped. However, traversing to the entry will
-  cause it to set its URL on the document which will process the fragment
-  directive before setting it on the Document (but the fragment directive
-  remains on the entry).
-
-
-  ```
-  history.pushState({}, 'title', 'index.html#foo:~:bar');
-  window.location = 'newpage.html';
-  // on newpage.html
-  history.back();
-  ```
-
-  Results in the current document having "bar" as the fragment directive.
-</div>
-
 
 ### Parsing the fragment directive ### {#parsing-the-fragment-directive}
 
@@ -838,8 +950,11 @@ and initialize a Document object</a> steps by adding the following steps before 
 >             activated per user-activated navigation.
 >           </div>
 >   16. Set |document|'s [=document/allow text fragment scroll=] by following these sub-steps:
+<!--
+TODO is the document's latest entry set by here yet? If not the allow bit will have to be set some other way.
 >       1. If |document|'s [=Document/fragment directive=] field is null or empty, set
 >           [=document/allow text fragment scroll=] to false and abort these sub-steps.
+-->
 >       1. Let |text directive user activation| be the value of |document|'s
 >           [=document/text directive user activation=] and set |document|'s
 >           [=document/text directive user activation=] to false.
@@ -1012,7 +1127,9 @@ so that the indicated part is a [=range=]:
 
 >   <strong>Monkeypatching [[HTML]]:</strong>
 >
->   1. Let |fragment directive string| be the document's [=Document/fragment directive=].
+>   1. Let |fragment directive string| be the document's
+>       <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry">latest entry</a>'s
+>       [=fragment directive=].
 >   1. If the document's [=document/allow text fragment scroll=] is true then:
 >       1. Let |ranges| be a <a spec=infra>list</a> that is the result of running
 >           the [=process a fragment directive=] steps with |fragment directive

--- a/index.bs
+++ b/index.bs
@@ -785,7 +785,7 @@ indicated part</a>, enable a fragment to indicate a [=range=]. Make the followin
 >   1. <span class="diff">If |directives| is non-null and |document|'s [=document/allow text
 >       fragment scroll=] is true then:</span>
 >       1. <span class="diff">Let |ranges| be a <a spec=infra>list</a> that is the result of running
->           the [=process a fragment directive=] steps with |directives| and the document.</span>
+>           the [=invoke text directives=] steps with |directives| and the document.</span>
 >       1. <span class="diff">If |ranges| is non-empty, then:</span>
 >           1. <span class="diff">Let |firstRange| be the first item of |ranges|.</span>
 >           1. <span class="diff">Visually indicate each [=range=] in |ranges| in an
@@ -1299,23 +1299,23 @@ To find the <dfn>shadow-including parent</dfn> of |node| follow these steps:
   regardless of how many other directives are provided or their match result.
 
   If a directive successfully matches to text in the document, it returns a
-  [=range=] indicating that match in the document. The [=process a fragment
-  directive=] steps are the high level API provided by this section. These
-  return a <a spec=infra>list</a> of [=ranges=] that were matched by the
-  individual directive matching steps, in the order the directives were
+  [=range=] indicating that match in the document. The
+  [=invoke text directives=] steps are the high level API provided by this
+  section. These return a <a spec=infra>list</a> of [=ranges=] that were matched
+  by the individual directive matching steps, in the order the directives were
   specified in the fragment directive string.
 
   If a directive was not matched, it does not add an item to the returned
   list.
 </div>
 
-<div algorithm="process a fragment directive">
-To <dfn>process a fragment directive</dfn>, given as input an <a
-spec=infra>ASCII string</a> |fragment directive input| and a [=Document=]
+<div algorithm="invoke text directives">
+To <dfn>invoke text directives</dfn>, given as input an <a
+spec=infra>ASCII string</a> |text directives| and a [=Document=]
 |document|, run these steps:
 
 <div class="note">
-  This algorithm takes as input a |fragment directive input|, that is the
+  This algorithm takes as input a |text directives|, that is the
   raw text of the fragment directive and the |document| over which it operates.
   It returns a <a spec=infra>list</a> of [=ranges=] that are to be visually
   indicated, the first of which will be scrolled into view (if the UA scrolls
@@ -1323,11 +1323,11 @@ spec=infra>ASCII string</a> |fragment directive input| and a [=Document=]
 </div>
 
   <ol class="algorithm">
-    1. If |fragment directive input| is not a [=valid fragment directive=], then
+    1. If |text directives| is not a [=valid fragment directive=], then
         return an empty <a spec=infra>list</a>.
     2. Let |directives| be a <a spec=infra>list</a> of <a spec=infra>ASCII string</a>s
         that is the result of [=strictly split a string|strictly splitting the
-        string=] |fragment directive input| on "&".
+        string=] |text directives| on "&".
     3. Let |ranges| be a <a spec=infra>list</a> of [=ranges=], initially empty.
     4. For each <a spec=infra>ASCII string</a> |directive| of |directives|:
         1. If |directive| does not match the production [=TextDirective=],

--- a/index.bs
+++ b/index.bs
@@ -274,7 +274,7 @@ To prevent impacting page operation, it is stripped from script-accessible APIs 
 interaction with author script. This also ensures future directives can be added without web
 compatibility risk.
 
-### Processing the fragment directive ### {#processing-the-fragment-directive}
+### Extracting the fragment directive ### {#extracting-the-fragment-directive}
 
 This section describes the mechanism by which the fragment directive is hidden
 from script and how it fits into [[HTML#navigation-and-session-history]].
@@ -570,78 +570,39 @@ In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-th
   ```
 </div>
 
+### Applying directives to a document ### {#applying-directives-to-a-document}
+
+The section above described how the [=fragment directive=] is separated from the URL and stored in a
+session history entry.
+
+This section defines how and when navigations and traversals make use of history entry's [=she/directive
+state=] to apply the directives associated with a session history entry to a [=Document=].
+
+>   <strong>Monkeypatching [[DOM#interface-document]]:</strong>
+>
+>   Each document has an associated <dfn for="Document">uninvoked directives</dfn> which is either
+>   null or an ASCII string holding data used by the UA to process the resource. It is initially
+>   null.
+
+In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-document-for-history-step-application">
+update document for history step application</a>:
+
+>   <strong>Monkeypatching [[HTML#updating-the-document]]:</strong>
+>
+>   <div class="monkeypatch">To update document for history step application given a Document
+>   |document|, a session history entry |entry|,...
+>     1. ...
+>         <li value="4">Set |document|'s history object's length to scriptHistoryLength</li>
+>     5. If <var ignore>documentsEntryChanged</var> is true, then:
+>         1. Let <var ignore>oldURL</var> be |document|'s latest entry's URL.
+>         2. <span class="diff">If |document|'s latest entry's [=she/directive state=] is not |entry|'s
+>             [=she/directive state=] then set |document|'s [=Document/uninvoked directives=] to |entry|'s
+>             [=she/directive state=]'s [=directive state/value=].</span>
+>         3. Set |document|'s latest entry to |entry|
+>         4. ...
+>   </div>
+
 ### Parsing the fragment directive ### {#parsing-the-fragment-directive}
-
-A <dfn>text directive</dfn> is a kind of [=directive=] representing a range of
-text to be indicated to the user. It is a <a spec=infra>struct</a> that consists of
-four strings: <dfn for="text directive">start</dfn>,
-<dfn for="text directive">end</dfn>,
-<dfn for="text directive">prefix</dfn>, and
-<dfn for="text directive">suffix</dfn>. [=text directive/start=]
-is required to be non-null. The other three items may be set to null,
-indicating they weren't provided. The empty string is not a valid value for any
-of these items.
-
-See [[#syntax]] for the what each of these components means and how they're
-used.
-
-<div algorithm="parse a text directive">
-
-To <dfn>parse a text directive</dfn>, on an <a spec="infra">ASCII string</a> |text
-directive input|, run these steps:
-
-<div class="note">
-  <p>
-    This algorithm takes a single text directive string as input (e.g.
-    "text=prefix-,foo,bar") and attempts to parse the string into the
-    components of the directive (e.g. ("prefix", "foo", "bar", null)). See
-    [[#syntax]] for the what each of these components means and how they're
-    used.
-  </p>
-  <p>
-    Returns null if the input is invalid or fails to parse in any way.
-    Otherwise, returns a [=text directive=].
-  </p>
-</div>
-
-  <ol class="algorithm">
-    1. [=/Assert=]: |text directive input| matches the production [=TextDirective=].
-    1. Let |textDirectiveString| be the substring of |text directive
-        input| starting at index 5.
-        <div class="note">
-          This is the remainder of the |text directive input| following,
-          but not including, the "text=" prefix.
-        </div>
-    1. Let |tokens| be a <a for=/>list</a> of strings that is the result of
-        <a lt="split on commas">splitting |textDirectiveString| on commas</a>.
-    1. If |tokens| has size less than 1 or greater than 4, return null.
-    1. If any of |tokens|'s items are the empty string, return null.
-    1. Let |retVal| be a [=text directive=] with each of its items initialized
-        to null.
-    1. Let |potential prefix| be the first item of |tokens|.
-    1. If the last character of |potential prefix| is U+002D (-), then:
-        1. Set |retVal|'s [=text directive/prefix=] to the
-            [=string/percent-decode|percent-decoding=] of the result of removing the
-            last character from |potential prefix|.
-        1. <a spec=infra for=list>Remove</a> the first item of the list |tokens|.
-    1. Let |potential suffix| be the last item of |tokens|, if one exists, null
-        otherwise.
-    1. If |potential suffix| is non-null and its first character is U+002D (-),
-        then:
-        1. Set |retVal|'s [=text directive/suffix=] to the
-            [=string/percent-decode|percent-decoding=] of the result of removing the
-            first character from |potential suffix|.
-        1. <a spec=infra for=list>Remove</a> the last item of the list |tokens|.
-    1. If |tokens| has <a spec=infra for=list>size</a> not equal to 1 nor 2 then
-        return null.
-    1. Set |retVal|'s [=text directive/start=] be the
-        [=string/percent-decode|percent-decoding=] of the first item of |tokens|.
-    1. If |tokens| has <a spec=infra for=list>size</a> 2, then set |retVal|'s
-        [=text directive/end=] be the
-        [=string/percent-decode|percent-decoding=] of the last item of |tokens|.
-    1. Return |retVal|.
-  </ol>
-</div>
 
 ### Fragment directive grammar ### {#fragment-directive-grammar}
 
@@ -718,6 +679,246 @@ it matches the production:
   <dt><dfn>`PercentEncodedChar`</dfn> `::=`</dt>
   <dd><code>"%" [a-zA-Z0-9]+</code></dd>
 </dl>
+
+## Text Directives ## {#text-directives}
+
+A <dfn>text directive</dfn> is a kind of [=/directive=] representing a range of
+text to be indicated to the user. It is a <a spec=infra>struct</a> that consists of
+four strings: <dfn for="text directive">start</dfn>,
+<dfn for="text directive">end</dfn>,
+<dfn for="text directive">prefix</dfn>, and
+<dfn for="text directive">suffix</dfn>. [=text directive/start=]
+is required to be non-null. The other three items may be set to null,
+indicating they weren't provided. The empty string is not a valid value for any
+of these items.
+
+See [[#syntax]] for the what each of these components means and how they're
+used.
+
+<div algorithm="parse a text directive">
+
+To <dfn>parse a text directive</dfn>, on an <a spec="infra">ASCII string</a> |text
+directive input|, run these steps:
+
+<div class="note">
+  <p>
+    This algorithm takes a single text directive string as input (e.g.
+    "text=prefix-,foo,bar") and attempts to parse the string into the
+    components of the directive (e.g. ("prefix", "foo", "bar", null)). See
+    [[#syntax]] for the what each of these components means and how they're
+    used.
+  </p>
+  <p>
+    Returns null if the input is invalid or fails to parse in any way.
+    Otherwise, returns a [=text directive=].
+  </p>
+</div>
+
+  <ol class="algorithm">
+    1. [=/Assert=]: |text directive input| matches the production [=TextDirective=].
+    1. Let |textDirectiveString| be the substring of |text directive
+        input| starting at index 5.
+        <div class="note">
+          This is the remainder of the |text directive input| following,
+          but not including, the "text=" prefix.
+        </div>
+    1. Let |tokens| be a <a for=/>list</a> of strings that is the result of
+        <a lt="split on commas">splitting |textDirectiveString| on commas</a>.
+    1. If |tokens| has size less than 1 or greater than 4, return null.
+    1. If any of |tokens|'s items are the empty string, return null.
+    1. Let |retVal| be a [=text directive=] with each of its items initialized
+        to null.
+    1. Let |potential prefix| be the first item of |tokens|.
+    1. If the last character of |potential prefix| is U+002D (-), then:
+        1. Set |retVal|'s [=text directive/prefix=] to the
+            [=string/percent-decode|percent-decoding=] of the result of removing the
+            last character from |potential prefix|.
+        1. <a spec=infra for=list>Remove</a> the first item of the list |tokens|.
+    1. Let |potential suffix| be the last item of |tokens|, if one exists, null
+        otherwise.
+    1. If |potential suffix| is non-null and its first character is U+002D (-),
+        then:
+        1. Set |retVal|'s [=text directive/suffix=] to the
+            [=string/percent-decode|percent-decoding=] of the result of removing the
+            first character from |potential suffix|.
+        1. <a spec=infra for=list>Remove</a> the last item of the list |tokens|.
+    1. If |tokens| has <a spec=infra for=list>size</a> not equal to 1 nor 2 then
+        return null.
+    1. Set |retVal|'s [=text directive/start=] be the
+        [=string/percent-decode|percent-decoding=] of the first item of |tokens|.
+    1. If |tokens| has <a spec=infra for=list>size</a> 2, then set |retVal|'s
+        [=text directive/end=] be the
+        [=string/percent-decode|percent-decoding=] of the last item of |tokens|.
+    1. Return |retVal|.
+  </ol>
+</div>
+
+### Invoking Text Directives ### {#invoking-text-directives}
+
+This section describes how text directives in a document's [=Document/uninvoked directives=] are
+processed and invoked to cause indication of the relevant text passages.
+
+<div class="note">
+    The summarized changes in this section:
+
+    * Modify the indicated part processing model to try processing [=Document/uninvoked directives=]
+        into a [=range=] that will be returned as the indicated part.
+    * Modify "scrolling to a fragment" to correctly scroll and set the Document's target element in the case
+        of a [=range=] based indicated part.
+    * Ensure [=Document/uninvoked directives=] is reset to null when the user agent has finished the
+        fragment search for the current navigation/traversal.
+    * If the user agent finishes searching for a text directive, ensure it tries the regular
+        fragment as a fallback.
+</div>
+
+In <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">
+indicated part</a>, enable a fragment to indicate a [=range=]. Make the following changes:
+
+>   <strong>Monkeypatching [[HTML#scrolling-to-a-fragment]]:</strong>
+>
+>   <div class="monkeypatch">
+>   For an HTML document |document|, the following processing model must be followed to determine
+>   its indicated part:
+>
+>   1. <span class="diff">Let |directives| be the document's [=Document/uninvoked directives=].
+>       </span>
+>   1. <span class="diff">If |directives| is non-null and |document|'s [=document/allow text
+>       fragment scroll=] is true then:</span>
+>       1. <span class="diff">Let |ranges| be a <a spec=infra>list</a> that is the result of running
+>           the [=process a fragment directive=] steps with |directives| and the document.</span>
+>       1. <span class="diff">If |ranges| is non-empty, then:</span>
+>           1. <span class="diff">Let |firstRange| be the first item of |ranges|.</span>
+>           1. <span class="diff">Visually indicate each [=range=] in |ranges| in an
+>               [=implementation-defined=] way. The indication must not be observable from author
+>               script. See [[#indicating-the-text-match]].</span>
+>               <div class="note">
+>                 The first [=range=] in |ranges| is the one that gets scrolled into view but all
+>                 ranges should be visually indicated to the user.
+>               </div>
+>           1. <span class="diff">Set |firstRange| as |document|'s indicated part, return.</span>
+>   1. Let fragment be document's URL's fragment.
+>   1. If fragment is the empty string, then return the special value top of the document.
+>   1. Let potentialIndicatedElement be the result of finding a potential indicated element given
+>       document and fragment.
+>   1. ...
+>
+>   </div>
+
+In <a spec=HTML>scroll to the fragment</a>, handle a indicated part that is a [=range=] and also
+prevent fragment scrolling if the force-load-at-top policy is enabled. Make the following changes:
+
+>   <strong>Monkeypatching [[HTML#scrolling-to-a-fragment]]:</strong>
+>
+>   <div class="monkeypatch">
+>   1. If document's indicated part is null, then set document's target element to null.
+>   2. Otherwise, if document's indicated part is top of the document, then:
+>       1. Set document's target element to null.
+>       2. Scroll to the beginning of the document for document.
+>       3. Return.
+>   3. Otherwise:
+>       1. Assert: document's indicated part is an element <span class="diff">or it is a [=range=].</span>
+>       2. <span class="diff">Let |scrollTarget| be |document|'s indicated part.</span>
+>       3. <span class="diff">Let |target| be |scrollTarget|.</span>
+>       4. <span class="diff">If |target| is a [=range=], then:</span>
+>           1. <span class="diff">Set |target| to be the [=first common ancestor=] of |target|'s
+>               [=range/start node=] and [=range/end node=].</span>
+>           2. <span class="diff">While |target| is non-null and is not an [=element=], set |target| to
+>               |target|'s [=tree/parent=].</span>
+>               <div class="issue">
+>                   What should be set as target if inside a shadow tree?
+>                   <a href="https://github.com/WICG/scroll-to-text-fragment/issues/190">#190</a>
+>               </div>
+>       4. <span class="diff">Assert: |target| is an [=element=].</span>
+>       5. Set |document|'s target element to |target|.
+>       6. Run the ancestor details revealing algorithm on |target|.
+>       7. Run the ancestor hidden-until-found revealing algorithm on |target|.
+>           <div class="issue">
+>               These revealing algorithms currently wont work well since |target| could be an
+>               ancestor or even the root document node. Issue
+>               <a href="https://github.com/WICG/scroll-to-text-fragment/issues/89">#89</a> proposes
+>               restricting matches to `contain:style layout` blocks which would resolve this
+>               problem.
+>           </div>
+>       8. <span class="diff"><a href="https://wicg.github.io/document-policy#algo-get-policy-value">Get the policy
+>           value</a> for `force-load-at-top` for |document|. If the result is false:</span>
+>           1. <span class="diff">[=scroll a target into view=],
+>               with <em>target</em> set to |scrollTarget|, <em>behavior</em> set to "auto", <em>block</em> set to "center", and
+>               <em>inline</em> set to "nearest".</span>
+>
+>               <span class="diff">Implementations MAY avoid scrolling to the target if it is
+>               produced from a [=text directive=].</span>
+>
+>           <div class="issue">
+>               <code>force-load-at-top</code> should be checked only when a new document is being
+>               loaded.
+>               <a href="https://github.com/WICG/scroll-to-text-fragment/issues/186">#186</a>
+>           </div>
+>       9. <strike class="diff">Scroll target into view, with behavior set to "auto", block set to
+>           "start", and inline set to "nearest".</strike>
+>       10. Run the focusing steps for target, with the Document's viewport as the fallback target.
+>           <div class="issue">Implementation note: Blink doesn’t currently set focus for text
+>           fragments, it probably should? TODO: file crbug.</div>
+>       11. Move the sequential focus navigation starting point to target.
+>
+>   </div>
+
+The next two monkeypatches ensure the user agent clears [=Document/uninvoked directives=] when
+the fragment search is complete. In the case where a text directive search finishes because parsing
+has stopped, it tries one more search for a non-text directive fragment.
+
+In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">
+try to scroll to the fragment</a>:
+
+>   <strong>Monkeypatching [[HTML#scrolling-to-a-fragment]]:</strong>
+>
+>   <div class="monkeypatch">
+>   To try to scroll to the fragment for a Document |document|, perform the following steps in
+>   parallel:
+>   1. Wait for an implementation-defined amount of time. (This is intended to allow the user agent
+>       to optimize the user experience in the face of performance concerns.)
+>   2. Queue a global task on the navigation and traversal task source given document's relevant
+>       global object to run these steps:
+>       1. <strike class="diff">If document has no parser, or its parser has stopped parsing, or the user agent
+>           has reason to believe the user is no longer interested in scrolling to the fragment, then
+>           abort these steps.</strike>
+>           <li value="1" class="diff">If the user agent has reason to believe the user is no longer interested in scrolling to
+>           the fragment, then:</span>
+>           1. <span class="diff">Set [=Document/uninvoked directives=] to null.</span>
+>           1. <span class="diff">Abort these steps.</span>
+>       1. <span class="diff">If the document has no parser, or its parser has stopped parsing,
+>           then:</li>
+>           1. <span class="diff">If [=Document/uninvoked directives=] is not null, then:</span>
+>               1. <span class="diff">Set [=Document/uninvoked directives=] to null.</span>
+>               1. <span class="diff"><a spec=HTML>Scroll to the fragment</a> given |document|.</span>
+>           1. <span class="diff">Abort these steps.</span>
+>       2. Scroll to the fragment given document.
+>       3. If document's indicated part is still null, then try to scroll to the fragment for
+>           document. <span class="diff">Otherwise, set [=Document/uninvoked directives=] to
+>           null.</span>
+
+In the definition of
+<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid">
+navigate to a fragment</a>:
+
+>   <strong>Monkeypatching [[HTML#scroll-to-fragid]]:</strong>
+>
+>   <div class="monkeypatch">To navigate to a fragment given navigable |navigable|, ...:
+>     1. ...
+>         <li value="8">Update document for history step application given navigable's active
+>         document, historyEntry, true, scriptHistoryIndex, and scriptHistoryLength. </li>
+>     9. Scroll to the fragment given navigable's active document.
+>         <li class="diff">Set |navigable|'s active document's [=Document/uninvoked directives=] to
+>         null.</li>
+>     11. Let traversable be navigable's traversable navigable.
+>     12. ...
+
+Scrolling to the indicated part is only one of several things that happens from "scroll to the
+fragment". Rename it and related definitions:
+
+>   <strong>Monkeypatching [[HTML#scroll-to-fragid]]:</strong>
+>
+>   Rename [[HTML#scroll-to-fragid]] and related steps to "indicating a fragment" to reflect it's
+>   broader effects.
 
 ## Security and Privacy ## {#security-and-privacy}
 
@@ -950,11 +1151,8 @@ and initialize a Document object</a> steps by adding the following steps before 
 >             activated per user-activated navigation.
 >           </div>
 >   16. Set |document|'s [=document/allow text fragment scroll=] by following these sub-steps:
-<!--
-TODO is the document's latest entry set by here yet? If not the allow bit will have to be set some other way.
->       1. If |document|'s [=Document/fragment directive=] field is null or empty, set
+>       1. If |document|'s [=Document/uninvoked directives=] field is null or empty, set
 >           [=document/allow text fragment scroll=] to false and abort these sub-steps.
--->
 >       1. Let |text directive user activation| be the value of |document|'s
 >           [=document/text directive user activation=] and set |document|'s
 >           [=document/text directive user activation=] to false.
@@ -1052,129 +1250,6 @@ the element fragment as the indicated part. We amend the HTML Document's
 indicated part processing model to return a [=range=], rather than an
 [=element=], that will be scrolled into view.
 </div>
-
-To enable the <a spec=HTML>scroll to the fragment</a> algorithm to operate on a
-[=range=] indicated part, replace step 3 of this algorithm as follows:
-
-<!--TODO This and following sections would flow better if reordered.-->
-
->   <strong>Monkeypatching [[HTML]]:</strong>
->
->   Replace:
->
->   1. <strike>Assert: document's indicated part is an element.</strike>
->   1. <strike>Let target be document's indicated part.</strike>
->   1. <strike>Set document's target element to target.</strike>
->   1. <strike>Run the ancestor details revealing algorithm on target.</strike>
->   1. <strike>Run the ancestor hidden-until-found revealing algorithm on target.</strike>
->   1. <strike>Scroll target into view, with behavior set to "auto", block set to "start", and inline set to "nearest".</strike>
->   1. <strike>Run the focusing steps for target, with the Document's viewport as the fallback target.</strike>
->   1. <strike>Move the sequential focus navigation starting point to target.</strike>
->
->   With:
->
->   1. Assert: document's indicated part is a [=range=].
->   1. Let |range| be the [=range=] that is |document|'s
->       <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">indicated part</a>.
->   1. Let |target| be the [=first common ancestor=] of |range|'s
->       [=range/start node=] and [=range/end node=].
->   1. While |target| is non-null and is not an [=element=], set |target| to
->       |target|'s [=tree/parent=].
->       <div class="issue">
->           What should be set as target if inside a shadow tree?
->           <a href="https://github.com/WICG/scroll-to-text-fragment/issues/190">#190</a>
->       </div>
->   1. Set |document|'s [=target element=] to |target|.
->   1. Run the ancestor details revealing algorithm on target.
->   1. Run the ancestor hidden-until-found revealing algorithm on target.
->       <div class="issue">
->         These revealing algorithms currently wont work well since |target|
->         could be an ancestor or even the root document node. Issue
->         <a href="https://github.com/WICG/scroll-to-text-fragment/issues/89">#89</a>
->         proposes restricting matches to `contain:style layout` blocks which
->         would resolve this problem.
->       </div>
->   1. <a href="https://wicg.github.io/document-policy#algo-get-policy-value">Get
->       the policy value</a> for `force-load-at-top` in the
->       [=Document=]. If the result is false:
->       1. If |range| wasn't produced as a result of a text fragment, or if the
->           UA supports scrolling of text fragments on navigation, invoke
->           <a href="https://drafts.csswg.org/cssom-view-1/#scroll-a-target-into-view">
->           scroll a target into view</a>, with <em>target</em> set to |range|,
->           containingElement |target|, <em>behavior</em> set to "auto",
->           <em>block</em> set to "center", and <em>inline</em> set to
->           "nearest".
->           <!-- TODO: Update scroll-a-target-into-view once autolink database
->           includes it. -->
->
->       <div class="issue">
->           <code>force-load-at-top</code> should be checked only when a new
->           document is being loaded.
->           <a href="https://github.com/WICG/scroll-to-text-fragment/issues/186">#186</a>
->       </div>
->   1. Let |start node| be |range|'s [=range/start node=].
->   1. Run the focusing steps for |start node|, with the Document's viewport as the fallback target.
->       <div class="issue">
->           Implementation note: Blink doesn't currently set focus for text
->           fragments, it probably should? TODO: file crbug.
->       </div>
->   1. Move the sequential focus navigation starting point to |start node|.
-
-To enable a fragment to indicate a range of text, add the following steps to the
-beginning of the processing model for the [=HTML Document=]'s
-<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">indicated part</a>
-so that the indicated part is a [=range=]:
-
->   <strong>Monkeypatching [[HTML]]:</strong>
->
->   1. Let |fragment directive string| be the document's
->       <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry">latest entry</a>'s
->       [=fragment directive=].
->   1. If the document's [=document/allow text fragment scroll=] is true then:
->       1. Let |ranges| be a <a spec=infra>list</a> that is the result of running
->           the [=process a fragment directive=] steps with |fragment directive
->           string| and the document.
->       1. If |ranges| is non-empty, then:
->           1. Let |range| be the first item of |ranges|.
->               <div class="note">
->                 The first [=range=] in |ranges| is specifically
->                 scrolled into view. This [=range=], along with the
->                 remaining |ranges| should be visually indicated in a way that
->                 is not revealed to script, which is left as UA-defined behavior.
->               </div>
->           1. Set |range| as |document|'s indicated part, return.
-
-In order for the indicated part to return a [=range=] for regular element
-fragments, modify the
-<a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#find-a-potential-indicated-element">
-find a potential indicated element</a> steps as follows:
-
->   <strong>Monkeypatching [[HTML]]:</strong>
->
->   Replace:
->
->   1. <strike>If there is an element in the document tree whose root is
->       document and that has an ID equal to fragment, then return the first
->       such element in tree order.</strike>
->   1. <strike>If there is an a element in the document tree whose root is
->       document that has a name attribute whose value is equal to fragment,
->       then return the first such element in tree order.</strike>
->   1. <strike>Return null.</strike>
->
->   With:
->
->   1. Let |element| be an [=Element=], initially null.
->   1. If there is an element in the document tree whose root is document and
->       that has an ID equal to fragment, set |element| to the first such
->       element in tree order.
->   1. Otherwise, if there is an element in the document tree whose root is
->       document that has a name attribute whose value is equal to fragment,
->       then set |element| to the first such element in tree order.
->   1. If |element| is null, return null.
->   1. Otherwise, return a [=range=] with [=range/start=] (|element|, 0) and
->       [=range/end=] (|element|, |element|'s [=Node/length=]).
->
->  And rename this algorithm and the returned variables.
 
 <div algorithm="first common ancestor">
 To find the <dfn>first common ancestor</dfn> of two nodes |nodeA| and |nodeB|,
@@ -1804,10 +1879,10 @@ The UA should provide to the user some method of dismissing the match, such
 that the matched text no longer appears visually indicated.
 
 The exact appearance and mechanics of the indication are left as UA-defined.
-However, the UA must not use the Document's <a
-href="https://w3c.github.io/selection-api/#dfn-selection">selection</a> to
-indicate the text match as doing so could allow attack vectors for content
-exfiltration.
+However, the UA must not use any methods observable by author script, such as
+the Document's <a href="https://w3c.github.io/selection-api/#dfn-selection">
+selection</a>, to indicate the text match. Doing so could allow attack vectors
+for content exfiltration.
 
 The UA must not visually indicate any provided context terms.
 

--- a/index.html
+++ b/index.html
@@ -810,37 +810,43 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>
        <a href="#the-fragment-directive"><span class="secno">3.3</span> <span class="content">The Fragment Directive</span></a>
        <ol class="toc">
-        <li><a href="#processing-the-fragment-directive"><span class="secno">3.3.1</span> <span class="content">Processing the fragment directive</span></a>
-        <li><a href="#parsing-the-fragment-directive"><span class="secno">3.3.2</span> <span class="content">Parsing the fragment directive</span></a>
-        <li><a href="#fragment-directive-grammar"><span class="secno">3.3.3</span> <span class="content">Fragment directive grammar</span></a>
+        <li><a href="#extracting-the-fragment-directive"><span class="secno">3.3.1</span> <span class="content">Extracting the fragment directive</span></a>
+        <li><a href="#applying-directives-to-a-document"><span class="secno">3.3.2</span> <span class="content">Applying directives to a document</span></a>
+        <li><a href="#parsing-the-fragment-directive"><span class="secno">3.3.3</span> <span class="content">Parsing the fragment directive</span></a>
+        <li><a href="#fragment-directive-grammar"><span class="secno">3.3.4</span> <span class="content">Fragment directive grammar</span></a>
        </ol>
       <li>
-       <a href="#security-and-privacy"><span class="secno">3.4</span> <span class="content">Security and Privacy</span></a>
+       <a href="#text-directives"><span class="secno">3.4</span> <span class="content">Text Directives</span></a>
        <ol class="toc">
-        <li><a href="#motivation"><span class="secno">3.4.1</span> <span class="content">Motivation</span></a>
-        <li><a href="#scroll-on-navigation"><span class="secno">3.4.2</span> <span class="content">Scroll On Navigation</span></a>
-        <li><a href="#search-timing"><span class="secno">3.4.3</span> <span class="content">Search Timing</span></a>
-        <li><a href="#restricting-the-text-fragment"><span class="secno">3.4.4</span> <span class="content">Restricting the Text Fragment</span></a>
+        <li><a href="#invoking-text-directives"><span class="secno">3.4.1</span> <span class="content">Invoking Text Directives</span></a>
        </ol>
       <li>
-       <a href="#navigating-to-text-fragment"><span class="secno">3.5</span> <span class="content">Navigating to a Text Fragment</span></a>
+       <a href="#security-and-privacy"><span class="secno">3.5</span> <span class="content">Security and Privacy</span></a>
        <ol class="toc">
-        <li><a href="#finding-ranges-in-a-document"><span class="secno">3.5.1</span> <span class="content">Finding Ranges in a Document</span></a>
-        <li><a href="#word-boundaries"><span class="secno">3.5.2</span> <span class="content">Word Boundaries</span></a>
+        <li><a href="#motivation"><span class="secno">3.5.1</span> <span class="content">Motivation</span></a>
+        <li><a href="#scroll-on-navigation"><span class="secno">3.5.2</span> <span class="content">Scroll On Navigation</span></a>
+        <li><a href="#search-timing"><span class="secno">3.5.3</span> <span class="content">Search Timing</span></a>
+        <li><a href="#restricting-the-text-fragment"><span class="secno">3.5.4</span> <span class="content">Restricting the Text Fragment</span></a>
        </ol>
       <li>
-       <a href="#indicating-the-text-match"><span class="secno">3.6</span> <span class="content">Indicating The Text Match</span></a>
+       <a href="#navigating-to-text-fragment"><span class="secno">3.6</span> <span class="content">Navigating to a Text Fragment</span></a>
+       <ol class="toc">
+        <li><a href="#finding-ranges-in-a-document"><span class="secno">3.6.1</span> <span class="content">Finding Ranges in a Document</span></a>
+        <li><a href="#word-boundaries"><span class="secno">3.6.2</span> <span class="content">Word Boundaries</span></a>
+       </ol>
+      <li>
+       <a href="#indicating-the-text-match"><span class="secno">3.7</span> <span class="content">Indicating The Text Match</span></a>
        <ol class="toc">
         <li>
-         <a href="#urls-in-ua-features"><span class="secno">3.6.1</span> <span class="content">URLs in UA features</span></a>
+         <a href="#urls-in-ua-features"><span class="secno">3.7.1</span> <span class="content">URLs in UA features</span></a>
          <ol class="toc">
-          <li><a href="#urls-in-location-bar"><span class="secno">3.6.1.1</span> <span class="content">Location Bar</span></a>
-          <li><a href="#urls-in-bookmarks"><span class="secno">3.6.1.2</span> <span class="content">Bookmarks</span></a>
-          <li><a href="#urls-in-sharing"><span class="secno">3.6.1.3</span> <span class="content">Sharing</span></a>
+          <li><a href="#urls-in-location-bar"><span class="secno">3.7.1.1</span> <span class="content">Location Bar</span></a>
+          <li><a href="#urls-in-bookmarks"><span class="secno">3.7.1.2</span> <span class="content">Bookmarks</span></a>
+          <li><a href="#urls-in-sharing"><span class="secno">3.7.1.3</span> <span class="content">Sharing</span></a>
          </ol>
        </ol>
-      <li><a href="#document-policy-integration"><span class="secno">3.7</span> <span class="content">Document Policy Integration</span></a>
-      <li><a href="#feature-detectability"><span class="secno">3.8</span> <span class="content">Feature Detectability</span></a>
+      <li><a href="#document-policy-integration"><span class="secno">3.8</span> <span class="content">Document Policy Integration</span></a>
+      <li><a href="#feature-detectability"><span class="secno">3.9</span> <span class="content">Feature Detectability</span></a>
      </ol>
     <li>
      <a href="#generating-text-fragment-directives"><span class="secno">4</span> <span class="content">Generating Text Fragment Directives</span></a>
@@ -910,7 +916,7 @@ user agent could make. Some examples of possible actions:</p>
      <p>Providing a notification when the text passage isn’t found in the page</p>
    </ul>
    <div class="note" role="note"> The choice of action can have implications for user security and privacy.  See
-the <a href="#security-and-privacy">§ 3.4 Security and Privacy</a> section for details. </div>
+the <a href="#security-and-privacy">§ 3.5 Security and Privacy</a> section for details. </div>
    <h3 class="heading settled" data-level="3.2" id="syntax"><span class="secno">3.2. </span><span class="content">Syntax</span><a class="self-link" href="#syntax"></a></h3>
    <div class="note" role="note">This section is non-normative</div>
    <p>A <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive">text directive</a> is specified in the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive">fragment directive</a> (see <a href="#the-fragment-directive">§ 3.3 The Fragment Directive</a>) with the following format:</p>
@@ -1006,7 +1012,7 @@ action. Multiple directives may appear in the fragment directive.</p>
    <p>To prevent impacting page operation, it is stripped from script-accessible APIs to prevent
 interaction with author script. This also ensures future directives can be added without web
 compatibility risk.</p>
-   <h4 class="heading settled" data-level="3.3.1" id="processing-the-fragment-directive"><span class="secno">3.3.1. </span><span class="content">Processing the fragment directive</span><a class="self-link" href="#processing-the-fragment-directive"></a></h4>
+   <h4 class="heading settled" data-level="3.3.1" id="extracting-the-fragment-directive"><span class="secno">3.3.1. </span><span class="content">Extracting the fragment directive</span><a class="self-link" href="#extracting-the-fragment-directive"></a></h4>
    <p>This section describes the mechanism by which the fragment directive is hidden
 from script and how it fits into <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-and-session-history"><cite>HTML</cite> § 7.4 Navigation and session history</a>.</p>
    <div class="note" role="note">
@@ -1323,7 +1329,86 @@ console.log(document.url.hash); // '#foo:~:bar'
 &lt;/script>
 </pre>
    </div>
-   <h4 class="heading settled" data-level="3.3.2" id="parsing-the-fragment-directive"><span class="secno">3.3.2. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
+   <h4 class="heading settled" data-level="3.3.2" id="applying-directives-to-a-document"><span class="secno">3.3.2. </span><span class="content">Applying directives to a document</span><a class="self-link" href="#applying-directives-to-a-document"></a></h4>
+   <p>The section above described how the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> is separated from the URL and stored in a
+session history entry.</p>
+   <p>This section defines how and when navigations and traversals make use of history entry’s <a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state⑦">directive
+state</a> to apply the directives associated with a session history entry to a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>.</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a href="https://dom.spec.whatwg.org/#interface-document"><cite>DOM</cite> § 4.5 Interface Document</a>:</strong></p>
+    <p>Each document has an associated <dfn class="dfn-paneled" data-dfn-for="Document" data-dfn-type="dfn" data-noexport id="document-uninvoked-directives">uninvoked directives</dfn> which is either
+  null or an ASCII string holding data used by the UA to process the resource. It is initially
+  null.</p>
+   </blockquote>
+   <p>In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-document-for-history-step-application"> update document for history step application</a>:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-document"><cite>HTML</cite> § 7.4.6.2 Updating the document</a>:</strong></p>
+    <div class="monkeypatch">
+     To update document for history step application given a Document <var>document</var>, a session history entry <var>entry</var>,... 
+     <ol>
+      <li data-md>
+       <p>...</p>
+      <li value="4">Set <var>document</var>’s history object’s length to scriptHistoryLength
+      <li data-md>
+       <p>If <var>documentsEntryChanged</var> is true, then:</p>
+       <ol>
+        <li data-md>
+         <p>Let <var>oldURL</var> be <var>document</var>’s latest entry’s URL.</p>
+        <li data-md>
+         <p><span class="diff">If <var>document</var>’s latest entry’s <a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state⑧">directive state</a> is not <var>entry</var>’s <a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state⑨">directive state</a> then set <var>document</var>’s <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives">uninvoked directives</a> to <var>entry</var>’s <a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state①⓪">directive state</a>'s <a data-link-type="dfn" href="#directive-state-value" id="ref-for-directive-state-value④">value</a>.</span></p>
+        <li data-md>
+         <p>Set <var>document</var>’s latest entry to <var>entry</var></p>
+        <li data-md>
+         <p>...</p>
+       </ol>
+     </ol>
+    </div>
+   </blockquote>
+   <h4 class="heading settled" data-level="3.3.3" id="parsing-the-fragment-directive"><span class="secno">3.3.3. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
+   <h4 class="heading settled" data-level="3.3.4" id="fragment-directive-grammar"><span class="secno">3.3.4. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
+   <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive</dfn> if
+it matches the production:</p>
+   <dl>
+    <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirectiveproduction"><code>FragmentDirective</code></dfn> <code>::=</code> 
+    <dd> <code>(<a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a> | <a data-link-type="dfn" href="#unknowndirective" id="ref-for-unknowndirective">UnknownDirective</a>) ("&amp;" <a data-link-type="dfn" href="#fragmentdirectiveproduction" id="ref-for-fragmentdirectiveproduction">FragmentDirective</a>)?</code> 
+    <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="unknowndirective"><code>UnknownDirective</code></dfn> <code>::=</code> 
+    <dd> <code><a data-link-type="dfn" href="#characterstring" id="ref-for-characterstring">CharacterString</a></code> 
+    <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="characterstring"><code>CharacterString</code></dfn> <code>::=</code> 
+    <dd> <code>(<a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar">ExplicitChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</code> 
+    <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="explicitchar"><code>ExplicitChar</code></dfn> <code>::=</code> 
+    <dd>
+      <code>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
+    ";" | "=" | "?" | "@" | "_" | "~" | "," | "-"</code> 
+     <div class="note" role="note"> An <a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar①">ExplicitChar</a> may be any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points">URL code point</a> other than "&amp;". </div>
+   </dl>
+   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirectiveproduction" id="ref-for-fragmentdirectiveproduction①">FragmentDirective</a> can contain multiple directives split by the "&amp;"
+  character. Currently this means we allow multiple text directives to enable
+  multiple indicated strings in the page, but this also allows for future
+  directive types to be added and combined. For extensibility, we do not fail to
+  parse if an unknown directive is in the &amp;-separated list of directives. </div>
+   <dl>
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective"><code>TextDirective</code></dfn> <code>::=</code>
+    <dd><code>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></code>
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters"><code>TextDirectiveParameters</code></dfn> <code>::=</code>
+    <dd> <code> (<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textdirectivestring" id="ref-for-textdirectivestring">TextDirectiveString</a> ("," <a data-link-type="dfn" href="#textdirectivestring" id="ref-for-textdirectivestring①">TextDirectiveString</a>)?  ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)? </code> 
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix"><code>TextDirectivePrefix</code></dfn> <code>::=</code>
+    <dd><code><a data-link-type="dfn" href="#textdirectivestring" id="ref-for-textdirectivestring②">TextDirectiveString</a>"-"</code>
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix"><code>TextDirectiveSuffix</code></dfn> <code>::=</code>
+    <dd><code>"-"<a data-link-type="dfn" href="#textdirectivestring" id="ref-for-textdirectivestring③">TextDirectiveString</a></code>
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivestring"><code>TextDirectiveString</code></dfn> <code>::=</code>
+    <dd><code>(<a data-link-type="dfn" href="#textdirectiveexplicitchar" id="ref-for-textdirectiveexplicitchar">TextDirectiveExplicitChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar①">PercentEncodedChar</a>)+</code>
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveexplicitchar"><code>TextDirectiveExplicitChar</code></dfn> <code>::=</code>
+    <dd>
+      <code> [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
+    ";" | "=" | "?" | "@" | "_" | "~" </code> 
+     <div class="note" role="note"> A <a data-link-type="dfn" href="#textdirectiveexplicitchar" id="ref-for-textdirectiveexplicitchar①">TextDirectiveExplicitChar</a> is any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points①">URL code point</a> that is not
+    explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a> syntax, that is "&amp;", "-", and ",".
+    If a text fragment refers to a "&amp;", "-", or "," character in the document,
+    it will be percent-encoded in the fragment. </div>
+    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar"><code>PercentEncodedChar</code></dfn> <code>::=</code>
+    <dd><code>"%" [a-zA-Z0-9]+</code>
+   </dl>
+   <h3 class="heading settled" data-level="3.4" id="text-directives"><span class="secno">3.4. </span><span class="content">Text Directives</span><a class="self-link" href="#text-directives"></a></h3>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-directive">text directive</dfn> is a kind of <a data-link-type="dfn" href="#directives" id="ref-for-directives">directive</a> representing a range of
 text to be indicated to the user. It is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#struct" id="ref-for-struct">struct</a> that consists of
 four strings: <dfn class="dfn-paneled" data-dfn-for="text directive" data-dfn-type="dfn" data-noexport id="text-directive-start">start</dfn>, <dfn class="dfn-paneled" data-dfn-for="text directive" data-dfn-type="dfn" data-noexport id="text-directive-end">end</dfn>, <dfn class="dfn-paneled" data-dfn-for="text directive" data-dfn-type="dfn" data-noexport id="text-directive-prefix">prefix</dfn>, and <dfn class="dfn-paneled" data-dfn-for="text directive" data-dfn-type="dfn" data-noexport id="text-directive-suffix">suffix</dfn>. <a data-link-type="dfn" href="#text-directive-start" id="ref-for-text-directive-start">start</a> is required to be non-null. The other three items may be set to null,
@@ -1332,7 +1417,7 @@ of these items.</p>
    <p>See <a href="#syntax">§ 3.2 Syntax</a> for the what each of these components means and how they’re
 used.</p>
    <div class="algorithm" data-algorithm="parse a text directive">
-    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parse-a-text-directive">parse a text directive</dfn>, on an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string">ASCII string</a> <var>text
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="parse-a-text-directive">parse a text directive</dfn>, on an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> <var>text
 directive input</var>, run these steps:</p>
     <div class="note" role="note">
      <p> This algorithm takes a single text directive string as input (e.g.
@@ -1344,7 +1429,7 @@ directive input</var>, run these steps:</p>
     </div>
     <ol class="algorithm">
      <li data-md>
-      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>text directive input</var> matches the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective">TextDirective</a>.</p>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>text directive input</var> matches the production <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a>.</p>
      <li data-md>
       <p>Let <var>textDirectiveString</var> be the substring of <var>text directive
 input</var> starting at index 5.</p>
@@ -1394,55 +1479,230 @@ return null.</p>
       <p>Return <var>retVal</var>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.3.3" id="fragment-directive-grammar"><span class="secno">3.3.3. </span><span class="content">Fragment directive grammar</span><a class="self-link" href="#fragment-directive-grammar"></a></h4>
-   <p>An <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string①">ASCII string</a> is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="valid-fragment-directive">valid fragment directive</dfn> if
-it matches the production:</p>
-   <dl>
-    <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="fragmentdirectiveproduction"><code>FragmentDirective</code></dfn> <code>::=</code> 
-    <dd> <code>(<a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective①">TextDirective</a> | <a data-link-type="dfn" href="#unknowndirective" id="ref-for-unknowndirective">UnknownDirective</a>) ("&amp;" <a data-link-type="dfn" href="#fragmentdirectiveproduction" id="ref-for-fragmentdirectiveproduction">FragmentDirective</a>)?</code> 
-    <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="unknowndirective"><code>UnknownDirective</code></dfn> <code>::=</code> 
-    <dd> <code><a data-link-type="dfn" href="#characterstring" id="ref-for-characterstring">CharacterString</a></code> 
-    <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="characterstring"><code>CharacterString</code></dfn> <code>::=</code> 
-    <dd> <code>(<a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar">ExplicitChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar">PercentEncodedChar</a>)+</code> 
-    <dt> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="explicitchar"><code>ExplicitChar</code></dfn> <code>::=</code> 
-    <dd>
-      <code>[a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
-    ";" | "=" | "?" | "@" | "_" | "~" | "," | "-"</code> 
-     <div class="note" role="note"> An <a data-link-type="dfn" href="#explicitchar" id="ref-for-explicitchar①">ExplicitChar</a> may be any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points">URL code point</a> other than "&amp;". </div>
-   </dl>
-   <div class="note" role="note"> The <a data-link-type="dfn" href="#fragmentdirectiveproduction" id="ref-for-fragmentdirectiveproduction①">FragmentDirective</a> can contain multiple directives split by the "&amp;"
-  character. Currently this means we allow multiple text directives to enable
-  multiple indicated strings in the page, but this also allows for future
-  directive types to be added and combined. For extensibility, we do not fail to
-  parse if an unknown directive is in the &amp;-separated list of directives. </div>
-   <dl>
-    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirective"><code>TextDirective</code></dfn> <code>::=</code>
-    <dd><code>"text=" <a data-link-type="dfn" href="#textdirectiveparameters" id="ref-for-textdirectiveparameters">TextDirectiveParameters</a></code>
-    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveparameters"><code>TextDirectiveParameters</code></dfn> <code>::=</code>
-    <dd> <code> (<a data-link-type="dfn" href="#textdirectiveprefix" id="ref-for-textdirectiveprefix">TextDirectivePrefix</a> ",")? <a data-link-type="dfn" href="#textdirectivestring" id="ref-for-textdirectivestring">TextDirectiveString</a> ("," <a data-link-type="dfn" href="#textdirectivestring" id="ref-for-textdirectivestring①">TextDirectiveString</a>)?  ("," <a data-link-type="dfn" href="#textdirectivesuffix" id="ref-for-textdirectivesuffix">TextDirectiveSuffix</a>)? </code> 
-    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveprefix"><code>TextDirectivePrefix</code></dfn> <code>::=</code>
-    <dd><code><a data-link-type="dfn" href="#textdirectivestring" id="ref-for-textdirectivestring②">TextDirectiveString</a>"-"</code>
-    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivesuffix"><code>TextDirectiveSuffix</code></dfn> <code>::=</code>
-    <dd><code>"-"<a data-link-type="dfn" href="#textdirectivestring" id="ref-for-textdirectivestring③">TextDirectiveString</a></code>
-    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectivestring"><code>TextDirectiveString</code></dfn> <code>::=</code>
-    <dd><code>(<a data-link-type="dfn" href="#textdirectiveexplicitchar" id="ref-for-textdirectiveexplicitchar">TextDirectiveExplicitChar</a> | <a data-link-type="dfn" href="#percentencodedchar" id="ref-for-percentencodedchar①">PercentEncodedChar</a>)+</code>
-    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="textdirectiveexplicitchar"><code>TextDirectiveExplicitChar</code></dfn> <code>::=</code>
-    <dd>
-      <code> [a-zA-Z0-9] | "!" | "$" | "'" | "(" | ")" | "*" | "+" | "." | "/" | ":" |
-    ";" | "=" | "?" | "@" | "_" | "~" </code> 
-     <div class="note" role="note"> A <a data-link-type="dfn" href="#textdirectiveexplicitchar" id="ref-for-textdirectiveexplicitchar①">TextDirectiveExplicitChar</a> is any <a data-link-type="dfn" href="https://url.spec.whatwg.org/#url-code-points" id="ref-for-url-code-points①">URL code point</a> that is not
-    explicitly used in the <a data-link-type="dfn" href="#textdirective" id="ref-for-textdirective②">TextDirective</a> syntax, that is "&amp;", "-", and ",".
-    If a text fragment refers to a "&amp;", "-", or "," character in the document,
-    it will be percent-encoded in the fragment. </div>
-    <dt><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="percentencodedchar"><code>PercentEncodedChar</code></dfn> <code>::=</code>
-    <dd><code>"%" [a-zA-Z0-9]+</code>
-   </dl>
-   <h3 class="heading settled" data-level="3.4" id="security-and-privacy"><span class="secno">3.4. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-and-privacy"></a></h3>
-   <h4 class="heading settled" data-level="3.4.1" id="motivation"><span class="secno">3.4.1. </span><span class="content">Motivation</span><a class="self-link" href="#motivation"></a></h4>
+   <h4 class="heading settled" data-level="3.4.1" id="invoking-text-directives"><span class="secno">3.4.1. </span><span class="content">Invoking Text Directives</span><a class="self-link" href="#invoking-text-directives"></a></h4>
+   <p>This section describes how text directives in a document’s <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives①">uninvoked directives</a> are
+processed and invoked to cause indication of the relevant text passages.</p>
+   <div class="note" role="note">
+     The summarized changes in this section: 
+    <ul>
+     <li data-md>
+      <p>Modify the indicated part processing model to try processing <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives②">uninvoked directives</a> into a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range">range</a> that will be returned as the indicated part.</p>
+     <li data-md>
+      <p>Modify "scrolling to a fragment" to correctly scroll and set the Document’s target element in the case
+of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①">range</a> based indicated part.</p>
+     <li data-md>
+      <p>Ensure <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives③">uninvoked directives</a> is reset to null when the user agent has finished the
+fragment search for the current navigation/traversal.</p>
+     <li data-md>
+      <p>If the user agent finishes searching for a text directive, ensure it tries the regular
+fragment as a fallback.</p>
+    </ul>
+   </div>
+   <p>In <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document"> indicated part</a>, enable a fragment to indicate a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②">range</a>. Make the following changes:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scrolling-to-a-fragment"><cite>HTML</cite> § 7.4.6.3 Scrolling to a fragment</a>:</strong></p>
+    <div class="monkeypatch">
+      For an HTML document <var>document</var>, the following processing model must be followed to determine
+  its indicated part: 
+     <ol>
+      <li data-md>
+       <p><span class="diff">Let <var>directives</var> be the document’s <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives④">uninvoked directives</a>. </span></p>
+      <li data-md>
+       <p><span class="diff">If <var>directives</var> is non-null and <var>document</var>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll">allow text
+  fragment scroll</a> is true then:</span></p>
+       <ol>
+        <li data-md>
+         <p><span class="diff">Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
+  the <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive">process a fragment directive</a> steps with <var>directives</var> and the document.</span></p>
+        <li data-md>
+         <p><span class="diff">If <var>ranges</var> is non-empty, then:</span></p>
+         <ol>
+          <li data-md>
+           <p><span class="diff">Let <var>firstRange</var> be the first item of <var>ranges</var>.</span></p>
+          <li data-md>
+           <p><span class="diff">Visually indicate each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range③">range</a> in <var>ranges</var> in an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#implementation-defined" id="ref-for-implementation-defined">implementation-defined</a> way. The indication must not be observable from author
+  script. See <a href="#indicating-the-text-match">§ 3.7 Indicating The Text Match</a>.</span></p>
+           <div class="note" role="note"> The first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range④">range</a> in <var>ranges</var> is the one that gets scrolled into view but all
+    ranges should be visually indicated to the user. </div>
+          <li data-md>
+           <p><span class="diff">Set <var>firstRange</var> as <var>document</var>’s indicated part, return.</span></p>
+         </ol>
+       </ol>
+      <li data-md>
+       <p>Let fragment be document’s URL’s fragment.</p>
+      <li data-md>
+       <p>If fragment is the empty string, then return the special value top of the document.</p>
+      <li data-md>
+       <p>Let potentialIndicatedElement be the result of finding a potential indicated element given
+  document and fragment.</p>
+      <li data-md>
+       <p>...</p>
+     </ol>
+    </div>
+   </blockquote>
+   <p>In <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier">scroll to the fragment</a>, handle a indicated part that is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑤">range</a> and also
+prevent fragment scrolling if the force-load-at-top policy is enabled. Make the following changes:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scrolling-to-a-fragment"><cite>HTML</cite> § 7.4.6.3 Scrolling to a fragment</a>:</strong></p>
+    <div class="monkeypatch">
+     <ol>
+      <li data-md>
+       <p>If document’s indicated part is null, then set document’s target element to null.</p>
+      <li data-md>
+       <p>Otherwise, if document’s indicated part is top of the document, then:</p>
+       <ol>
+        <li data-md>
+         <p>Set document’s target element to null.</p>
+        <li data-md>
+         <p>Scroll to the beginning of the document for document.</p>
+        <li data-md>
+         <p>Return.</p>
+       </ol>
+      <li data-md>
+       <p>Otherwise:</p>
+       <ol>
+        <li data-md>
+         <p class="assertion">Assert: document’s indicated part is an element <span class="diff">or it is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑥">range</a>.</span></p>
+        <li data-md>
+         <p><span class="diff">Let <var>scrollTarget</var> be <var>document</var>’s indicated part.</span></p>
+        <li data-md>
+         <p><span class="diff">Let <var>target</var> be <var>scrollTarget</var>.</span></p>
+        <li data-md>
+         <p><span class="diff">If <var>target</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑦">range</a>, then:</span></p>
+         <ol>
+          <li data-md>
+           <p><span class="diff">Set <var>target</var> to be the <a data-link-type="dfn" href="#first-common-ancestor" id="ref-for-first-common-ancestor">first common ancestor</a> of <var>target</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node">start node</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node">end node</a>.</span></p>
+          <li data-md>
+           <p><span class="diff">While <var>target</var> is non-null and is not an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element">element</a>, set <var>target</var> to <var>target</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent">parent</a>.</span></p>
+           <div class="issue" id="issue-424a4e25"><a class="self-link" href="#issue-424a4e25"></a> What should be set as target if inside a shadow tree? <a href="https://github.com/WICG/scroll-to-text-fragment/issues/190">#190</a> </div>
+         </ol>
+        <li data-md>
+         <p><span class="diff">Assert: <var>target</var> is an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element①">element</a>.</span></p>
+        <li data-md>
+         <p>Set <var>document</var>’s target element to <var>target</var>.</p>
+        <li data-md>
+         <p>Run the ancestor details revealing algorithm on <var>target</var>.</p>
+        <li data-md>
+         <p>Run the ancestor hidden-until-found revealing algorithm on <var>target</var>.</p>
+         <div class="issue" id="issue-10739530"><a class="self-link" href="#issue-10739530"></a> These revealing algorithms currently wont work well since <var>target</var> could be an
+      ancestor or even the root document node. Issue <a href="https://github.com/WICG/scroll-to-text-fragment/issues/89">#89</a> proposes
+      restricting matches to <code>contain:style layout</code> blocks which would resolve this
+      problem. </div>
+        <li data-md>
+         <p><span class="diff"><a href="https://wicg.github.io/document-policy#algo-get-policy-value">Get the policy
+  value</a> for <code>force-load-at-top</code> for <var>document</var>. If the result is false:</span></p>
+         <ol>
+          <li data-md>
+           <p><span class="diff"><a data-link-type="dfn" href="https://drafts.csswg.org/cssom-view-1/#scroll-a-target-into-view" id="ref-for-scroll-a-target-into-view">scroll a target into view</a>,
+  with <em>target</em> set to <var>scrollTarget</var>, <em>behavior</em> set to "auto", <em>block</em> set to "center", and <em>inline</em> set to "nearest".</span></p>
+           <p><span class="diff">Implementations MAY avoid scrolling to the target if it is
+  produced from a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive③">text directive</a>.</span></p>
+         </ol>
+         <div class="issue" id="issue-b49aac41"><a class="self-link" href="#issue-b49aac41"></a> <code>force-load-at-top</code> should be checked only when a new document is being
+      loaded. <a href="https://github.com/WICG/scroll-to-text-fragment/issues/186">#186</a> </div>
+        <li data-md>
+         <strike class="diff">Scroll target into view, with behavior set to "auto", block set to
+  "start", and inline set to "nearest".</strike>
+        <li data-md>
+         <p>Run the focusing steps for target, with the Document’s viewport as the fallback target.</p>
+         <div class="issue" id="issue-e253a983"><a class="self-link" href="#issue-e253a983"></a>Implementation note: Blink doesn’t currently set focus for text
+  fragments, it probably should? TODO: file crbug.</div>
+        <li data-md>
+         <p>Move the sequential focus navigation starting point to target.</p>
+       </ol>
+     </ol>
+    </div>
+   </blockquote>
+   <p>The next two monkeypatches ensure the user agent clears <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives⑤">uninvoked directives</a> when
+the fragment search is complete. In the case where a text directive search finishes because parsing
+has stopped, it tries one more search for a non-text directive fragment.</p>
+   <p>In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-4e67373797cfec56e2dadb5a69ad2ed0"> try to scroll to the fragment</a>:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scrolling-to-a-fragment"><cite>HTML</cite> § 7.4.6.3 Scrolling to a fragment</a>:</strong></p>
+    <div class="monkeypatch">
+      To try to scroll to the fragment for a Document <var>document</var>, perform the following steps in
+  parallel: 
+     <ol>
+      <li data-md>
+       <p>Wait for an implementation-defined amount of time. (This is intended to allow the user agent
+  to optimize the user experience in the face of performance concerns.)</p>
+      <li data-md>
+       <p>Queue a global task on the navigation and traversal task source given document’s relevant
+  global object to run these steps:</p>
+       <ol>
+        <li data-md>
+         <strike class="diff">If document has no parser, or its parser has stopped parsing, or the user agent
+  has reason to believe the user is no longer interested in scrolling to the fragment, then
+  abort these steps.</strike>
+        <li class="diff" value="1">
+         If the user agent has reason to believe the user is no longer interested in scrolling to
+  the fragment, then: 
+         <ol>
+          <li data-md>
+           <p><span class="diff">Set <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives⑥">uninvoked directives</a> to null.</span></p>
+          <li data-md>
+           <p><span class="diff">Abort these steps.</span></p>
+         </ol>
+        <li data-md>
+         <p><span class="diff">If the document has no parser, or its parser has stopped parsing,
+  then:</span></p>
+        <p></p>
+        <ol>
+         <li data-md>
+          <p><span class="diff">If <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives⑦">uninvoked directives</a> is not null, then:</span></p>
+          <ol>
+           <li data-md>
+            <p><span class="diff">Set <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives⑧">uninvoked directives</a> to null.</span></p>
+           <li data-md>
+            <p><span class="diff"><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier①">Scroll to the fragment</a> given <var>document</var>.</span></p>
+          </ol>
+         <li data-md>
+          <p><span class="diff">Abort these steps.</span></p>
+        </ol>
+        <li data-md>
+         <p>Scroll to the fragment given document.</p>
+        <li data-md>
+         <p>If document’s indicated part is still null, then try to scroll to the fragment for
+  document. <span class="diff">Otherwise, set <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives⑨">uninvoked directives</a> to
+  null.</span></p>
+       </ol>
+     </ol>
+    </div>
+   </blockquote>
+   <p>In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid"> navigate to a fragment</a>:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.4.2.3.3 Fragment navigations</a>:</strong></p>
+    <div class="monkeypatch">
+     To navigate to a fragment given navigable <var>navigable</var>, ...: 
+     <ol>
+      <li data-md>
+       <p>...</p>
+      <li value="8">Update document for history step application given navigable’s active
+document, historyEntry, true, scriptHistoryIndex, and scriptHistoryLength. 
+      <li data-md>
+       <p>Scroll to the fragment given navigable’s active document.</p>
+      <li class="diff">Set <var>navigable</var>’s active document’s <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives①⓪">uninvoked directives</a> to
+null.
+      <li data-md>
+       <p>Let traversable be navigable’s traversable navigable.</p>
+      <li data-md>
+       <p>...</p>
+     </ol>
+    </div>
+   </blockquote>
+   <p>Scrolling to the indicated part is only one of several things that happens from "scroll to the
+fragment". Rename it and related definitions:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.4.2.3.3 Fragment navigations</a>:</strong></p>
+    <p>Rename <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.4.2.3.3 Fragment navigations</a> and related steps to "indicating a fragment" to reflect it’s
+  broader effects.</p>
+   </blockquote>
+   <h3 class="heading settled" data-level="3.5" id="security-and-privacy"><span class="secno">3.5. </span><span class="content">Security and Privacy</span><a class="self-link" href="#security-and-privacy"></a></h3>
+   <h4 class="heading settled" data-level="3.5.1" id="motivation"><span class="secno">3.5.1. </span><span class="content">Motivation</span><a class="self-link" href="#motivation"></a></h4>
    <div class="note" role="note">This section is non-normative</div>
-   <p>Care must be taken when implementing <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive③">text directive</a> so that it
+   <p>Care must be taken when implementing <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive④">text directive</a> so that it
 cannot be used to exfiltrate information across origins. Scripts can navigate a
-page to a cross-origin URL with a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive④">text directive</a>. If a malicious
+page to a cross-origin URL with a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑤">text directive</a>. If a malicious
 actor can determine that the text fragment was successfully found in victim
 page as a result of such a navigation, they can infer the existence of any text
 on the page.</p>
@@ -1452,7 +1712,7 @@ navigations that are the result of a user activation.  Additionally,
 navigations originating from a different origin than the destination will
 require the navigation to take place in a "noopener" context, such that the
 destination page is known to be sufficiently isolated.</p>
-   <h4 class="heading settled" data-level="3.4.2" id="scroll-on-navigation"><span class="secno">3.4.2. </span><span class="content">Scroll On Navigation</span><a class="self-link" href="#scroll-on-navigation"></a></h4>
+   <h4 class="heading settled" data-level="3.5.2" id="scroll-on-navigation"><span class="secno">3.5.2. </span><span class="content">Scroll On Navigation</span><a class="self-link" href="#scroll-on-navigation"></a></h4>
    <p>A UA may choose to automatically scroll a matched text passage into view. This
 can be a convenient experience for the user but does present some risks that
 implementing UAs need to be aware of.</p>
@@ -1507,23 +1767,23 @@ attackers from trying to secretly automate a search in background documents.</p>
 element-id into view, if provided, regardless of whether a text fragment was
 matched. Not doing so would allow detecting the text fragment match based on
 whether the element-id was scrolled.</p>
-   <h4 class="heading settled" data-level="3.4.3" id="search-timing"><span class="secno">3.4.3. </span><span class="content">Search Timing</span><a class="self-link" href="#search-timing"></a></h4>
+   <h4 class="heading settled" data-level="3.5.3" id="search-timing"><span class="secno">3.5.3. </span><span class="content">Search Timing</span><a class="self-link" href="#search-timing"></a></h4>
    <p>A naive implementation of the text search algorithm could allow information
 exfiltration based on runtime duration differences between a matching and non-
 matching query. If an attacker could find a way to synchronously navigate
-to a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑤">text directive</a>-invoking URL, they would be able to determine
+to a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑥">text directive</a>-invoking URL, they would be able to determine
 the existence of a text snippet by measuring how long the navigation call takes.</p>
-   <div class="note" role="note"> The restrictions in <a href="#restricting-the-text-fragment">§ 3.4.4 Restricting the Text Fragment</a> prevent this
+   <div class="note" role="note"> The restrictions in <a href="#restricting-the-text-fragment">§ 3.5.4 Restricting the Text Fragment</a> prevent this
   specific case; in particular, the no-same-document-navigation restriction.
   However, these restrictions are provided as multiple layers of defence. </div>
-   <p>For this reason, the implementation <em>must ensure the runtime of <a href="#navigating-to-text-fragment">§ 3.5 Navigating to a Text Fragment</a> steps does not differ based on whether a match
+   <p>For this reason, the implementation <em>must ensure the runtime of <a href="#navigating-to-text-fragment">§ 3.6 Navigating to a Text Fragment</a> steps does not differ based on whether a match
 has been successfully found</em>.</p>
    <p>This specification does not specify exactly how a UA achieves this as there are
 multiple solutions with differing tradeoffs. For example, a UA <em>may</em> continue to walk the tree even after a match is found in <a data-link-type="dfn" href="#find-a-range-from-a-text-directive" id="ref-for-find-a-range-from-a-text-directive">find a range from a
 text directive</a>.  Alternatively, it <em>may</em> schedule an asynchronous task
-to find and set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>'s indicated part.</p>
-   <h4 class="heading settled" data-level="3.4.4" id="restricting-the-text-fragment"><span class="secno">3.4.4. </span><span class="content">Restricting the Text Fragment</span><a class="self-link" href="#restricting-the-text-fragment"></a></h4>
-   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">Document</a> to include a new
+to find and set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">Document</a>'s indicated part.</p>
+   <h4 class="heading settled" data-level="3.5.4" id="restricting-the-text-fragment"><span class="secno">3.5.4. </span><span class="content">Restricting the Text Fragment</span><a class="self-link" href="#restricting-the-text-fragment"></a></h4>
+   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a> to include a new
 boolean <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation">text directive user activation</a> field:</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a>:</strong></p>
@@ -1532,17 +1792,17 @@ boolean <a data-link-type="dfn" href="#document-text-directive-user-activation" 
    </blockquote>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-text-directive-user-activation">text directive user activation</dfn>, which is a boolean,
+    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-text-directive-user-activation">text directive user activation</dfn>, which is a boolean,
   initially false.</p>
     <div class="note" role="note">
       <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation①">text directive user activation</a> provides the necessary user gesture signal to allow
     a single activation of a text fragment. It is set to true during document loading only if the
     navigation occurred as a result of a user activation and is propagated across client-side
     redirects. 
-     <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a>'s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation②">text directive user activation</a> isn’t used to activate a text
+     <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a>'s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation②">text directive user activation</a> isn’t used to activate a text
     fragment, it is instead used to set a new navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>'s <a data-link-type="dfn" href="#request-text-directive-user-activation" id="ref-for-request-text-directive-user-activation">text directive user activation</a> to true. In this way, a <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation③">text directive user activation</a> can be propagated
-    from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a> to another across a navigation.</p>
-     <p>Both <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a>'s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation④">text directive user activation</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-directive-user-activation" id="ref-for-request-text-directive-user-activation①">text directive user activation</a> are always set to false when used, such that a
+    from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a> to another across a navigation.</p>
+     <p>Both <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a>'s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation④">text directive user activation</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-directive-user-activation" id="ref-for-request-text-directive-user-activation①">text directive user activation</a> are always set to false when used, such that a
     single user activation cannot be reused to activate more than one text fragment.</p>
     </div>
    </blockquote>
@@ -1573,15 +1833,15 @@ boolean <a data-link-type="dfn" href="#document-text-directive-user-activation" 
    </div>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allow-text-fragment-scroll">allow text fragment scroll</dfn>, which is a
+    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allow-text-fragment-scroll">allow text fragment scroll</dfn>, which is a
   boolean, initially false.</p>
     <div class="note" role="note">
-     <p> <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll">allow text fragment scroll</a> is used to determine whether a text fragment will
+     <p> <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll①">allow text fragment scroll</a> is used to determine whether a text fragment will
       perform scrolling when the document is loaded. If it is false, the text fragment can be
-      visually indicated but will not be scrolled to. This implements the mitigations discussed in <a href="#scroll-on-navigation">§ 3.4.2 Scroll On Navigation</a>. </p>
+      visually indicated but will not be scrolled to. This implements the mitigations discussed in <a href="#scroll-on-navigation">§ 3.5.2 Scroll On Navigation</a>. </p>
      <p> The reason we compute and store allow text fragment scroll, rather than performing these
       checks at the time of use, is that it relies on the properties of the navigation while the
-      invocation will occur as part of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier">scroll to the fragment</a> steps which can
+      invocation will occur as part of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier②">scroll to the fragment</a> steps which can
       happen outside the context of a navigation. </p>
     </div>
    </blockquote>
@@ -1609,12 +1869,14 @@ and initialize a Document object</a> steps by adding the following steps before 
     activated per user-activated navigation. </div>
       </ol>
      <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll①">allow text fragment scroll</a> by following these sub-steps:</p>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll②">allow text fragment scroll</a> by following these sub-steps:</p>
       <ol>
+       <li data-md>
+        <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-uninvoked-directives" id="ref-for-document-uninvoked-directives①①">uninvoked directives</a> field is null or empty, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll③">allow text fragment scroll</a> to false and abort these sub-steps.</p>
        <li data-md>
         <p>Let <var>text directive user activation</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation⑧">text directive user activation</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation⑨">text directive user activation</a> to false.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll②">allow text fragment scroll</a> to true and abort these sub-steps.</p>
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll④">allow text fragment scroll</a> to true and abort these sub-steps.</p>
         <div class="note" role="note">
          <p> If a navigation originates from browser UI, it’s always ok to allow it
       since it’ll be user triggered and the page/script isn’t providing the
@@ -1632,19 +1894,19 @@ and initialize a Document object</a> steps by adding the following steps before 
          <p> See <a href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a> in <a data-link-type="biblio" href="#biblio-fetch-metadata" title="Fetch Metadata Request Headers">[FETCH-METADATA]</a> for a more detailed discussion of how this applies. </p>
         </div>
        <li data-md>
-        <p>If <var>text directive user activation</var> is false, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll③">allow text fragment scroll</a> to false and abort these sub-steps.</p>
+        <p>If <var>text directive user activation</var> is false, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑤">allow text fragment scroll</a> to false and abort these sub-steps.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll④">allow text fragment scroll</a> to true and abort these
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑥">allow text fragment scroll</a> to true and abort these
   sub-steps.</p>
        <li data-md>
         <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing
-  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑤">allow text fragment scroll</a> to true and abort these sub-steps.</p>
+  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑦">allow text fragment scroll</a> to true and abort these sub-steps.</p>
         <div class="note" role="note"> i.e. Only allow navigation from a cross-origin element/script if the
     document is loaded in a noopener context. That is, a new top level
     browsing context group to which the navigator does not have script access
     and which can be placed into a separate process. </div>
        <li data-md>
-        <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑥">allow text fragment scroll</a> to false.</p>
+        <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑧">allow text fragment scroll</a> to false.</p>
       </ol>
     </ol>
    </blockquote>
@@ -1671,148 +1933,20 @@ steps of the task queued in step 2:</p>
      <li data-md>
       <p>If document has no parser, or its parser has stopped parsing, or the user
   agent has reason to believe the user is no longer interested in scrolling to
-  the fragment, then set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑦">allow text fragment scroll</a> to false and abort these steps.</p>
+  the fragment, then set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑨">allow text fragment scroll</a> to false and abort these steps.</p>
      <li data-md>
       <p>Scroll to the fragment given in document’s URL. If this does not find an
   indicated part, then try to scroll to the fragment for
   document.</p>
      <li data-md>
-      <p>Set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑧">allow text fragment scroll</a> to false.</p>
+      <p>Set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll①⓪">allow text fragment scroll</a> to false.</p>
     </ol>
    </blockquote>
-   <h3 class="heading settled" data-level="3.5" id="navigating-to-text-fragment"><span class="secno">3.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
-   <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.4.2.3.3 Fragment navigations</a>. In summary, if a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑥">text directive</a> is
+   <h3 class="heading settled" data-level="3.6" id="navigating-to-text-fragment"><span class="secno">3.6. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
+   <div class="note" role="note"> The text fragment specification proposes an amendment to <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.4.2.3.3 Fragment navigations</a>. In summary, if a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑦">text directive</a> is
 present and a match is found in the page, the text fragment takes precedent over
 the element fragment as the indicated part. We amend the HTML Document’s
-indicated part processing model to return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range">range</a>, rather than an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element">element</a>, that will be scrolled into view. </div>
-   <p>To enable the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier①">scroll to the fragment</a> algorithm to operate on a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①">range</a> indicated part, replace step 3 of this algorithm as follows:</p>
-   <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>Replace:</p>
-    <ol>
-     <li data-md>
-      <strike>Assert: document’s indicated part is an element.</strike>
-     <li data-md>
-      <strike>Let target be document’s indicated part.</strike>
-     <li data-md>
-      <strike>Set document’s target element to target.</strike>
-     <li data-md>
-      <strike>Run the ancestor details revealing algorithm on target.</strike>
-     <li data-md>
-      <strike>Run the ancestor hidden-until-found revealing algorithm on target.</strike>
-     <li data-md>
-      <strike>Scroll target into view, with behavior set to "auto", block set to "start", and inline set to "nearest".</strike>
-     <li data-md>
-      <strike>Run the focusing steps for target, with the Document’s viewport as the fallback target.</strike>
-     <li data-md>
-      <strike>Move the sequential focus navigation starting point to target.</strike>
-    </ol>
-    <p>With:</p>
-    <ol>
-     <li data-md>
-      <p class="assertion">Assert: document’s indicated part is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②">range</a>.</p>
-     <li data-md>
-      <p>Let <var>range</var> be the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range③">range</a> that is <var>document</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">indicated part</a>.</p>
-     <li data-md>
-      <p>Let <var>target</var> be the <a data-link-type="dfn" href="#first-common-ancestor" id="ref-for-first-common-ancestor">first common ancestor</a> of <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node">start node</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node">end node</a>.</p>
-     <li data-md>
-      <p>While <var>target</var> is non-null and is not an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element①">element</a>, set <var>target</var> to <var>target</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent">parent</a>.</p>
-      <div class="issue" id="issue-424a4e25"><a class="self-link" href="#issue-424a4e25"></a> What should be set as target if inside a shadow tree? <a href="https://github.com/WICG/scroll-to-text-fragment/issues/190">#190</a> </div>
-     <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/web-animations-1/#effect-target-target-element" id="ref-for-effect-target-target-element">target element</a> to <var>target</var>.</p>
-     <li data-md>
-      <p>Run the ancestor details revealing algorithm on target.</p>
-     <li data-md>
-      <p>Run the ancestor hidden-until-found revealing algorithm on target.</p>
-      <div class="issue" id="issue-10739530"><a class="self-link" href="#issue-10739530"></a> These revealing algorithms currently wont work well since <var>target</var> could be an ancestor or even the root document node. Issue <a href="https://github.com/WICG/scroll-to-text-fragment/issues/89">#89</a> proposes restricting matches to <code>contain:style layout</code> blocks which
-    would resolve this problem. </div>
-     <li data-md>
-      <p><a href="https://wicg.github.io/document-policy#algo-get-policy-value">Get
-  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>. If the result is false:</p>
-      <ol>
-       <li data-md>
-        <p>If <var>range</var> wasn’t produced as a result of a text fragment, or if the
-  UA supports scrolling of text fragments on navigation, invoke <a href="https://drafts.csswg.org/cssom-view-1/#scroll-a-target-into-view"> scroll a target into view</a>, with <em>target</em> set to <var>range</var>,
-  containingElement <var>target</var>, <em>behavior</em> set to "auto", <em>block</em> set to "center", and <em>inline</em> set to
-  "nearest".</p>
-      </ol>
-      <div class="issue" id="issue-b49aac41"><a class="self-link" href="#issue-b49aac41"></a> <code>force-load-at-top</code> should be checked only when a new
-      document is being loaded. <a href="https://github.com/WICG/scroll-to-text-fragment/issues/186">#186</a> </div>
-     <li data-md>
-      <p>Let <var>start node</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node①">start node</a>.</p>
-     <li data-md>
-      <p>Run the focusing steps for <var>start node</var>, with the Document’s viewport as the fallback target.</p>
-      <div class="issue" id="issue-e253a983"><a class="self-link" href="#issue-e253a983"></a> Implementation note: Blink doesn’t currently set focus for text
-      fragments, it probably should? TODO: file crbug. </div>
-     <li data-md>
-      <p>Move the sequential focus navigation starting point to <var>start node</var>.</p>
-    </ol>
-   </blockquote>
-   <p>To enable a fragment to indicate a range of text, add the following steps to the
-beginning of the processing model for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#html-document" id="ref-for-html-document">HTML Document</a>'s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document">indicated part</a> so that the indicated part is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range④">range</a>:</p>
-   <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <ol>
-     <li data-md>
-      <p>Let <var>fragment directive string</var> be the document’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry">latest entry</a>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a>.</p>
-     <li data-md>
-      <p>If the document’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑨">allow text fragment scroll</a> is true then:</p>
-      <ol>
-       <li data-md>
-        <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
-  the <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive">process a fragment directive</a> steps with <var>fragment directive
-  string</var> and the document.</p>
-       <li data-md>
-        <p>If <var>ranges</var> is non-empty, then:</p>
-        <ol>
-         <li data-md>
-          <p>Let <var>range</var> be the first item of <var>ranges</var>.</p>
-          <div class="note" role="note"> The first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑤">range</a> in <var>ranges</var> is specifically
-    scrolled into view. This <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑥">range</a>, along with the
-    remaining <var>ranges</var> should be visually indicated in a way that
-    is not revealed to script, which is left as UA-defined behavior. </div>
-         <li data-md>
-          <p>Set <var>range</var> as <var>document</var>’s indicated part, return.</p>
-        </ol>
-      </ol>
-    </ol>
-   </blockquote>
-   <p>In order for the indicated part to return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑦">range</a> for regular element
-fragments, modify the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#find-a-potential-indicated-element"> find a potential indicated element</a> steps as follows:</p>
-   <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>Replace:</p>
-    <ol>
-     <li data-md>
-      <strike>If there is an element in the document tree whose root is
-  document and that has an ID equal to fragment, then return the first
-  such element in tree order.</strike>
-     <li data-md>
-      <strike>If there is an a element in the document tree whose root is
-  document that has a name attribute whose value is equal to fragment,
-  then return the first such element in tree order.</strike>
-     <li data-md>
-      <strike>Return null.</strike>
-    </ol>
-    <p>With:</p>
-    <ol>
-     <li data-md>
-      <p>Let <var>element</var> be an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element②">Element</a>, initially null.</p>
-     <li data-md>
-      <p>If there is an element in the document tree whose root is document and
-  that has an ID equal to fragment, set <var>element</var> to the first such
-  element in tree order.</p>
-     <li data-md>
-      <p>Otherwise, if there is an element in the document tree whose root is
-  document that has a name attribute whose value is equal to fragment,
-  then set <var>element</var> to the first such element in tree order.</p>
-     <li data-md>
-      <p>If <var>element</var> is null, return null.</p>
-     <li data-md>
-      <p>Otherwise, return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑧">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start">start</a> (<var>element</var>, 0) and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end">end</a> (<var>element</var>, <var>element</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length">length</a>).</p>
-    </ol>
-    <p>And rename this algorithm and the returned variables.</p>
-   </blockquote>
+indicated part processing model to return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑧">range</a>, rather than an <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element" id="ref-for-concept-element②">element</a>, that will be scrolled into view. </div>
    <div class="algorithm" data-algorithm="first common ancestor">
      To find the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="first-common-ancestor">first common ancestor</dfn> of two nodes <var>nodeA</var> and <var>nodeB</var>,
 follow these steps: 
@@ -1835,7 +1969,7 @@ ancestor</a> of <var>nodeB</var>, let <var>commonAncestor</var> be <var>commonAn
       <p>Otherwise, return <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-parent" id="ref-for-concept-tree-parent①">parent</a>.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.5.1" id="finding-ranges-in-a-document"><span class="secno">3.5.1. </span><span class="content">Finding Ranges in a Document</span><a class="self-link" href="#finding-ranges-in-a-document"></a></h4>
+   <h4 class="heading settled" data-level="3.6.1" id="finding-ranges-in-a-document"><span class="secno">3.6.1. </span><span class="content">Finding Ranges in a Document</span><a class="self-link" href="#finding-ranges-in-a-document"></a></h4>
    <div class="note" role="note">
      This section outlines several algorithms and definitions that specify how to
   turn a full fragment directive string into a list of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range⑨">Ranges</a> in the
@@ -1895,7 +2029,7 @@ directive</a> steps on <var>directive</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="find a range from a text directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑦">text directive</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a> <var>document</var>, run the
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑧">text directive</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a> <var>document</var>, run the
 following steps: 
     <div class="note" role="note">
       This algorithm takes as input a successfully parsed text directive and a
@@ -1934,7 +2068,7 @@ following steps:
     </div>
     <ol class="algorithm">
      <li data-md>
-      <p>Let <var>searchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①">start</a> (<var>document</var>, 0) and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①">end</a> (<var>document</var>, <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length①">length</a>)</p>
+      <p>Let <var>searchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑦">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start">start</a> (<var>document</var>, 0) and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end">end</a> (<var>document</var>, <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length">length</a>)</p>
      <li data-md>
       <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed">collapsed</a>:</p>
       <ol>
@@ -1949,18 +2083,18 @@ in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-lin
          <li data-md>
           <p>If <var>prefixMatch</var> is null, return null.</p>
          <li data-md>
-          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start②">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after">after</a> <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start③">start</a></p>
+          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after">after</a> <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start②">start</a></p>
          <li data-md>
-          <p>Let <var>matchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑧">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start④">start</a> is <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end②">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end③">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end④">end</a>.</p>
+          <p>Let <var>matchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑧">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start③">start</a> is <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end②">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end③">end</a>.</p>
          <li data-md>
-          <p>Advance <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑤">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position">next non-whitespace position</a>.</p>
+          <p>Advance <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start④">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position">next non-whitespace position</a>.</p>
          <li data-md>
           <p>If <var>matchRange</var> is <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed①">collapsed</a> return null.</p>
-          <div class="note" role="note"> This can happen if <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑤">end</a> or its subsequent
+          <div class="note" role="note"> This can happen if <var>prefixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end④">end</a> or its subsequent
   non-whitespace position is at the end of the document. </div>
          <li data-md>
-          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node②">start node</a> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text">Text</a></code> node.</p>
-          <div class="note" role="note"> <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑥">start</a> now points to the next
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node①">start node</a> is a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text">Text</a></code> node.</p>
+          <div class="note" role="note"> <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑤">start</a> now points to the next
   non-whitespace text data following a matched prefix. </div>
          <li data-md>
           <p>Let <var>mustEndAtWordBoundary</var> be true if <var>parsedValues</var>’s <a data-link-type="dfn" href="#text-directive-end" id="ref-for-text-directive-end⑥">end</a> is non-null or <var>parsedValues</var>’s <a data-link-type="dfn" href="#text-directive-suffix" id="ref-for-text-directive-suffix③">suffix</a> is null, false
@@ -1971,7 +2105,7 @@ range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-t
          <li data-md>
           <p>If <var>potentialMatch</var> is null, return null.</p>
          <li data-md>
-          <p>If <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑦">start</a> is not <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑧">start</a>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">continue</a>.</p>
+          <p>If <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑥">start</a> is not <var>matchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑦">start</a>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">continue</a>.</p>
           <div class="note" role="note"> In this case, we found a prefix but it was followed by something
   other than a matching text so we’ll continue searching for the
   next instance of <a data-link-type="dfn" href="#text-directive-prefix" id="ref-for-text-directive-prefix⑥">prefix</a>. </div>
@@ -1988,10 +2122,10 @@ range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-t
          <li data-md>
           <p>If <var>potentialMatch</var> is null, return null.</p>
          <li data-md>
-          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑨">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp①">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after①">after</a> <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⓪">start</a></p>
+          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑧">start</a> to the first <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp①">boundary point</a> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after①">after</a> <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start⑨">start</a></p>
         </ol>
        <li data-md>
-        <p>Let <var>rangeEndSearchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑨">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①①">start</a> is <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑥">end</a> and whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑦">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑧">end</a>.</p>
+        <p>Let <var>rangeEndSearchRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⑨">range</a> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⓪">start</a> is <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑤">end</a> and whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑥">end</a> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑦">end</a>.</p>
        <li data-md>
         <p>While <var>rangeEndSearchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed②">collapsed</a>:</p>
         <ol>
@@ -2007,7 +2141,7 @@ in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-lin
            <li data-md>
             <p>If <var>endMatch</var> is null then return null.</p>
            <li data-md>
-            <p>Set <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑨">end</a> to <var>endMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⓪">end</a>.</p>
+            <p>Set <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑧">end</a> to <var>endMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end⑨">end</a>.</p>
           </ol>
          <li data-md>
           <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">Assert</a>: <var>potentialMatch</var> is non-null, not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed③">collapsed</a> and
@@ -2015,9 +2149,9 @@ represents a range exactly containing an instance of matching text.</p>
          <li data-md>
           <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#text-directive-suffix" id="ref-for-text-directive-suffix⑥">suffix</a> is null, return <var>potentialMatch</var>.</p>
          <li data-md>
-          <p>Let <var>suffixRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⓪">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①②">start</a> equal to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①①">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①②">end</a> equal to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①③">end</a>.</p>
+          <p>Let <var>suffixRange</var> be a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⓪">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①①">start</a> equal to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⓪">end</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①①">end</a> equal to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①②">end</a>.</p>
          <li data-md>
-          <p>Advance <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①③">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position①">next non-whitespace
+          <p>Advance <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①②">start</a> to the <a data-link-type="dfn" href="#next-non-whitespace-position" id="ref-for-next-non-whitespace-position①">next non-whitespace
 position</a>.</p>
          <li data-md>
           <p>Let <var>suffixMatch</var> be result of running the <a data-link-type="dfn" href="#find-a-string-in-range" id="ref-for-find-a-string-in-range④">find a string in range</a> steps with <var>query</var> <var>parsedValues</var>’s <a data-link-type="dfn" href="#text-directive-suffix" id="ref-for-text-directive-suffix⑦">suffix</a>, <var>searchRange</var> <var>suffixRange</var>, <var>wordStartBounded</var> false, and <var>wordEndBounded</var> true.</p>
@@ -2026,7 +2160,7 @@ position</a>.</p>
           <div class="note" role="note"> If the suffix doesn’t appear in the remaining text of the document,
   there’s no possible way to make a match. </div>
          <li data-md>
-          <p>If <var>suffixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①④">start</a> is <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑤">start</a>,
+          <p>If <var>suffixMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①③">start</a> is <var>suffixRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①④">start</a>,
 return <var>potentialMatch</var>.</p>
          <li data-md>
           <p>If <var>parsedValues</var>’s <a data-link-type="dfn" href="#text-directive-end" id="ref-for-text-directive-end①⓪">end</a> item is null
@@ -2037,7 +2171,7 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-brea
   If we’re looking for a range match, we’ll continue iterating
   this inner loop since the range start will already be correct. </div>
          <li data-md>
-          <p>Set <var>rangeEndSearchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑥">start</a> to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①④">end</a>.</p>
+          <p>Set <var>rangeEndSearchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑤">start</a> to <var>potentialMatch</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①③">end</a>.</p>
           <div class="note" role="note"> Otherwise, it is possible that we found the correct range
   start, but not the correct range end. Continue the inner
   loop to keep searching for another matching instance of
@@ -2067,22 +2201,22 @@ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-brea
     </ul>
    </details>
    <div class="algorithm" data-algorithm="advance range start to next non-whitespace position">
-     To advance a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②①">range</a> <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑦">start</a> to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="next non-whitespace position" data-noexport id="next-non-whitespace-position">next
+     To advance a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②①">range</a> <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑥">start</a> to the <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="next non-whitespace position" data-noexport id="next-non-whitespace-position">next
 non-whitespace position</dfn> follow the steps: 
     <ol class="algorithm">
      <li data-md>
       <p>While <var>range</var> is not collapsed:</p>
       <ol>
        <li data-md>
-        <p>Let <var>node</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node③">start node</a>.</p>
+        <p>Let <var>node</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node②">start node</a>.</p>
        <li data-md>
         <p>Let <var>offset</var> be <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset">start offset</a>.</p>
        <li data-md>
         <p>If <var>node</var> is part of a <a data-link-type="dfn" href="#non-searchable-subtree" id="ref-for-non-searchable-subtree">non-searchable subtree</a> or if <var>node</var> is
-not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node">visible text node</a> or if <var>offset</var> is equal to <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length②">length</a> then:</p>
+not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node">visible text node</a> or if <var>offset</var> is equal to <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length①">length</a> then:</p>
         <ol>
          <li data-md>
-          <p>Set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node④">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order">shadow-including tree order</a>.</p>
+          <p>Set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node③">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order">shadow-including tree order</a>.</p>
          <li data-md>
           <p>Set <var>range</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset①">start offset</a> to 0.</p>
          <li data-md>
@@ -2118,7 +2252,7 @@ not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text
 run these steps: 
     <div class="note" role="note"> This algorithm will return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②③">range</a> that represents the first instance of
   the <var>query</var> text that is fully contained within <var>searchRange</var>, optionally
-  restricting itself to matches that start and/or end at word boundaries (see <a href="#word-boundaries">§ 3.5.2 Word Boundaries</a>). Returns null if none is found. </div>
+  restricting itself to matches that start and/or end at word boundaries (see <a href="#word-boundaries">§ 3.6.2 Word Boundaries</a>). Returns null if none is found. </div>
     <div class="note" role="note">
      <p> The basic premise of this algorithm is to walk all searchable text nodes
     within a block, collecting them into a list. The list is then concatenated
@@ -2139,12 +2273,12 @@ run these steps:
       <p>While <var>searchRange</var> is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#range-collapsed" id="ref-for-range-collapsed⑤">collapsed</a>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>curNode</var> be <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑤">start node</a>.</p>
+        <p>Let <var>curNode</var> be <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node④">start node</a>.</p>
        <li data-md>
         <p>If <var>curNode</var> is part of a <a data-link-type="dfn" href="#non-searchable-subtree" id="ref-for-non-searchable-subtree①">non-searchable subtree</a>:</p>
         <ol>
          <li data-md>
-          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑥">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order①">shadow-including tree order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant">shadow-including
+          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑤">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order①">shadow-including tree order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant">shadow-including
 descendant</a> of <var>curNode</var>.</p>
          <li data-md>
           <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑤">start offset</a> to 0.</p>
@@ -2155,7 +2289,7 @@ descendant</a> of <var>curNode</var>.</p>
         <p>If <var>curNode</var> is not a <a data-link-type="dfn" href="#visible-text-node" id="ref-for-visible-text-node①">visible text node</a>:</p>
         <ol>
          <li data-md>
-          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑦">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order②">shadow-including tree order</a>, that is not a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-doctype" id="ref-for-concept-doctype">doctype</a>.</p>
+          <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑥">start node</a> to the next node, in <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order" id="ref-for-concept-shadow-including-tree-order②">shadow-including tree order</a>, that is not a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-doctype" id="ref-for-concept-doctype">doctype</a>.</p>
          <li data-md>
           <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑥">start offset</a> to 0.</p>
          <li data-md>
@@ -2167,7 +2301,7 @@ descendant</a> of <var>curNode</var>.</p>
         <p>Let <var>textNodeList</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑦">list</a> of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text①">Text</a></code> nodes,
 initially empty.</p>
        <li data-md>
-        <p>While <var>curNode</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant①">shadow-including descendant</a> of <var>blockAncestor</var> and the position of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp②">boundary point</a> (<var>curNode</var>, 0) is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after②">after</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⑤">end</a>:</p>
+        <p>While <var>curNode</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant" id="ref-for-concept-shadow-including-descendant①">shadow-including descendant</a> of <var>blockAncestor</var> and the position of the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp②">boundary point</a> (<var>curNode</var>, 0) is not <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp-after" id="ref-for-concept-range-bp-after②">after</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①④">end</a>:</p>
         <ol>
          <li data-md>
           <p>If <var>curNode</var> <a data-link-type="dfn" href="#has-block-level-display" id="ref-for-has-block-level-display">has block-level display</a> then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break②">break</a>.</p>
@@ -2190,9 +2324,9 @@ order</a>, that isn’t a <a data-link-type="dfn" href="https://dom.spec.whatwg.
        <li data-md>
         <p>If <var>curNode</var> is null, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-break" id="ref-for-iteration-break③">break</a>.</p>
        <li data-md>
-        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert④">Assert</a>: <var>curNode</var> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-following" id="ref-for-concept-tree-following">follows</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑧">start node</a>.</p>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert④">Assert</a>: <var>curNode</var> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-following" id="ref-for-concept-tree-following">follows</a> <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑦">start node</a>.</p>
        <li data-md>
-        <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑧">start</a> to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp③">boundary point</a> (<var>curNode</var>,
+        <p>Set <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑦">start</a> to the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp③">boundary point</a> (<var>curNode</var>,
 0).</p>
       </ol>
      <li data-md>
@@ -2247,7 +2381,7 @@ a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="
         <p>When requiring a word boundary at the end, it will not match in “forest ranger”.</p>
       </ol>
      </div>
-     <p>See <a href="#word-boundaries">§ 3.5.2 Word Boundaries</a> for details and more examples.</p>
+     <p>See <a href="#word-boundaries">§ 3.6.2 Word Boundaries</a> for details and more examples.</p>
     </div>
     <ol class="algorithm">
      <li data-md>
@@ -2259,7 +2393,7 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
      <li data-md>
       <p>Let <var>searchStart</var> be 0.</p>
      <li data-md>
-      <p>If the first item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑨">start node</a> then
+      <p>If the first item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-node" id="ref-for-concept-range-start-node⑧">start node</a> then
 set <var>searchStart</var> to <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start-offset" id="ref-for-concept-range-start-offset⑦">start offset</a>.</p>
      <li data-md>
       <p>Let <var>start</var> and <var>end</var> be <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp④">boundary points</a>, initially null.</p>
@@ -2298,7 +2432,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
      <li data-md>
       <p>Let <var>endInset</var> be 0.</p>
      <li data-md>
-      <p>If the last item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node①">end node</a> then set <var>endInset</var> to (<var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node②">end node</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length③">length</a> − <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-offset" id="ref-for-concept-range-end-offset">end offset</a>)</p>
+      <p>If the last item in <var>nodes</var> is <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node①">end node</a> then set <var>endInset</var> to (<var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-node" id="ref-for-concept-range-end-node②">end node</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length②">length</a> − <var>searchRange</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end-offset" id="ref-for-concept-range-end-offset">end offset</a>)</p>
       <div class="note" role="note"> <var>endInset</var> is the offset from the last position in the last node in the
   reverse direction. Alternatively, it is the length of the node that’s not
   included in the range. </div>
@@ -2308,7 +2442,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
      <li data-md>
       <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert⑤">Assert</a>: <var>start</var> and <var>end</var> are non-null, valid <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑦">boundary points</a> in <var>searchRange</var>.</p>
      <li data-md>
-      <p>Return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⑦">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑨">start</a> <var>start</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⑥">end</a> <var>end</var>.</p>
+      <p>Return a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range②⑦">range</a> with <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-start" id="ref-for-concept-range-start①⑧">start</a> <var>start</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-end" id="ref-for-concept-range-end①⑤">end</a> <var>end</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="boundary point at index">
@@ -2328,7 +2462,7 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
       <p>For each <var>curNode</var> of <var>nodes</var>:</p>
       <ol>
        <li data-md>
-        <p>Let <var>nodeEnd</var> be <var>counted</var> + <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length④">length</a>.</p>
+        <p>Let <var>nodeEnd</var> be <var>counted</var> + <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length③">length</a>.</p>
        <li data-md>
         <p>If <var>isEnd</var> is true, add 1 to <var>nodeEnd</var>.</p>
        <li data-md>
@@ -2338,13 +2472,13 @@ not at a word boundary</a> in <var>searchBuffer</var>, given the <a data-link-ty
           <p>Return the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range-bp" id="ref-for-concept-range-bp⑧">boundary point</a> (<var>curNode</var>, <var>index</var> − <var>counted</var>).</p>
         </ol>
        <li data-md>
-        <p>Increment <var>counted</var> by <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length⑤">length</a>.</p>
+        <p>Increment <var>counted</var> by <var>curNode</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-length" id="ref-for-concept-node-length④">length</a>.</p>
       </ol>
      <li data-md>
       <p>Return null.</p>
     </ol>
    </div>
-   <h4 class="heading settled" data-level="3.5.2" id="word-boundaries"><span class="secno">3.5.2. </span><span class="content">Word Boundaries</span><a class="self-link" href="#word-boundaries"></a></h4>
+   <h4 class="heading settled" data-level="3.6.2" id="word-boundaries"><span class="secno">3.6.2. </span><span class="content">Word Boundaries</span><a class="self-link" href="#word-boundaries"></a></h4>
    <div class="note" role="note"> Limiting matching to word boundaries is one of the mitigations to limit
   cross-origin information leakage. </div>
    <div class="note" role="note"> See <a href="https://github.com/tc39/proposal-intl-segmenter">Intl.Segmenter</a>, a
@@ -2397,7 +2531,7 @@ is more than 0 and <var>position</var> equals either 0 or <var>text</var>’s le
   mountain range" but not within "An impressive mountain ranger". </div>
    <div class="example" id="example-c7882c95"><a class="self-link" href="#example-c7882c95"></a> In the Japanese string "ウィキペディアへようこそ" (Welcome to Wikipedia),
   "ようこそ" (Welcome) is considered word-bounded but "ようこ" is not. </div>
-   <h3 class="heading settled" data-level="3.6" id="indicating-the-text-match"><span class="secno">3.6. </span><span class="content">Indicating The Text Match</span><a class="self-link" href="#indicating-the-text-match"></a></h3>
+   <h3 class="heading settled" data-level="3.7" id="indicating-the-text-match"><span class="secno">3.7. </span><span class="content">Indicating The Text Match</span><a class="self-link" href="#indicating-the-text-match"></a></h3>
    <p>The UA may choose to scroll the text fragment into view as part of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment" id="ref-for-try-to-scroll-to-the-fragment①">try to scroll to the fragment</a> steps or by some other mechanism;
 however, it is not required to scroll the match into view.</p>
    <p>The UA should visually indicate the matched text in some way such that the user
@@ -2405,16 +2539,16 @@ is made aware of the text match, such as with a high-contrast highlight.</p>
    <p>The UA should provide to the user some method of dismissing the match, such
 that the matched text no longer appears visually indicated.</p>
    <p>The exact appearance and mechanics of the indication are left as UA-defined.
-However, the UA must not use the Document’s <a href="https://w3c.github.io/selection-api/#dfn-selection">selection</a> to
-indicate the text match as doing so could allow attack vectors for content
-exfiltration.</p>
+However, the UA must not use any methods observable by author script, such as
+the Document’s <a href="https://w3c.github.io/selection-api/#dfn-selection"> selection</a>, to indicate the text match. Doing so could allow attack vectors
+for content exfiltration.</p>
    <p>The UA must not visually indicate any provided context terms.</p>
    <p>Since the indicator is not part of the document’s content, UAs should consider
 ways to differentiate it from the page’s content as perceived by the user.</p>
    <div class="example" id="example-30d9320e"><a class="self-link" href="#example-30d9320e"></a> The UA could provide an in-product help prompt the first few times the
   indicator appears to help train the user that it comes from the linking page
   and is provided by the UA. </div>
-   <h4 class="heading settled" data-level="3.6.1" id="urls-in-ua-features"><span class="secno">3.6.1. </span><span class="content">URLs in UA features</span><a class="self-link" href="#urls-in-ua-features"></a></h4>
+   <h4 class="heading settled" data-level="3.7.1" id="urls-in-ua-features"><span class="secno">3.7.1. </span><span class="content">URLs in UA features</span><a class="self-link" href="#urls-in-ua-features"></a></h4>
    <p>UAs provide a number of consumers for a document’s URL (outside of programmatic
 APIs like <code>window.location</code>). Examples include a location bar
 indicating the URL of the currently visible document, or the URL used when a
@@ -2450,26 +2584,26 @@ page, the UA may choose to omit it from the exposed URL.</p>
   fragments are assumed to be the only kind of directive. If additional
   directives are added in the future, the UX in these cases will have to be
   re-evaluated separately for new directive types. </div>
-   <h5 class="heading settled" data-level="3.6.1.1" id="urls-in-location-bar"><span class="secno">3.6.1.1. </span><span class="content">Location Bar</span><a class="self-link" href="#urls-in-location-bar"></a></h5>
+   <h5 class="heading settled" data-level="3.7.1.1" id="urls-in-location-bar"><span class="secno">3.7.1.1. </span><span class="content">Location Bar</span><a class="self-link" href="#urls-in-location-bar"></a></h5>
    <p>The location bar’s URL should include a text fragment while it is visually
 indicated. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①①">fragment directive</a> should be stripped from the location bar
 URL when the user dismisses the indication.</p>
    <p>It is recommended that the text fragment be displayed in the location bar’s URL
 even if a match wasn’t located in the document.</p>
-   <h5 class="heading settled" data-level="3.6.1.2" id="urls-in-bookmarks"><span class="secno">3.6.1.2. </span><span class="content">Bookmarks</span><a class="self-link" href="#urls-in-bookmarks"></a></h5>
+   <h5 class="heading settled" data-level="3.7.1.2" id="urls-in-bookmarks"><span class="secno">3.7.1.2. </span><span class="content">Bookmarks</span><a class="self-link" href="#urls-in-bookmarks"></a></h5>
    <p>Many UAs provide a "bookmark" feature allowing users to store a convenient link
 to the current page in the UA’s interface.</p>
    <p>A newly created bookmark should, by default, include the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①②">fragment directive</a> in the URL if, and only if, a match was found and the visual indicator hasn’t
 been dismissed.</p>
    <p>Navigating to a URL from a bookmark should process a <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①③">fragment directive</a> as
 if it were navigated to in a typical navigation.</p>
-   <h5 class="heading settled" data-level="3.6.1.3" id="urls-in-sharing"><span class="secno">3.6.1.3. </span><span class="content">Sharing</span><a class="self-link" href="#urls-in-sharing"></a></h5>
+   <h5 class="heading settled" data-level="3.7.1.3" id="urls-in-sharing"><span class="secno">3.7.1.3. </span><span class="content">Sharing</span><a class="self-link" href="#urls-in-sharing"></a></h5>
    <p>Some UAs provide a method for users to share the current page with others,
 typically by providing the URL to another app or messaging service.</p>
    <p>When providing a URL in these situations, it should include the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive①④">fragment
 directive</a> if, and only if, a match was found and the visual indicator hasn’t
 been dismissed.</p>
-   <h3 class="heading settled" data-level="3.7" id="document-policy-integration"><span class="secno">3.7. </span><span class="content">Document Policy Integration</span><a class="self-link" href="#document-policy-integration"></a></h3>
+   <h3 class="heading settled" data-level="3.8" id="document-policy-integration"><span class="secno">3.8. </span><span class="content">Document Policy Integration</span><a class="self-link" href="#document-policy-integration"></a></h3>
    <p>This specification defines a <a href="https://wicg.github.io/document-policy#configuration-point">configuration point</a> in <a data-link-type="biblio" href="#biblio-document-policy" title="Document Policy">Document Policy</a> with name "force-load-at-top". Its <a href="https://wicg.github.io/document-policy#configuration-point-type">type</a> is <code>boolean</code> with <a href="https://wicg.github.io/document-policy#configuration-point-default-value">default value</a> <code>false</code>.</p>
    <div class="note" role="note"> When enabled, this policy disables all automatic scroll-on-load features:
   text-fragments, element fragments, history scroll restoration. </div>
@@ -2482,7 +2616,7 @@ been dismissed.</p>
   indicated part and set as the document’s target element. However, "foo"
   will not be scrolled into view.</p>
    </div>
-   <p>Fragment-based scroll blocking from this policy is specified in an amendment to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier②">scroll to the fragment</a> algorithm in the <a href="#navigating-to-text-fragment">§ 3.5 Navigating to a Text Fragment</a> section of this document.</p>
+   <p>Fragment-based scroll blocking from this policy is specified in an amendment to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier③">scroll to the fragment</a> algorithm in the <a href="#navigating-to-text-fragment">§ 3.6 Navigating to a Text Fragment</a> section of this document.</p>
    <p>History scroll restoration is blocked by amending the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state" id="ref-for-restore-persisted-state">restore
 persisted state</a> steps by inserting a new step after 2:</p>
    <ol start="3">
@@ -2492,7 +2626,7 @@ the document policy value</a> of the "force-load-at-top" feature for the <a data
 the result is true, then the user agent should not restore the scroll
 position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">Document</a> or any of its scrollable regions.</p>
    </ol>
-   <h3 class="heading settled" data-level="3.8" id="feature-detectability"><span class="secno">3.8. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
+   <h3 class="heading settled" data-level="3.9" id="feature-detectability"><span class="secno">3.9. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
 that is exposed via <code>document.fragmentDirective</code> if the UA supports
 the feature.</p>
@@ -2510,7 +2644,7 @@ fragment or other fragment directives in the future.</p>
    <h2 class="heading settled" data-level="4" id="generating-text-fragment-directives"><span class="secno">4. </span><span class="content">Generating Text Fragment Directives</span><a class="self-link" href="#generating-text-fragment-directives"></a></h2>
    <div class="note" role="note"> This section is non-normative. </div>
    <p>This section contains recommendations for UAs automatically generating URLs
-with a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑧">text directive</a>. These recommendations aren’t normative but
+with a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑨">text directive</a>. These recommendations aren’t normative but
 are provided to ensure generated URLs result in maximally stable and usable
 URLs.</p>
    <h3 class="heading settled" data-level="4.1" id="prefer-exact-matching-to-range-based"><span class="secno">4.1. </span><span class="content">Prefer Exact Matching To Range-based</span><a class="self-link" href="#prefer-exact-matching-to-range-based"></a></h3>
@@ -2545,18 +2679,18 @@ exact match. Above this limit, the UA can encode the string as a range-based
 match.</p>
    <div class="note" role="note"> TODO:  Can we determine the above limit in some less arbitrary way? </div>
    <h3 class="heading settled" data-level="4.2" id="use-context-only-when-necessary"><span class="secno">4.2. </span><span class="content">Use Context Only When Necessary</span><a class="self-link" href="#use-context-only-when-necessary"></a></h3>
-   <p>Context terms allow the <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑨">text directive</a> to disambiguate text
+   <p>Context terms allow the <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive①⓪">text directive</a> to disambiguate text
 snippets on a page. However, their use can make the URL more brittle in some
 cases. Often, the desired string will start or end at an element boundary. The
 context will therefore exist in an adjacent element. Changes to the page
-structure could invalidate the <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive①⓪">text directive</a> since the context and
+structure could invalidate the <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive①①">text directive</a> since the context and
 match text will no longer appear to be adjacent.</p>
    <div class="example" id="example-7a86f6f5">
     <a class="self-link" href="#example-7a86f6f5"></a> Suppose we wish to craft a URL for the following text: 
 <pre>&lt;div class="section">HEADER&lt;/div>
 &lt;div class="content">Text to quote&lt;/div>
 </pre>
-    <p>We could craft the <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive①①">text directive</a> as follows:</p>
+    <p>We could craft the <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive①②">text directive</a> as follows:</p>
 <pre>text=HEADER-,Text%20to%20quote
 </pre>
     <p>However, suppose the page changes to add a "[edit]" link beside all section
@@ -2571,11 +2705,11 @@ adding superfluous context terms.</p>
    </ul>
    <div class="note" role="note"> TODO: Determine the numeric limit above in less arbitrary way. </div>
    <h3 class="heading settled" data-level="4.3" id="determine-if-fragment-id-is-needed"><span class="secno">4.3. </span><span class="content">Determine If Fragment Id Is Needed</span><a class="self-link" href="#determine-if-fragment-id-is-needed"></a></h3>
-   <p>When the UA navigates to a URL containing a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive①②">text directive</a>, it will
+   <p>When the UA navigates to a URL containing a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive①③">text directive</a>, it will
 fallback to scrolling into view a regular element-id based fragment if it
 exists and the text fragment isn’t found.</p>
    <p>This can be useful to provide a fallback, in case the text in the document
-changes, invalidating the <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive①③">text directive</a>.</p>
+changes, invalidating the <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive①④">text directive</a>.</p>
    <div class="example" id="example-5990805b">
     <a class="self-link" href="#example-5990805b"></a> Suppose we wish to craft a URL to
   https://en.wikipedia.org/wiki/History_of_computing quoting the sentence: 
@@ -2659,8 +2793,8 @@ manipulations
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#document-allow-text-fragment-scroll">allow text fragment scroll</a><span>, in § 3.4.4</span>
-   <li><a href="#characterstring">CharacterString</a><span>, in § 3.3.3</span>
+   <li><a href="#document-allow-text-fragment-scroll">allow text fragment scroll</a><span>, in § 3.5.4</span>
+   <li><a href="#characterstring">CharacterString</a><span>, in § 3.3.4</span>
    <li><a href="#directives">directives</a><span>, in § 3.3</span>
    <li>
     directive state
@@ -2668,660 +2802,662 @@ manipulations
      <li><a href="#directive-state">definition of</a><span>, in § 3.3.1</span>
      <li><a href="#she-directive-state">dfn for she</a><span>, in § 3.3.1</span>
     </ul>
-   <li><a href="#text-directive-end">end</a><span>, in § 3.3.2</span>
-   <li><a href="#explicitchar">ExplicitChar</a><span>, in § 3.3.3</span>
-   <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in § 3.5.1</span>
-   <li><a href="#find-a-range-from-a-text-directive">find a range from a text directive</a><span>, in § 3.5.1</span>
-   <li><a href="#find-a-string-in-range">find a string in range</a><span>, in § 3.5.1</span>
-   <li><a href="#first-common-ancestor">first common ancestor</a><span>, in § 3.5</span>
+   <li><a href="#text-directive-end">end</a><span>, in § 3.4</span>
+   <li><a href="#explicitchar">ExplicitChar</a><span>, in § 3.3.4</span>
+   <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in § 3.6.1</span>
+   <li><a href="#find-a-range-from-a-text-directive">find a range from a text directive</a><span>, in § 3.6.1</span>
+   <li><a href="#find-a-string-in-range">find a string in range</a><span>, in § 3.6.1</span>
+   <li><a href="#first-common-ancestor">first common ancestor</a><span>, in § 3.6</span>
    <li><a href="#fragment-directive">fragment directive</a><span>, in § 3.3</span>
    <li>
     FragmentDirective
     <ul>
-     <li><a href="#fragmentdirective">(interface)</a><span>, in § 3.8</span>
-     <li><a href="#fragmentdirectiveproduction">definition of</a><span>, in § 3.3.3</span>
+     <li><a href="#fragmentdirective">(interface)</a><span>, in § 3.9</span>
+     <li><a href="#fragmentdirectiveproduction">definition of</a><span>, in § 3.3.4</span>
     </ul>
-   <li><a href="#dom-document-fragmentdirective">fragmentDirective</a><span>, in § 3.8</span>
+   <li><a href="#dom-document-fragmentdirective">fragmentDirective</a><span>, in § 3.9</span>
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in § 3.3</span>
-   <li><a href="#get-boundary-point-at-index">get boundary point at index</a><span>, in § 3.5.1</span>
-   <li><a href="#has-block-level-display">has block-level display</a><span>, in § 3.5.1</span>
-   <li><a href="#is-at-a-word-boundary">is at a word boundary</a><span>, in § 3.5.2</span>
-   <li><a href="#locale">locale</a><span>, in § 3.5.2</span>
-   <li><a href="#nearest-block-ancestor">nearest block ancestor</a><span>, in § 3.5.1</span>
-   <li><a href="#next-non-whitespace-position">next non-whitespace position</a><span>, in § 3.5.1</span>
-   <li><a href="#non-searchable-subtree">non-searchable subtree</a><span>, in § 3.5.1</span>
-   <li><a href="#parse-a-text-directive">parse a text directive</a><span>, in § 3.3.2</span>
-   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in § 3.3.3</span>
-   <li><a href="#text-directive-prefix">prefix</a><span>, in § 3.3.2</span>
-   <li><a href="#process-a-fragment-directive">process a fragment directive</a><span>, in § 3.5.1</span>
+   <li><a href="#get-boundary-point-at-index">get boundary point at index</a><span>, in § 3.6.1</span>
+   <li><a href="#has-block-level-display">has block-level display</a><span>, in § 3.6.1</span>
+   <li><a href="#is-at-a-word-boundary">is at a word boundary</a><span>, in § 3.6.2</span>
+   <li><a href="#locale">locale</a><span>, in § 3.6.2</span>
+   <li><a href="#nearest-block-ancestor">nearest block ancestor</a><span>, in § 3.6.1</span>
+   <li><a href="#next-non-whitespace-position">next non-whitespace position</a><span>, in § 3.6.1</span>
+   <li><a href="#non-searchable-subtree">non-searchable subtree</a><span>, in § 3.6.1</span>
+   <li><a href="#parse-a-text-directive">parse a text directive</a><span>, in § 3.4</span>
+   <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in § 3.3.4</span>
+   <li><a href="#text-directive-prefix">prefix</a><span>, in § 3.4</span>
+   <li><a href="#process-a-fragment-directive">process a fragment directive</a><span>, in § 3.6.1</span>
    <li><a href="#remove-the-fragment-directive">remove the fragment directive</a><span>, in § 3.3.1</span>
-   <li><a href="#search-invisible">search invisible</a><span>, in § 3.5.1</span>
-   <li><a href="#shadow-including-parent">shadow-including parent</a><span>, in § 3.5</span>
-   <li><a href="#text-directive-start">start</a><span>, in § 3.3.2</span>
-   <li><a href="#text-directive-suffix">suffix</a><span>, in § 3.3.2</span>
-   <li><a href="#text-directive">text directive</a><span>, in § 3.3.2</span>
-   <li><a href="#textdirective">TextDirective</a><span>, in § 3.3.3</span>
-   <li><a href="#textdirectiveexplicitchar">TextDirectiveExplicitChar</a><span>, in § 3.3.3</span>
-   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in § 3.3.3</span>
-   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in § 3.3.3</span>
-   <li><a href="#textdirectivestring">TextDirectiveString</a><span>, in § 3.3.3</span>
-   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in § 3.3.3</span>
+   <li><a href="#search-invisible">search invisible</a><span>, in § 3.6.1</span>
+   <li><a href="#shadow-including-parent">shadow-including parent</a><span>, in § 3.6</span>
+   <li><a href="#text-directive-start">start</a><span>, in § 3.4</span>
+   <li><a href="#text-directive-suffix">suffix</a><span>, in § 3.4</span>
+   <li><a href="#text-directive">text directive</a><span>, in § 3.4</span>
+   <li><a href="#textdirective">TextDirective</a><span>, in § 3.3.4</span>
+   <li><a href="#textdirectiveexplicitchar">TextDirectiveExplicitChar</a><span>, in § 3.3.4</span>
+   <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in § 3.3.4</span>
+   <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in § 3.3.4</span>
+   <li><a href="#textdirectivestring">TextDirectiveString</a><span>, in § 3.3.4</span>
+   <li><a href="#textdirectivesuffix">TextDirectiveSuffix</a><span>, in § 3.3.4</span>
    <li>
     text directive user activation
     <ul>
-     <li><a href="#document-text-directive-user-activation">dfn for document</a><span>, in § 3.4.4</span>
-     <li><a href="#request-text-directive-user-activation">dfn for request</a><span>, in § 3.4.4</span>
+     <li><a href="#document-text-directive-user-activation">dfn for document</a><span>, in § 3.5.4</span>
+     <li><a href="#request-text-directive-user-activation">dfn for request</a><span>, in § 3.5.4</span>
     </ul>
-   <li><a href="#unknowndirective">UnknownDirective</a><span>, in § 3.3.3</span>
-   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in § 3.3.3</span>
+   <li><a href="#document-uninvoked-directives">uninvoked directives</a><span>, in § 3.3.2</span>
+   <li><a href="#unknowndirective">UnknownDirective</a><span>, in § 3.3.4</span>
+   <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in § 3.3.4</span>
    <li><a href="#directive-state-value">value</a><span>, in § 3.3.1</span>
-   <li><a href="#visible-text-node">visible text node</a><span>, in § 3.5.1</span>
-   <li><a href="#word-boundary">word boundary</a><span>, in § 3.5.2</span>
-   <li><a href="#word-bounded">word bounded</a><span>, in § 3.5.2</span>
+   <li><a href="#visible-text-node">visible text node</a><span>, in § 3.6.1</span>
+   <li><a href="#word-boundary">word boundary</a><span>, in § 3.6.2</span>
+   <li><a href="#word-bounded">word bounded</a><span>, in § 3.6.2</span>
   </ul>
   <aside aria-labelledby="infopaneltitle-for-04a3e56775153b770147c82efb4a7fcc" class="dfn-panel" data-for="04a3e56775153b770147c82efb4a7fcc" id="infopanel-for-04a3e56775153b770147c82efb4a7fcc">
    <span id="infopaneltitle-for-04a3e56775153b770147c82efb4a7fcc" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-computed-value">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a>
+    <li><a href="#ref-for-computed-value">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-237214a4fd6d7213e767ffff72449766" class="dfn-panel" data-for="237214a4fd6d7213e767ffff72449766" id="infopanel-for-237214a4fd6d7213e767ffff72449766">
    <span id="infopaneltitle-for-237214a4fd6d7213e767ffff72449766" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-flex">https://drafts.csswg.org/css-display-3/#valdef-display-flex</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-display-flex">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-valdef-display-flex">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-ec8797201183b965b0d6d6fb070cd536" class="dfn-panel" data-for="ec8797201183b965b0d6d6fb070cd536" id="infopanel-for-ec8797201183b965b0d6d6fb070cd536">
    <span id="infopaneltitle-for-ec8797201183b965b0d6d6fb070cd536" style="display:none">Info about the 'grid' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-grid">https://drafts.csswg.org/css-display-3/#valdef-display-grid</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-display-grid">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-valdef-display-grid">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-b8338bd8fab72fca326f5384a61ae74f" class="dfn-panel" data-for="b8338bd8fab72fca326f5384a61ae74f" id="infopanel-for-b8338bd8fab72fca326f5384a61ae74f">
    <span id="infopaneltitle-for-b8338bd8fab72fca326f5384a61ae74f" style="display:none">Info about the 'block' external reference.</span><a href="https://drafts.csswg.org/css-display-4/#valdef-display-block">https://drafts.csswg.org/css-display-4/#valdef-display-block</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-display-block">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-valdef-display-block">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-522431f7808b21d88503d04e52e61f86" class="dfn-panel" data-for="522431f7808b21d88503d04e52e61f86" id="infopanel-for-522431f7808b21d88503d04e52e61f86">
    <span id="infopaneltitle-for-522431f7808b21d88503d04e52e61f86" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-4/#propdef-display">https://drafts.csswg.org/css-display-4/#propdef-display</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-display">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-propdef-display①">(2)</a>
+    <li><a href="#ref-for-propdef-display">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-propdef-display①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-254ee5b37c3db69231dd9123f1a7e46d" class="dfn-panel" data-for="254ee5b37c3db69231dd9123f1a7e46d" id="infopanel-for-254ee5b37c3db69231dd9123f1a7e46d">
    <span id="infopaneltitle-for-254ee5b37c3db69231dd9123f1a7e46d" style="display:none">Info about the 'flow-root' external reference.</span><a href="https://drafts.csswg.org/css-display-4/#valdef-display-flow-root">https://drafts.csswg.org/css-display-4/#valdef-display-flow-root</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-display-flow-root">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-valdef-display-flow-root">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-52abd6169b5c1ec7799450a6e984bbcd" class="dfn-panel" data-for="52abd6169b5c1ec7799450a6e984bbcd" id="infopanel-for-52abd6169b5c1ec7799450a6e984bbcd">
    <span id="infopaneltitle-for-52abd6169b5c1ec7799450a6e984bbcd" style="display:none">Info about the 'list-item' external reference.</span><a href="https://drafts.csswg.org/css-display-4/#valdef-display-list-item">https://drafts.csswg.org/css-display-4/#valdef-display-list-item</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-display-list-item">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-valdef-display-list-item">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-ed84484b5357103410a6b9a8c395c581" class="dfn-panel" data-for="ed84484b5357103410a6b9a8c395c581" id="infopanel-for-ed84484b5357103410a6b9a8c395c581">
    <span id="infopaneltitle-for-ed84484b5357103410a6b9a8c395c581" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-4/#valdef-display-none">https://drafts.csswg.org/css-display-4/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-display-none">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-valdef-display-none">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-24a24da5995b85864d9ba2a5723717c2" class="dfn-panel" data-for="24a24da5995b85864d9ba2a5723717c2" id="infopanel-for-24a24da5995b85864d9ba2a5723717c2">
    <span id="infopaneltitle-for-24a24da5995b85864d9ba2a5723717c2" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css-display-4/#valdef-display-table">https://drafts.csswg.org/css-display-4/#valdef-display-table</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-display-table">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-valdef-display-table">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-66c7cac658bb54d45bb26c155a86ba15" class="dfn-panel" data-for="66c7cac658bb54d45bb26c155a86ba15" id="infopanel-for-66c7cac658bb54d45bb26c155a86ba15">
    <span id="infopaneltitle-for-66c7cac658bb54d45bb26c155a86ba15" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-4/#propdef-visibility">https://drafts.csswg.org/css-display-4/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-propdef-visibility">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-propdef-visibility">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-64b773084479966b88900296ed9bbc3d" class="dfn-panel" data-for="64b773084479966b88900296ed9bbc3d" id="infopanel-for-64b773084479966b88900296ed9bbc3d">
    <span id="infopaneltitle-for-64b773084479966b88900296ed9bbc3d" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-display-4/#valdef-visibility-visible">https://drafts.csswg.org/css-display-4/#valdef-visibility-visible</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-valdef-visibility-visible">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-valdef-visibility-visible">3.6.1. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-791f17d32821aad088ae925e0f0b13c5" class="dfn-panel" data-for="791f17d32821aad088ae925e0f0b13c5" id="infopanel-for-791f17d32821aad088ae925e0f0b13c5">
+   <span id="infopaneltitle-for-791f17d32821aad088ae925e0f0b13c5" style="display:none">Info about the 'scroll a target into view' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#scroll-a-target-into-view">https://drafts.csswg.org/cssom-view-1/#scroll-a-target-into-view</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-scroll-a-target-into-view">3.4.1. Invoking Text Directives</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-07886e33695d0e7b473ef18f656ad7ac" class="dfn-panel" data-for="07886e33695d0e7b473ef18f656ad7ac" id="infopanel-for-07886e33695d0e7b473ef18f656ad7ac">
    <span id="infopaneltitle-for-07886e33695d0e7b473ef18f656ad7ac" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document">3.8. Feature Detectability</a> <a href="#ref-for-document①">(2)</a>
+    <li><a href="#ref-for-document">3.9. Feature Detectability</a> <a href="#ref-for-document①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-106b91ce1ac7f01d4824f5509c502039" class="dfn-panel" data-for="106b91ce1ac7f01d4824f5509c502039" id="infopanel-for-106b91ce1ac7f01d4824f5509c502039">
    <span id="infopaneltitle-for-106b91ce1ac7f01d4824f5509c502039" style="display:none">Info about the 'Text' external reference.</span><a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-text">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-text①">(2)</a> <a href="#ref-for-text②">(3)</a> <a href="#ref-for-text③">(4)</a> <a href="#ref-for-text④">(5)</a> <a href="#ref-for-text⑤">(6)</a>
+    <li><a href="#ref-for-text">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-text①">(2)</a> <a href="#ref-for-text②">(3)</a> <a href="#ref-for-text③">(4)</a> <a href="#ref-for-text④">(5)</a> <a href="#ref-for-text⑤">(6)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-edf5142dd2b5d2a009c400649821eddd" class="dfn-panel" data-for="edf5142dd2b5d2a009c400649821eddd" id="infopanel-for-edf5142dd2b5d2a009c400649821eddd">
    <span id="infopaneltitle-for-edf5142dd2b5d2a009c400649821eddd" style="display:none">Info about the 'after' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-bp-after">https://dom.spec.whatwg.org/#concept-range-bp-after</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range-bp-after">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-bp-after①">(2)</a> <a href="#ref-for-concept-range-bp-after②">(3)</a>
+    <li><a href="#ref-for-concept-range-bp-after">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-bp-after①">(2)</a> <a href="#ref-for-concept-range-bp-after②">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-9d2e985ff01578d3c485962a6bbd0845" class="dfn-panel" data-for="9d2e985ff01578d3c485962a6bbd0845" id="infopanel-for-9d2e985ff01578d3c485962a6bbd0845">
    <span id="infopaneltitle-for-9d2e985ff01578d3c485962a6bbd0845" style="display:none">Info about the 'boundary point' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-bp">https://dom.spec.whatwg.org/#concept-range-bp</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range-bp">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-bp①">(2)</a> <a href="#ref-for-concept-range-bp②">(3)</a> <a href="#ref-for-concept-range-bp③">(4)</a> <a href="#ref-for-concept-range-bp④">(5)</a> <a href="#ref-for-concept-range-bp⑤">(6)</a> <a href="#ref-for-concept-range-bp⑥">(7)</a> <a href="#ref-for-concept-range-bp⑦">(8)</a> <a href="#ref-for-concept-range-bp⑧">(9)</a>
+    <li><a href="#ref-for-concept-range-bp">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-bp①">(2)</a> <a href="#ref-for-concept-range-bp②">(3)</a> <a href="#ref-for-concept-range-bp③">(4)</a> <a href="#ref-for-concept-range-bp④">(5)</a> <a href="#ref-for-concept-range-bp⑤">(6)</a> <a href="#ref-for-concept-range-bp⑥">(7)</a> <a href="#ref-for-concept-range-bp⑦">(8)</a> <a href="#ref-for-concept-range-bp⑧">(9)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-ed282e7847345f30e78230f14fdb52ff" class="dfn-panel" data-for="ed282e7847345f30e78230f14fdb52ff" id="infopanel-for-ed282e7847345f30e78230f14fdb52ff">
    <span id="infopaneltitle-for-ed282e7847345f30e78230f14fdb52ff" style="display:none">Info about the 'collapsed' external reference.</span><a href="https://dom.spec.whatwg.org/#range-collapsed">https://dom.spec.whatwg.org/#range-collapsed</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-range-collapsed">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-range-collapsed①">(2)</a> <a href="#ref-for-range-collapsed②">(3)</a> <a href="#ref-for-range-collapsed③">(4)</a> <a href="#ref-for-range-collapsed④">(5)</a> <a href="#ref-for-range-collapsed⑤">(6)</a>
+    <li><a href="#ref-for-range-collapsed">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-range-collapsed①">(2)</a> <a href="#ref-for-range-collapsed②">(3)</a> <a href="#ref-for-range-collapsed③">(4)</a> <a href="#ref-for-range-collapsed④">(5)</a> <a href="#ref-for-range-collapsed⑤">(6)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-f2efda2d3d7a172500570045686d8285" class="dfn-panel" data-for="f2efda2d3d7a172500570045686d8285" id="infopanel-for-f2efda2d3d7a172500570045686d8285">
    <span id="infopaneltitle-for-f2efda2d3d7a172500570045686d8285" style="display:none">Info about the 'data' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-cd-data">https://dom.spec.whatwg.org/#concept-cd-data</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-cd-data">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-data①">(2)</a> <a href="#ref-for-concept-cd-data②">(3)</a>
+    <li><a href="#ref-for-concept-cd-data">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-data①">(2)</a> <a href="#ref-for-concept-cd-data②">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-76c65f143cb419c0fa5636eb9ad3f070" class="dfn-panel" data-for="76c65f143cb419c0fa5636eb9ad3f070" id="infopanel-for-76c65f143cb419c0fa5636eb9ad3f070">
    <span id="infopaneltitle-for-76c65f143cb419c0fa5636eb9ad3f070" style="display:none">Info about the 'doctype' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-doctype">https://dom.spec.whatwg.org/#concept-doctype</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-doctype">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-concept-doctype">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-985c42e2af63b3e74bd3b70d55668fd4" class="dfn-panel" data-for="985c42e2af63b3e74bd3b70d55668fd4" id="infopanel-for-985c42e2af63b3e74bd3b70d55668fd4">
    <span id="infopaneltitle-for-985c42e2af63b3e74bd3b70d55668fd4" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document">3.4.3. Search Timing</a>
-    <li><a href="#ref-for-concept-document①">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a> <a href="#ref-for-concept-document④">(4)</a> <a href="#ref-for-concept-document⑤">(5)</a> <a href="#ref-for-concept-document⑥">(6)</a>
-    <li><a href="#ref-for-concept-document⑦">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-concept-document⑧">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-document⑨">(2)</a>
-    <li><a href="#ref-for-concept-document①⓪">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①①">(2)</a>
+    <li><a href="#ref-for-concept-document">3.3.2. Applying directives to a document</a>
+    <li><a href="#ref-for-concept-document①">3.5.3. Search Timing</a>
+    <li><a href="#ref-for-concept-document②">3.5.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document③">(2)</a> <a href="#ref-for-concept-document④">(3)</a> <a href="#ref-for-concept-document⑤">(4)</a> <a href="#ref-for-concept-document⑥">(5)</a> <a href="#ref-for-concept-document⑦">(6)</a>
+    <li><a href="#ref-for-concept-document⑧">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-document⑨">(2)</a>
+    <li><a href="#ref-for-concept-document①⓪">3.8. Document Policy Integration</a> <a href="#ref-for-concept-document①①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-6780f5129791c577e5710641ce0e787a" class="dfn-panel" data-for="6780f5129791c577e5710641ce0e787a" id="infopanel-for-6780f5129791c577e5710641ce0e787a">
    <span id="infopaneltitle-for-6780f5129791c577e5710641ce0e787a" style="display:none">Info about the 'document element' external reference.</span><a href="https://dom.spec.whatwg.org/#document-element">https://dom.spec.whatwg.org/#document-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-element">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-document-element">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-0e9d2b68d8d34152d128b48f1a821cc6" class="dfn-panel" data-for="0e9d2b68d8d34152d128b48f1a821cc6" id="infopanel-for-0e9d2b68d8d34152d128b48f1a821cc6">
    <span id="infopaneltitle-for-0e9d2b68d8d34152d128b48f1a821cc6" style="display:none">Info about the 'element' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-element">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-element①">(2)</a> <a href="#ref-for-concept-element②">(3)</a>
-    <li><a href="#ref-for-concept-element③">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-element④">(2)</a>
+    <li><a href="#ref-for-concept-element">3.4.1. Invoking Text Directives</a> <a href="#ref-for-concept-element①">(2)</a>
+    <li><a href="#ref-for-concept-element②">3.6. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-element③">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-element④">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-3eaf36df88595e1b1fb545bb425dbfff" class="dfn-panel" data-for="3eaf36df88595e1b1fb545bb425dbfff" id="infopanel-for-3eaf36df88595e1b1fb545bb425dbfff">
    <span id="infopaneltitle-for-3eaf36df88595e1b1fb545bb425dbfff" style="display:none">Info about the 'end' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-end">https://dom.spec.whatwg.org/#concept-range-end</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range-end">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-concept-range-end①">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end②">(2)</a> <a href="#ref-for-concept-range-end③">(3)</a> <a href="#ref-for-concept-range-end④">(4)</a> <a href="#ref-for-concept-range-end⑤">(5)</a> <a href="#ref-for-concept-range-end⑥">(6)</a> <a href="#ref-for-concept-range-end⑦">(7)</a> <a href="#ref-for-concept-range-end⑧">(8)</a> <a href="#ref-for-concept-range-end⑨">(9)</a> <a href="#ref-for-concept-range-end①⓪">(10)</a> <a href="#ref-for-concept-range-end①①">(11)</a> <a href="#ref-for-concept-range-end①②">(12)</a> <a href="#ref-for-concept-range-end①③">(13)</a> <a href="#ref-for-concept-range-end①④">(14)</a> <a href="#ref-for-concept-range-end①⑤">(15)</a> <a href="#ref-for-concept-range-end①⑥">(16)</a>
+    <li><a href="#ref-for-concept-range-end">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end①">(2)</a> <a href="#ref-for-concept-range-end②">(3)</a> <a href="#ref-for-concept-range-end③">(4)</a> <a href="#ref-for-concept-range-end④">(5)</a> <a href="#ref-for-concept-range-end⑤">(6)</a> <a href="#ref-for-concept-range-end⑥">(7)</a> <a href="#ref-for-concept-range-end⑦">(8)</a> <a href="#ref-for-concept-range-end⑧">(9)</a> <a href="#ref-for-concept-range-end⑨">(10)</a> <a href="#ref-for-concept-range-end①⓪">(11)</a> <a href="#ref-for-concept-range-end①①">(12)</a> <a href="#ref-for-concept-range-end①②">(13)</a> <a href="#ref-for-concept-range-end①③">(14)</a> <a href="#ref-for-concept-range-end①④">(15)</a> <a href="#ref-for-concept-range-end①⑤">(16)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-3595088e5123f2838b7b6a27b98fd0a5" class="dfn-panel" data-for="3595088e5123f2838b7b6a27b98fd0a5" id="infopanel-for-3595088e5123f2838b7b6a27b98fd0a5">
    <span id="infopaneltitle-for-3595088e5123f2838b7b6a27b98fd0a5" style="display:none">Info about the 'end node' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-end-node">https://dom.spec.whatwg.org/#concept-range-end-node</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range-end-node">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-concept-range-end-node①">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end-node②">(2)</a>
+    <li><a href="#ref-for-concept-range-end-node">3.4.1. Invoking Text Directives</a>
+    <li><a href="#ref-for-concept-range-end-node①">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end-node②">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-d196280e8309de02330b386f7b7f41d5" class="dfn-panel" data-for="d196280e8309de02330b386f7b7f41d5" id="infopanel-for-d196280e8309de02330b386f7b7f41d5">
    <span id="infopaneltitle-for-d196280e8309de02330b386f7b7f41d5" style="display:none">Info about the 'end offset' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-end-offset">https://dom.spec.whatwg.org/#concept-range-end-offset</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range-end-offset">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-concept-range-end-offset">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-42520ea878e2f46d9f9a0b2c695dd7ed" class="dfn-panel" data-for="42520ea878e2f46d9f9a0b2c695dd7ed" id="infopanel-for-42520ea878e2f46d9f9a0b2c695dd7ed">
    <span id="infopaneltitle-for-42520ea878e2f46d9f9a0b2c695dd7ed" style="display:none">Info about the 'following' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-following">https://dom.spec.whatwg.org/#concept-tree-following</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-tree-following">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-concept-tree-following">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-336f9dec7e7e3f85d4ed32b3ca6ad4d4" class="dfn-panel" data-for="336f9dec7e7e3f85d4ed32b3ca6ad4d4" id="infopanel-for-336f9dec7e7e3f85d4ed32b3ca6ad4d4">
    <span id="infopaneltitle-for-336f9dec7e7e3f85d4ed32b3ca6ad4d4" style="display:none">Info about the 'host' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-documentfragment-host">3.5. Navigating to a Text Fragment</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-7f09c44566c0c49d2cb28c4878acf2ab" class="dfn-panel" data-for="7f09c44566c0c49d2cb28c4878acf2ab" id="infopanel-for-7f09c44566c0c49d2cb28c4878acf2ab">
-   <span id="infopaneltitle-for-7f09c44566c0c49d2cb28c4878acf2ab" style="display:none">Info about the 'html document' external reference.</span><a href="https://dom.spec.whatwg.org/#html-document">https://dom.spec.whatwg.org/#html-document</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-html-document">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-documentfragment-host">3.6. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-db19c0d2ac621c4f4f2ff03911d64150" class="dfn-panel" data-for="db19c0d2ac621c4f4f2ff03911d64150" id="infopanel-for-db19c0d2ac621c4f4f2ff03911d64150">
    <span id="infopaneltitle-for-db19c0d2ac621c4f4f2ff03911d64150" style="display:none">Info about the 'length' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-length">https://dom.spec.whatwg.org/#concept-node-length</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-node-length">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-concept-node-length①">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-node-length②">(2)</a> <a href="#ref-for-concept-node-length③">(3)</a> <a href="#ref-for-concept-node-length④">(4)</a> <a href="#ref-for-concept-node-length⑤">(5)</a>
+    <li><a href="#ref-for-concept-node-length">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-node-length①">(2)</a> <a href="#ref-for-concept-node-length②">(3)</a> <a href="#ref-for-concept-node-length③">(4)</a> <a href="#ref-for-concept-node-length④">(5)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-f89bf81e89d1487d0236c9740d7f7b85" class="dfn-panel" data-for="f89bf81e89d1487d0236c9740d7f7b85" id="infopanel-for-f89bf81e89d1487d0236c9740d7f7b85">
    <span id="infopaneltitle-for-f89bf81e89d1487d0236c9740d7f7b85" style="display:none">Info about the 'node' external reference.</span><a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-boundary-point-node">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-boundary-point-node①">(2)</a>
+    <li><a href="#ref-for-boundary-point-node">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-boundary-point-node①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-e374c2a979dc7a73f7d03be0623d67e6" class="dfn-panel" data-for="e374c2a979dc7a73f7d03be0623d67e6" id="infopanel-for-e374c2a979dc7a73f7d03be0623d67e6">
    <span id="infopaneltitle-for-e374c2a979dc7a73f7d03be0623d67e6" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-node-document">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-concept-node-document">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-bcfb3881f3a3ab6a912b4e9343723961" class="dfn-panel" data-for="bcfb3881f3a3ab6a912b4e9343723961" id="infopanel-for-bcfb3881f3a3ab6a912b4e9343723961">
    <span id="infopaneltitle-for-bcfb3881f3a3ab6a912b4e9343723961" style="display:none">Info about the 'parent' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-parent">https://dom.spec.whatwg.org/#concept-tree-parent</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-tree-parent">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-tree-parent①">(2)</a>
-    <li><a href="#ref-for-concept-tree-parent②">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-concept-tree-parent">3.4.1. Invoking Text Directives</a>
+    <li><a href="#ref-for-concept-tree-parent①">3.6. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-tree-parent②">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-e2bf2f94dbcb51e9619badf334cedd2f" class="dfn-panel" data-for="e2bf2f94dbcb51e9619badf334cedd2f" id="infopanel-for-e2bf2f94dbcb51e9619badf334cedd2f">
    <span id="infopaneltitle-for-e2bf2f94dbcb51e9619badf334cedd2f" style="display:none">Info about the 'parent element' external reference.</span><a href="https://dom.spec.whatwg.org/#parent-element">https://dom.spec.whatwg.org/#parent-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parent-element">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-parent-element">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-d32c450d88a0eb615ada385939371cf2" class="dfn-panel" data-for="d32c450d88a0eb615ada385939371cf2" id="infopanel-for-d32c450d88a0eb615ada385939371cf2">
    <span id="infopaneltitle-for-d32c450d88a0eb615ada385939371cf2" style="display:none">Info about the 'range' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range">https://dom.spec.whatwg.org/#concept-range</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-range①">(2)</a> <a href="#ref-for-concept-range②">(3)</a> <a href="#ref-for-concept-range③">(4)</a> <a href="#ref-for-concept-range④">(5)</a> <a href="#ref-for-concept-range⑤">(6)</a> <a href="#ref-for-concept-range⑥">(7)</a> <a href="#ref-for-concept-range⑦">(8)</a> <a href="#ref-for-concept-range⑧">(9)</a>
-    <li><a href="#ref-for-concept-range⑨">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range①⓪">(2)</a> <a href="#ref-for-concept-range①①">(3)</a> <a href="#ref-for-concept-range①②">(4)</a> <a href="#ref-for-concept-range①③">(5)</a> <a href="#ref-for-concept-range①④">(6)</a> <a href="#ref-for-concept-range①⑤">(7)</a> <a href="#ref-for-concept-range①⑥">(8)</a> <a href="#ref-for-concept-range①⑦">(9)</a> <a href="#ref-for-concept-range①⑧">(10)</a> <a href="#ref-for-concept-range①⑨">(11)</a> <a href="#ref-for-concept-range②⓪">(12)</a> <a href="#ref-for-concept-range②①">(13)</a> <a href="#ref-for-concept-range②②">(14)</a> <a href="#ref-for-concept-range②③">(15)</a> <a href="#ref-for-concept-range②④">(16)</a> <a href="#ref-for-concept-range②⑤">(17)</a> <a href="#ref-for-concept-range②⑥">(18)</a> <a href="#ref-for-concept-range②⑦">(19)</a>
+    <li><a href="#ref-for-concept-range">3.4.1. Invoking Text Directives</a> <a href="#ref-for-concept-range①">(2)</a> <a href="#ref-for-concept-range②">(3)</a> <a href="#ref-for-concept-range③">(4)</a> <a href="#ref-for-concept-range④">(5)</a> <a href="#ref-for-concept-range⑤">(6)</a> <a href="#ref-for-concept-range⑥">(7)</a> <a href="#ref-for-concept-range⑦">(8)</a>
+    <li><a href="#ref-for-concept-range⑧">3.6. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-range⑨">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range①⓪">(2)</a> <a href="#ref-for-concept-range①①">(3)</a> <a href="#ref-for-concept-range①②">(4)</a> <a href="#ref-for-concept-range①③">(5)</a> <a href="#ref-for-concept-range①④">(6)</a> <a href="#ref-for-concept-range①⑤">(7)</a> <a href="#ref-for-concept-range①⑥">(8)</a> <a href="#ref-for-concept-range①⑦">(9)</a> <a href="#ref-for-concept-range①⑧">(10)</a> <a href="#ref-for-concept-range①⑨">(11)</a> <a href="#ref-for-concept-range②⓪">(12)</a> <a href="#ref-for-concept-range②①">(13)</a> <a href="#ref-for-concept-range②②">(14)</a> <a href="#ref-for-concept-range②③">(15)</a> <a href="#ref-for-concept-range②④">(16)</a> <a href="#ref-for-concept-range②⑤">(17)</a> <a href="#ref-for-concept-range②⑥">(18)</a> <a href="#ref-for-concept-range②⑦">(19)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-a0776d2c12f01e4264ed344ff747bce1" class="dfn-panel" data-for="a0776d2c12f01e4264ed344ff747bce1" id="infopanel-for-a0776d2c12f01e4264ed344ff747bce1">
    <span id="infopaneltitle-for-a0776d2c12f01e4264ed344ff747bce1" style="display:none">Info about the 'shadow root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-shadow-root">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-shadow-root">3.6. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-6cf8d76260ca17ac744213dd88df7467" class="dfn-panel" data-for="6cf8d76260ca17ac744213dd88df7467" id="infopanel-for-6cf8d76260ca17ac744213dd88df7467">
    <span id="infopaneltitle-for-6cf8d76260ca17ac744213dd88df7467" style="display:none">Info about the 'shadow-including ancestor' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-ancestor</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-shadow-including-ancestor">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-concept-shadow-including-ancestor">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-6cbf20ec6ae658e3dfeb68963b6b3d19" class="dfn-panel" data-for="6cbf20ec6ae658e3dfeb68963b6b3d19" id="infopanel-for-6cbf20ec6ae658e3dfeb68963b6b3d19">
    <span id="infopaneltitle-for-6cbf20ec6ae658e3dfeb68963b6b3d19" style="display:none">Info about the 'shadow-including descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-descendant</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-shadow-including-descendant">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-shadow-including-descendant①">(2)</a> <a href="#ref-for-concept-shadow-including-descendant②">(3)</a>
+    <li><a href="#ref-for-concept-shadow-including-descendant">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-shadow-including-descendant①">(2)</a> <a href="#ref-for-concept-shadow-including-descendant②">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-7049f0f7045691b6d0511a167ad33988" class="dfn-panel" data-for="7049f0f7045691b6d0511a167ad33988" id="infopanel-for-7049f0f7045691b6d0511a167ad33988">
    <span id="infopaneltitle-for-7049f0f7045691b6d0511a167ad33988" style="display:none">Info about the 'shadow-including inclusive ancestor' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-shadow-including-inclusive-ancestor">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-shadow-including-inclusive-ancestor">3.6. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-529584996f402e6737c1f987fc0e4f74" class="dfn-panel" data-for="529584996f402e6737c1f987fc0e4f74" id="infopanel-for-529584996f402e6737c1f987fc0e4f74">
    <span id="infopaneltitle-for-529584996f402e6737c1f987fc0e4f74" style="display:none">Info about the 'shadow-including tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-shadow-including-tree-order">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-shadow-including-tree-order①">(2)</a> <a href="#ref-for-concept-shadow-including-tree-order②">(3)</a> <a href="#ref-for-concept-shadow-including-tree-order③">(4)</a> <a href="#ref-for-concept-shadow-including-tree-order④">(5)</a>
+    <li><a href="#ref-for-concept-shadow-including-tree-order">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-shadow-including-tree-order①">(2)</a> <a href="#ref-for-concept-shadow-including-tree-order②">(3)</a> <a href="#ref-for-concept-shadow-including-tree-order③">(4)</a> <a href="#ref-for-concept-shadow-including-tree-order④">(5)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-f993e7a5a63693dc8df0d0ec9979bee1" class="dfn-panel" data-for="f993e7a5a63693dc8df0d0ec9979bee1" id="infopanel-for-f993e7a5a63693dc8df0d0ec9979bee1">
    <span id="infopaneltitle-for-f993e7a5a63693dc8df0d0ec9979bee1" style="display:none">Info about the 'start' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-start">https://dom.spec.whatwg.org/#concept-range-start</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range-start">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-concept-range-start①">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start②">(2)</a> <a href="#ref-for-concept-range-start③">(3)</a> <a href="#ref-for-concept-range-start④">(4)</a> <a href="#ref-for-concept-range-start⑤">(5)</a> <a href="#ref-for-concept-range-start⑥">(6)</a> <a href="#ref-for-concept-range-start⑦">(7)</a> <a href="#ref-for-concept-range-start⑧">(8)</a> <a href="#ref-for-concept-range-start⑨">(9)</a> <a href="#ref-for-concept-range-start①⓪">(10)</a> <a href="#ref-for-concept-range-start①①">(11)</a> <a href="#ref-for-concept-range-start①②">(12)</a> <a href="#ref-for-concept-range-start①③">(13)</a> <a href="#ref-for-concept-range-start①④">(14)</a> <a href="#ref-for-concept-range-start①⑤">(15)</a> <a href="#ref-for-concept-range-start①⑥">(16)</a> <a href="#ref-for-concept-range-start①⑦">(17)</a> <a href="#ref-for-concept-range-start①⑧">(18)</a> <a href="#ref-for-concept-range-start①⑨">(19)</a>
+    <li><a href="#ref-for-concept-range-start">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start①">(2)</a> <a href="#ref-for-concept-range-start②">(3)</a> <a href="#ref-for-concept-range-start③">(4)</a> <a href="#ref-for-concept-range-start④">(5)</a> <a href="#ref-for-concept-range-start⑤">(6)</a> <a href="#ref-for-concept-range-start⑥">(7)</a> <a href="#ref-for-concept-range-start⑦">(8)</a> <a href="#ref-for-concept-range-start⑧">(9)</a> <a href="#ref-for-concept-range-start⑨">(10)</a> <a href="#ref-for-concept-range-start①⓪">(11)</a> <a href="#ref-for-concept-range-start①①">(12)</a> <a href="#ref-for-concept-range-start①②">(13)</a> <a href="#ref-for-concept-range-start①③">(14)</a> <a href="#ref-for-concept-range-start①④">(15)</a> <a href="#ref-for-concept-range-start①⑤">(16)</a> <a href="#ref-for-concept-range-start①⑥">(17)</a> <a href="#ref-for-concept-range-start①⑦">(18)</a> <a href="#ref-for-concept-range-start①⑧">(19)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-8c242aed29c9bcebb4c9c109c420c838" class="dfn-panel" data-for="8c242aed29c9bcebb4c9c109c420c838" id="infopanel-for-8c242aed29c9bcebb4c9c109c420c838">
    <span id="infopaneltitle-for-8c242aed29c9bcebb4c9c109c420c838" style="display:none">Info about the 'start node' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-start-node">https://dom.spec.whatwg.org/#concept-range-start-node</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range-start-node">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-range-start-node①">(2)</a>
-    <li><a href="#ref-for-concept-range-start-node②">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start-node③">(2)</a> <a href="#ref-for-concept-range-start-node④">(3)</a> <a href="#ref-for-concept-range-start-node⑤">(4)</a> <a href="#ref-for-concept-range-start-node⑥">(5)</a> <a href="#ref-for-concept-range-start-node⑦">(6)</a> <a href="#ref-for-concept-range-start-node⑧">(7)</a> <a href="#ref-for-concept-range-start-node⑨">(8)</a>
+    <li><a href="#ref-for-concept-range-start-node">3.4.1. Invoking Text Directives</a>
+    <li><a href="#ref-for-concept-range-start-node①">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start-node②">(2)</a> <a href="#ref-for-concept-range-start-node③">(3)</a> <a href="#ref-for-concept-range-start-node④">(4)</a> <a href="#ref-for-concept-range-start-node⑤">(5)</a> <a href="#ref-for-concept-range-start-node⑥">(6)</a> <a href="#ref-for-concept-range-start-node⑦">(7)</a> <a href="#ref-for-concept-range-start-node⑧">(8)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-19e2b479bf922057a37590c166b0e4d8" class="dfn-panel" data-for="19e2b479bf922057a37590c166b0e4d8" id="infopanel-for-19e2b479bf922057a37590c166b0e4d8">
    <span id="infopaneltitle-for-19e2b479bf922057a37590c166b0e4d8" style="display:none">Info about the 'start offset' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-start-offset">https://dom.spec.whatwg.org/#concept-range-start-offset</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-range-start-offset">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start-offset①">(2)</a> <a href="#ref-for-concept-range-start-offset②">(3)</a> <a href="#ref-for-concept-range-start-offset③">(4)</a> <a href="#ref-for-concept-range-start-offset④">(5)</a> <a href="#ref-for-concept-range-start-offset⑤">(6)</a> <a href="#ref-for-concept-range-start-offset⑥">(7)</a> <a href="#ref-for-concept-range-start-offset⑦">(8)</a>
+    <li><a href="#ref-for-concept-range-start-offset">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start-offset①">(2)</a> <a href="#ref-for-concept-range-start-offset②">(3)</a> <a href="#ref-for-concept-range-start-offset③">(4)</a> <a href="#ref-for-concept-range-start-offset④">(5)</a> <a href="#ref-for-concept-range-start-offset⑤">(6)</a> <a href="#ref-for-concept-range-start-offset⑥">(7)</a> <a href="#ref-for-concept-range-start-offset⑦">(8)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-550461d883f8ee59a2caa514ddd21a53" class="dfn-panel" data-for="550461d883f8ee59a2caa514ddd21a53" id="infopanel-for-550461d883f8ee59a2caa514ddd21a53">
    <span id="infopaneltitle-for-550461d883f8ee59a2caa514ddd21a53" style="display:none">Info about the 'substring data' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-cd-substring">https://dom.spec.whatwg.org/#concept-cd-substring</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-cd-substring">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-substring①">(2)</a>
+    <li><a href="#ref-for-concept-cd-substring">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-substring①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-2fc74f43c6d7f15a4a2fbfbece346388" class="dfn-panel" data-for="2fc74f43c6d7f15a4a2fbfbece346388" id="infopanel-for-2fc74f43c6d7f15a4a2fbfbece346388">
    <span id="infopaneltitle-for-2fc74f43c6d7f15a4a2fbfbece346388" style="display:none">Info about the 'url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document-url">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-concept-document-url">3.3.1. Extracting the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-491791562dd138987138e7051a96c07c" class="dfn-panel" data-for="491791562dd138987138e7051a96c07c" id="infopanel-for-491791562dd138987138e7051a96c07c">
    <span id="infopaneltitle-for-491791562dd138987138e7051a96c07c" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-request">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a> <a href="#ref-for-concept-request③">(4)</a>
+    <li><a href="#ref-for-concept-request">3.5.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a> <a href="#ref-for-concept-request③">(4)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-676cde839e3bd2930dd87545de24bb1a" class="dfn-panel" data-for="676cde839e3bd2930dd87545de24bb1a" id="infopanel-for-676cde839e3bd2930dd87545de24bb1a">
    <span id="infopaneltitle-for-676cde839e3bd2930dd87545de24bb1a" style="display:none">Info about the 'user-activation' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-user-activation">https://fetch.spec.whatwg.org/#request-user-activation</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-user-activation">3.4.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-request-user-activation">3.5.4. Restricting the Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-d86264b91becec76f76c64bd87d6ee8d" class="dfn-panel" data-for="d86264b91becec76f76c64bd87d6ee8d" id="infopanel-for-d86264b91becec76f76c64bd87d6ee8d">
    <span id="infopaneltitle-for-d86264b91becec76f76c64bd87d6ee8d" style="display:none">Info about the 'HTMLAudioElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement">https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlaudioelement">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-htmlaudioelement">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-75ff12c16ae1a8f6cbf2920128280261" class="dfn-panel" data-for="75ff12c16ae1a8f6cbf2920128280261" id="infopanel-for-75ff12c16ae1a8f6cbf2920128280261">
    <span id="infopaneltitle-for-75ff12c16ae1a8f6cbf2920128280261" style="display:none">Info about the 'HTMLIFrameElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmliframeelement">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-htmliframeelement">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-8bd1567bfeee6a7f042b4739599829fd" class="dfn-panel" data-for="8bd1567bfeee6a7f042b4739599829fd" id="infopanel-for-8bd1567bfeee6a7f042b4739599829fd">
    <span id="infopaneltitle-for-8bd1567bfeee6a7f042b4739599829fd" style="display:none">Info about the 'HTMLImageElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlimageelement">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-htmlimageelement">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-239ce47ea8ddbfe7c0404c23d1c5876c" class="dfn-panel" data-for="239ce47ea8ddbfe7c0404c23d1c5876c" id="infopanel-for-239ce47ea8ddbfe7c0404c23d1c5876c">
    <span id="infopaneltitle-for-239ce47ea8ddbfe7c0404c23d1c5876c" style="display:none">Info about the 'HTMLMeterElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlmeterelement">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-htmlmeterelement">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-07819f370163076e23d268f7ec2b9056" class="dfn-panel" data-for="07819f370163076e23d268f7ec2b9056" id="infopanel-for-07819f370163076e23d268f7ec2b9056">
    <span id="infopaneltitle-for-07819f370163076e23d268f7ec2b9056" style="display:none">Info about the 'HTMLObjectElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlobjectelement">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-htmlobjectelement">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-a08e22107da0c99822a74cf7ff2a29cc" class="dfn-panel" data-for="a08e22107da0c99822a74cf7ff2a29cc" id="infopanel-for-a08e22107da0c99822a74cf7ff2a29cc">
    <span id="infopaneltitle-for-a08e22107da0c99822a74cf7ff2a29cc" style="display:none">Info about the 'HTMLProgressElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlprogresselement">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-htmlprogresselement">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-257c32b9f7676f6cdb079793771ec03b" class="dfn-panel" data-for="257c32b9f7676f6cdb079793771ec03b" id="infopanel-for-257c32b9f7676f6cdb079793771ec03b">
    <span id="infopaneltitle-for-257c32b9f7676f6cdb079793771ec03b" style="display:none">Info about the 'HTMLScriptElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlscriptelement">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-htmlscriptelement">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-004ac07b9e7dd26f7341693e2162496d" class="dfn-panel" data-for="004ac07b9e7dd26f7341693e2162496d" id="infopanel-for-004ac07b9e7dd26f7341693e2162496d">
    <span id="infopaneltitle-for-004ac07b9e7dd26f7341693e2162496d" style="display:none">Info about the 'HTMLStyleElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlstyleelement">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-htmlstyleelement">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-a958269402aae8e8d7d28d3cb6aacc8d" class="dfn-panel" data-for="a958269402aae8e8d7d28d3cb6aacc8d" id="infopanel-for-a958269402aae8e8d7d28d3cb6aacc8d">
    <span id="infopaneltitle-for-a958269402aae8e8d7d28d3cb6aacc8d" style="display:none">Info about the 'HTMLVideoElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-htmlvideoelement">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-htmlvideoelement">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-e57cf03d5231bf211b6e11747eb511a2" class="dfn-panel" data-for="e57cf03d5231bf211b6e11747eb511a2" id="infopanel-for-e57cf03d5231bf211b6e11747eb511a2">
    <span id="infopaneltitle-for-e57cf03d5231bf211b6e11747eb511a2" style="display:none">Info about the 'HashChangeEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent">https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-hashchangeevent">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-hashchangeevent">3.3.1. Extracting the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-4b63022be77634e01931166ef990401a" class="dfn-panel" data-for="4b63022be77634e01931166ef990401a" id="infopanel-for-4b63022be77634e01931166ef990401a">
    <span id="infopaneltitle-for-4b63022be77634e01931166ef990401a" style="display:none">Info about the 'Location' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-location">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-location">3.3.1. Extracting the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-de11cdc07a64c79878f1c3074e81554a" class="dfn-panel" data-for="de11cdc07a64c79878f1c3074e81554a" id="infopanel-for-de11cdc07a64c79878f1c3074e81554a">
    <span id="infopaneltitle-for-de11cdc07a64c79878f1c3074e81554a" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-nav-document">3.3.1. Processing the fragment directive</a>
-    <li><a href="#ref-for-nav-document①">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-nav-document②">(2)</a>
+    <li><a href="#ref-for-nav-document">3.3.1. Extracting the fragment directive</a>
+    <li><a href="#ref-for-nav-document①">3.5.4. Restricting the Text Fragment</a> <a href="#ref-for-nav-document②">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-004498b212013045422acbba8c92f503" class="dfn-panel" data-for="004498b212013045422acbba8c92f503" id="infopanel-for-004498b212013045422acbba8c92f503">
    <span id="infopaneltitle-for-004498b212013045422acbba8c92f503" style="display:none">Info about the 'being rendered' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-being-rendered">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-being-rendered">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-3eaa51ed66e1d8aa0c39a4f1fead29c0" class="dfn-panel" data-for="3eaa51ed66e1d8aa0c39a4f1fead29c0" id="infopanel-for-3eaa51ed66e1d8aa0c39a4f1fead29c0">
    <span id="infopaneltitle-for-3eaa51ed66e1d8aa0c39a4f1fead29c0" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document-bc">3.4.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-concept-document-bc">3.5.4. Restricting the Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-7033f3e77cd84c91db6d5e82613c4d33" class="dfn-panel" data-for="7033f3e77cd84c91db6d5e82613c4d33" id="infopanel-for-7033f3e77cd84c91db6d5e82613c4d33">
    <span id="infopaneltitle-for-7033f3e77cd84c91db6d5e82613c4d33" style="display:none">Info about the 'browsing context set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-browsing-context-set">3.4.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-browsing-context-set">3.5.4. Restricting the Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-726a16249061363ef85fbdad67a6e959" class="dfn-panel" data-for="726a16249061363ef85fbdad67a6e959" id="infopanel-for-726a16249061363ef85fbdad67a6e959">
    <span id="infopaneltitle-for-726a16249061363ef85fbdad67a6e959" style="display:none">Info about the 'language' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-language">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-language①">(2)</a>
+    <li><a href="#ref-for-language">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-language①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-b51df82e894ee794ca3f536db97ad537" class="dfn-panel" data-for="b51df82e894ee794ca3f536db97ad537" id="infopanel-for-b51df82e894ee794ca3f536db97ad537">
    <span id="infopaneltitle-for-b51df82e894ee794ca3f536db97ad537" style="display:none">Info about the 'multiple' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple">https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-attr-select-multiple">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-attr-select-multiple">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-566b28e53fa11b6a6ff3a9d32626c2c5" class="dfn-panel" data-for="566b28e53fa11b6a6ff3a9d32626c2c5" id="infopanel-for-566b28e53fa11b6a6ff3a9d32626c2c5">
    <span id="infopaneltitle-for-566b28e53fa11b6a6ff3a9d32626c2c5" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-navigate">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-navigate">3.3.1. Extracting the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-7369d61835fa8a54aba2f14b16179bb7" class="dfn-panel" data-for="7369d61835fa8a54aba2f14b16179bb7" id="infopanel-for-7369d61835fa8a54aba2f14b16179bb7">
    <span id="infopaneltitle-for-7369d61835fa8a54aba2f14b16179bb7" style="display:none">Info about the 'restore persisted state' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state">https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-restore-persisted-state">3.7. Document Policy Integration</a>
+    <li><a href="#ref-for-restore-persisted-state">3.8. Document Policy Integration</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-0bbe052a00d2d9a1853b94d848e97f83" class="dfn-panel" data-for="0bbe052a00d2d9a1853b94d848e97f83" id="infopanel-for-0bbe052a00d2d9a1853b94d848e97f83">
    <span id="infopaneltitle-for-0bbe052a00d2d9a1853b94d848e97f83" style="display:none">Info about the 'scroll to the fragment' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier">https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-scroll-to-the-fragment-identifier">3.4.4. Restricting the Text Fragment</a>
-    <li><a href="#ref-for-scroll-to-the-fragment-identifier①">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-scroll-to-the-fragment-identifier②">3.7. Document Policy Integration</a>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier">3.4.1. Invoking Text Directives</a> <a href="#ref-for-scroll-to-the-fragment-identifier①">(2)</a>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier②">3.5.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-scroll-to-the-fragment-identifier③">3.8. Document Policy Integration</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-3fff2218abea20e2aebc96a3c4ed942d" class="dfn-panel" data-for="3fff2218abea20e2aebc96a3c4ed942d" id="infopanel-for-3fff2218abea20e2aebc96a3c4ed942d">
    <span id="infopaneltitle-for-3fff2218abea20e2aebc96a3c4ed942d" style="display:none">Info about the 'select' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-the-select-element">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-the-select-element">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-1e2b4e9c3af3712ccb3048eb5e83ae9d" class="dfn-panel" data-for="1e2b4e9c3af3712ccb3048eb5e83ae9d" id="infopanel-for-1e2b4e9c3af3712ccb3048eb5e83ae9d">
    <span id="infopaneltitle-for-1e2b4e9c3af3712ccb3048eb5e83ae9d" style="display:none">Info about the 'serializes as void' external reference.</span><a href="https://html.spec.whatwg.org/multipage/parsing.html#serializes-as-void">https://html.spec.whatwg.org/multipage/parsing.html#serializes-as-void</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-serializes-as-void">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-serializes-as-void">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-c104b697744f6f246969dcc26b898f11" class="dfn-panel" data-for="c104b697744f6f246969dcc26b898f11" id="infopanel-for-c104b697744f6f246969dcc26b898f11">
    <span id="infopaneltitle-for-c104b697744f6f246969dcc26b898f11" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-top-level-browsing-context">3.4.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-top-level-browsing-context">3.5.4. Restricting the Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-5b762d09d78e8674458b84982b3cb3c9" class="dfn-panel" data-for="5b762d09d78e8674458b84982b3cb3c9" id="infopanel-for-5b762d09d78e8674458b84982b3cb3c9">
    <span id="infopaneltitle-for-5b762d09d78e8674458b84982b3cb3c9" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-transient-activation">3.4.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-transient-activation">3.5.4. Restricting the Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-4e67373797cfec56e2dadb5a69ad2ed0" class="dfn-panel" data-for="4e67373797cfec56e2dadb5a69ad2ed0" id="infopanel-for-4e67373797cfec56e2dadb5a69ad2ed0">
    <span id="infopaneltitle-for-4e67373797cfec56e2dadb5a69ad2ed0" style="display:none">Info about the 'try to scroll to the fragment' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-try-to-scroll-to-the-fragment">3.4.4. Restricting the Text Fragment</a>
-    <li><a href="#ref-for-try-to-scroll-to-the-fragment①">3.6. Indicating The Text Match</a>
+    <li><a href="#ref-for-4e67373797cfec56e2dadb5a69ad2ed0">3.4.1. Invoking Text Directives</a>
+    <li><a href="#ref-for-try-to-scroll-to-the-fragment">3.5.4. Restricting the Text Fragment</a>
+    <li><a href="#ref-for-try-to-scroll-to-the-fragment①">3.7. Indicating The Text Match</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-fcfc8b0ed220faa237969aed00e2586d" class="dfn-panel" data-for="fcfc8b0ed220faa237969aed00e2586d" id="infopanel-for-fcfc8b0ed220faa237969aed00e2586d">
    <span id="infopaneltitle-for-fcfc8b0ed220faa237969aed00e2586d" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-append">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-list-append">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-61c7c9c76ff1cedf412e7a18bbe24e2c" class="dfn-panel" data-for="61c7c9c76ff1cedf412e7a18bbe24e2c" id="infopanel-for-61c7c9c76ff1cedf412e7a18bbe24e2c">
    <span id="infopaneltitle-for-61c7c9c76ff1cedf412e7a18bbe24e2c" style="display:none">Info about the 'ascii string' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ascii-string">3.3.2. Parsing the fragment directive</a>
-    <li><a href="#ref-for-ascii-string①">3.3.3. Fragment directive grammar</a>
-    <li><a href="#ref-for-ascii-string②">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-ascii-string③">(2)</a> <a href="#ref-for-ascii-string④">(3)</a>
+    <li><a href="#ref-for-ascii-string">3.3.4. Fragment directive grammar</a>
+    <li><a href="#ref-for-ascii-string①">3.4. Text Directives</a>
+    <li><a href="#ref-for-ascii-string②">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-ascii-string③">(2)</a> <a href="#ref-for-ascii-string④">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-7618b9a6d44febb7e784c8f39faac140" class="dfn-panel" data-for="7618b9a6d44febb7e784c8f39faac140" id="infopanel-for-7618b9a6d44febb7e784c8f39faac140">
    <span id="infopaneltitle-for-7618b9a6d44febb7e784c8f39faac140" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-assert">3.3.2. Parsing the fragment directive</a>
-    <li><a href="#ref-for-assert①">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-assert②">(2)</a> <a href="#ref-for-assert③">(3)</a> <a href="#ref-for-assert④">(4)</a> <a href="#ref-for-assert⑤">(5)</a>
+    <li><a href="#ref-for-assert">3.4. Text Directives</a>
+    <li><a href="#ref-for-assert①">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-assert②">(2)</a> <a href="#ref-for-assert③">(3)</a> <a href="#ref-for-assert④">(4)</a> <a href="#ref-for-assert⑤">(5)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-2889fa868b02a31759864aaf77f851d6" class="dfn-panel" data-for="2889fa868b02a31759864aaf77f851d6" id="infopanel-for-2889fa868b02a31759864aaf77f851d6">
    <span id="infopaneltitle-for-2889fa868b02a31759864aaf77f851d6" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-iteration-break">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-iteration-break①">(2)</a> <a href="#ref-for-iteration-break②">(3)</a> <a href="#ref-for-iteration-break③">(4)</a>
+    <li><a href="#ref-for-iteration-break">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-iteration-break①">(2)</a> <a href="#ref-for-iteration-break②">(3)</a> <a href="#ref-for-iteration-break③">(4)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-4103741029595e9e13c67dab91d1e3bd" class="dfn-panel" data-for="4103741029595e9e13c67dab91d1e3bd" id="infopanel-for-4103741029595e9e13c67dab91d1e3bd">
    <span id="infopaneltitle-for-4103741029595e9e13c67dab91d1e3bd" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-code-point">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-code-point">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-0c5b8810162108ca42f42ac154072480" class="dfn-panel" data-for="0c5b8810162108ca42f42ac154072480" id="infopanel-for-0c5b8810162108ca42f42ac154072480">
    <span id="infopaneltitle-for-0c5b8810162108ca42f42ac154072480" style="display:none">Info about the 'code point length' external reference.</span><a href="https://infra.spec.whatwg.org/#string-code-point-length">https://infra.spec.whatwg.org/#string-code-point-length</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string-code-point-length">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-string-code-point-length">3.3.1. Extracting the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-f0460547da5b011defe7b8f6f359524f" class="dfn-panel" data-for="f0460547da5b011defe7b8f6f359524f" id="infopanel-for-f0460547da5b011defe7b8f6f359524f">
    <span id="infopaneltitle-for-f0460547da5b011defe7b8f6f359524f" style="display:none">Info about the 'code point substring by positions' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point-substring-by-positions">https://infra.spec.whatwg.org/#code-point-substring-by-positions</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-code-point-substring-by-positions">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-code-point-substring-by-positions">3.3.1. Extracting the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-500c3d9147f1a7d23aec5cebaadf9dc5" class="dfn-panel" data-for="500c3d9147f1a7d23aec5cebaadf9dc5" id="infopanel-for-500c3d9147f1a7d23aec5cebaadf9dc5">
    <span id="infopaneltitle-for-500c3d9147f1a7d23aec5cebaadf9dc5" style="display:none">Info about the 'code point substring to the end of the string' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point-substring-to-the-end-of-the-string">https://infra.spec.whatwg.org/#code-point-substring-to-the-end-of-the-string</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-code-point-substring-to-the-end-of-the-string">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-code-point-substring-to-the-end-of-the-string">3.3.1. Extracting the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-7605aa4703a0a6921736ddd5321cfc07" class="dfn-panel" data-for="7605aa4703a0a6921736ddd5321cfc07" id="infopanel-for-7605aa4703a0a6921736ddd5321cfc07">
    <span id="infopaneltitle-for-7605aa4703a0a6921736ddd5321cfc07" style="display:none">Info about the 'concatenate' external reference.</span><a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string-concatenate">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-string-concatenate">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-ce9efec0e74a2cbfe986593eb861ade6" class="dfn-panel" data-for="ce9efec0e74a2cbfe986593eb861ade6" id="infopanel-for-ce9efec0e74a2cbfe986593eb861ade6">
    <span id="infopaneltitle-for-ce9efec0e74a2cbfe986593eb861ade6" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-iteration-continue">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a> <a href="#ref-for-iteration-continue③">(4)</a> <a href="#ref-for-iteration-continue④">(5)</a> <a href="#ref-for-iteration-continue⑤">(6)</a> <a href="#ref-for-iteration-continue⑥">(7)</a>
+    <li><a href="#ref-for-iteration-continue">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a> <a href="#ref-for-iteration-continue③">(4)</a> <a href="#ref-for-iteration-continue④">(5)</a> <a href="#ref-for-iteration-continue⑤">(6)</a> <a href="#ref-for-iteration-continue⑥">(7)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-39deea7d529a23ee9b82b61369f78690" class="dfn-panel" data-for="39deea7d529a23ee9b82b61369f78690" id="infopanel-for-39deea7d529a23ee9b82b61369f78690">
    <span id="infopaneltitle-for-39deea7d529a23ee9b82b61369f78690" style="display:none">Info about the 'html namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-html-namespace">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-html-namespace">3.6.1. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-fd74d8159933c4a74d0b23390bed43e3" class="dfn-panel" data-for="fd74d8159933c4a74d0b23390bed43e3" id="infopanel-for-fd74d8159933c4a74d0b23390bed43e3">
+   <span id="infopaneltitle-for-fd74d8159933c4a74d0b23390bed43e3" style="display:none">Info about the 'implementation-defined' external reference.</span><a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-implementation-defined">3.4.1. Invoking Text Directives</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-81b03c84949641fc3081227509aab38f" class="dfn-panel" data-for="81b03c84949641fc3081227509aab38f" id="infopanel-for-81b03c84949641fc3081227509aab38f">
    <span id="infopaneltitle-for-81b03c84949641fc3081227509aab38f" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string-length">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-string-length①">(2)</a> <a href="#ref-for-string-length②">(3)</a>
+    <li><a href="#ref-for-string-length">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-string-length①">(2)</a> <a href="#ref-for-string-length②">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-fafd38d2108e357bcc9a6fd7f3cd04a7" class="dfn-panel" data-for="fafd38d2108e357bcc9a6fd7f3cd04a7" id="infopanel-for-fafd38d2108e357bcc9a6fd7f3cd04a7">
    <span id="infopaneltitle-for-fafd38d2108e357bcc9a6fd7f3cd04a7" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list">3.3.2. Parsing the fragment directive</a>
-    <li><a href="#ref-for-list①">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-list②">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-list③">(2)</a> <a href="#ref-for-list④">(3)</a> <a href="#ref-for-list⑤">(4)</a> <a href="#ref-for-list⑥">(5)</a> <a href="#ref-for-list⑦">(6)</a> <a href="#ref-for-list⑧">(7)</a> <a href="#ref-for-list⑨">(8)</a>
+    <li><a href="#ref-for-list">3.4. Text Directives</a>
+    <li><a href="#ref-for-list①">3.4.1. Invoking Text Directives</a>
+    <li><a href="#ref-for-list②">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-list③">(2)</a> <a href="#ref-for-list④">(3)</a> <a href="#ref-for-list⑤">(4)</a> <a href="#ref-for-list⑥">(5)</a> <a href="#ref-for-list⑦">(6)</a> <a href="#ref-for-list⑧">(7)</a> <a href="#ref-for-list⑨">(8)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-a261ff0f11f981dec5af7b60f3229916" class="dfn-panel" data-for="a261ff0f11f981dec5af7b60f3229916" id="infopanel-for-a261ff0f11f981dec5af7b60f3229916">
    <span id="infopaneltitle-for-a261ff0f11f981dec5af7b60f3229916" style="display:none">Info about the 'position variable' external reference.</span><a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string-position-variable">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-string-position-variable">3.3.1. Extracting the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-fadc27e826887faf120674544589ae68" class="dfn-panel" data-for="fadc27e826887faf120674544589ae68" id="infopanel-for-fadc27e826887faf120674544589ae68">
    <span id="infopaneltitle-for-fadc27e826887faf120674544589ae68" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-remove">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-list-remove①">(2)</a>
+    <li><a href="#ref-for-list-remove">3.4. Text Directives</a> <a href="#ref-for-list-remove①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-bed8381510f5967f5d37a33de776e857" class="dfn-panel" data-for="bed8381510f5967f5d37a33de776e857" id="infopanel-for-bed8381510f5967f5d37a33de776e857">
    <span id="infopaneltitle-for-bed8381510f5967f5d37a33de776e857" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-size">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-list-size①">(2)</a>
+    <li><a href="#ref-for-list-size">3.4. Text Directives</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-896aa3c7ff2be812b3ea9c5f7f9bc5e4" class="dfn-panel" data-for="896aa3c7ff2be812b3ea9c5f7f9bc5e4" id="infopanel-for-896aa3c7ff2be812b3ea9c5f7f9bc5e4">
    <span id="infopaneltitle-for-896aa3c7ff2be812b3ea9c5f7f9bc5e4" style="display:none">Info about the 'split on commas' external reference.</span><a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-split-on-commas">3.3.2. Parsing the fragment directive</a>
+    <li><a href="#ref-for-split-on-commas">3.4. Text Directives</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-adb176cd03e93496f5eaada8f9e4dc0f" class="dfn-panel" data-for="adb176cd03e93496f5eaada8f9e4dc0f" id="infopanel-for-adb176cd03e93496f5eaada8f9e4dc0f">
    <span id="infopaneltitle-for-adb176cd03e93496f5eaada8f9e4dc0f" style="display:none">Info about the 'strictly split a string' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-strictly-split">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-strictly-split">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-40b59bc325bd4d66701dfd8b7f1847c0" class="dfn-panel" data-for="40b59bc325bd4d66701dfd8b7f1847c0" id="infopanel-for-40b59bc325bd4d66701dfd8b7f1847c0">
    <span id="infopaneltitle-for-40b59bc325bd4d66701dfd8b7f1847c0" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string">3.5.1. Finding Ranges in a Document</a>
-    <li><a href="#ref-for-string①">3.5.2. Word Boundaries</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a>
+    <li><a href="#ref-for-string">3.6.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-string①">3.6.2. Word Boundaries</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-3ee316b93eb2dbe81d01a666cce50f9b" class="dfn-panel" data-for="3ee316b93eb2dbe81d01a666cce50f9b" id="infopanel-for-3ee316b93eb2dbe81d01a666cce50f9b">
    <span id="infopaneltitle-for-3ee316b93eb2dbe81d01a666cce50f9b" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-struct">3.3.2. Parsing the fragment directive</a>
+    <li><a href="#ref-for-struct">3.4. Text Directives</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-60cc34e102fbb39581626f2f37e3179a" class="dfn-panel" data-for="60cc34e102fbb39581626f2f37e3179a" id="infopanel-for-60cc34e102fbb39581626f2f37e3179a">
    <span id="infopaneltitle-for-60cc34e102fbb39581626f2f37e3179a" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">3.3. The Fragment Directive</a>
-    <li><a href="#ref-for-concept-url-fragment①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-url-fragment②">(2)</a>
+    <li><a href="#ref-for-concept-url-fragment①">3.3.1. Extracting the fragment directive</a> <a href="#ref-for-concept-url-fragment②">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-3999a3b3593c7cb689ffd79b86bd5b34" class="dfn-panel" data-for="3999a3b3593c7cb689ffd79b86bd5b34" id="infopanel-for-3999a3b3593c7cb689ffd79b86bd5b34">
    <span id="infopaneltitle-for-3999a3b3593c7cb689ffd79b86bd5b34" style="display:none">Info about the 'percent-decode' external reference.</span><a href="https://url.spec.whatwg.org/#string-percent-decode">https://url.spec.whatwg.org/#string-percent-decode</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-string-percent-decode">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-string-percent-decode①">(2)</a> <a href="#ref-for-string-percent-decode②">(3)</a> <a href="#ref-for-string-percent-decode③">(4)</a>
+    <li><a href="#ref-for-string-percent-decode">3.4. Text Directives</a> <a href="#ref-for-string-percent-decode①">(2)</a> <a href="#ref-for-string-percent-decode②">(3)</a> <a href="#ref-for-string-percent-decode③">(4)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-fc05c76e016d3aec6a25a91c066500c8" class="dfn-panel" data-for="fc05c76e016d3aec6a25a91c066500c8" id="infopanel-for-fc05c76e016d3aec6a25a91c066500c8">
    <span id="infopaneltitle-for-fc05c76e016d3aec6a25a91c066500c8" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-url①">(2)</a> <a href="#ref-for-concept-url②">(3)</a>
+    <li><a href="#ref-for-concept-url">3.3.1. Extracting the fragment directive</a> <a href="#ref-for-concept-url①">(2)</a> <a href="#ref-for-concept-url②">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-46bd2da80269c4e9d4491ad1e341a8f5" class="dfn-panel" data-for="46bd2da80269c4e9d4491ad1e341a8f5" id="infopanel-for-46bd2da80269c4e9d4491ad1e341a8f5">
    <span id="infopaneltitle-for-46bd2da80269c4e9d4491ad1e341a8f5" style="display:none">Info about the 'url code point' external reference.</span><a href="https://url.spec.whatwg.org/#url-code-points">https://url.spec.whatwg.org/#url-code-points</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-url-code-points">3.3.3. Fragment directive grammar</a> <a href="#ref-for-url-code-points①">(2)</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-c8f6aafa6499946be59e4d1486023981" class="dfn-panel" data-for="c8f6aafa6499946be59e4d1486023981" id="infopanel-for-c8f6aafa6499946be59e4d1486023981">
-   <span id="infopaneltitle-for-c8f6aafa6499946be59e4d1486023981" style="display:none">Info about the 'target element' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#effect-target-target-element">https://drafts.csswg.org/web-animations-1/#effect-target-target-element</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-effect-target-target-element">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-url-code-points">3.3.4. Fragment directive grammar</a> <a href="#ref-for-url-code-points①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-dde049eb112f043fc45407ec0d4cb457" class="dfn-panel" data-for="dde049eb112f043fc45407ec0d4cb457" id="infopanel-for-dde049eb112f043fc45407ec0d4cb457">
    <span id="infopaneltitle-for-dde049eb112f043fc45407ec0d4cb457" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-Exposed">3.8. Feature Detectability</a>
+    <li><a href="#ref-for-Exposed">3.9. Feature Detectability</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-f572762cd4679aeacd36722d99d2b741" class="dfn-panel" data-for="f572762cd4679aeacd36722d99d2b741" id="infopanel-for-f572762cd4679aeacd36722d99d2b741">
    <span id="infopaneltitle-for-f572762cd4679aeacd36722d99d2b741" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-SameObject">3.8. Feature Detectability</a>
+    <li><a href="#ref-for-SameObject">3.9. Feature Detectability</a>
    </ul>
   </aside>
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
@@ -3350,6 +3486,11 @@ manipulations
      <li><span class="dfn-paneled" id="64b773084479966b88900296ed9bbc3d">visible</span>
     </ul>
    <li>
+    <a data-link-type="biblio">[CSSOM-VIEW-1]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="791f17d32821aad088ae925e0f0b13c5">scroll a target into view</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[DOM]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="07886e33695d0e7b473ef18f656ad7ac">Document</span>
@@ -3367,7 +3508,6 @@ manipulations
      <li><span class="dfn-paneled" id="d196280e8309de02330b386f7b7f41d5">end offset</span>
      <li><span class="dfn-paneled" id="42520ea878e2f46d9f9a0b2c695dd7ed">following</span>
      <li><span class="dfn-paneled" id="336f9dec7e7e3f85d4ed32b3ca6ad4d4">host</span>
-     <li><span class="dfn-paneled" id="7f09c44566c0c49d2cb28c4878acf2ab">html document</span>
      <li><span class="dfn-paneled" id="db19c0d2ac621c4f4f2ff03911d64150">length</span>
      <li><span class="dfn-paneled" id="f89bf81e89d1487d0236c9740d7f7b85">node</span>
      <li><span class="dfn-paneled" id="e374c2a979dc7a73f7d03be0623d67e6">node document</span>
@@ -3434,6 +3574,7 @@ manipulations
      <li><span class="dfn-paneled" id="7605aa4703a0a6921736ddd5321cfc07">concatenate</span>
      <li><span class="dfn-paneled" id="ce9efec0e74a2cbfe986593eb861ade6">continue</span>
      <li><span class="dfn-paneled" id="39deea7d529a23ee9b82b61369f78690">html namespace</span>
+     <li><span class="dfn-paneled" id="fd74d8159933c4a74d0b23390bed43e3">implementation-defined</span>
      <li><span class="dfn-paneled" id="81b03c84949641fc3081227509aab38f">length</span>
      <li><span class="dfn-paneled" id="fafd38d2108e357bcc9a6fd7f3cd04a7">list</span>
      <li><span class="dfn-paneled" id="a261ff0f11f981dec5af7b60f3229916">position variable</span>
@@ -3453,11 +3594,6 @@ manipulations
      <li><span class="dfn-paneled" id="46bd2da80269c4e9d4491ad1e341a8f5">url code point</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[WEB-ANIMATIONS-1]</a> defines the following terms:
-    <ul>
-     <li><span class="dfn-paneled" id="c8f6aafa6499946be59e4d1486023981">target element</span>
-    </ul>
-   <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="dde049eb112f043fc45407ec0d4cb457">Exposed</span>
@@ -3473,6 +3609,8 @@ manipulations
    <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://drafts.csswg.org/css-display/"><cite>CSS Display Module Level 3</cite></a>. URL: <a href="https://drafts.csswg.org/css-display/">https://drafts.csswg.org/css-display/</a>
    <dt id="biblio-css-display-4">[CSS-DISPLAY-4]
    <dd>CSS Display Module Level 4 URL: <a href="https://drafts.csswg.org/css-display-4/">https://drafts.csswg.org/css-display-4/</a>
+   <dt id="biblio-cssom-view-1">[CSSOM-VIEW-1]
+   <dd>Simon Pieters. <a href="https://drafts.csswg.org/cssom-view/"><cite>CSSOM View Module</cite></a>. URL: <a href="https://drafts.csswg.org/cssom-view/">https://drafts.csswg.org/cssom-view/</a>
    <dt id="biblio-document-policy">[DOCUMENT-POLICY]
    <dd>Ian Clelland. <a href="https://wicg.github.io/document-policy"><cite>Document Policy</cite></a>. ED. URL: <a href="https://wicg.github.io/document-policy">https://wicg.github.io/document-policy</a>
    <dt id="biblio-dom">[DOM]
@@ -3491,8 +3629,6 @@ manipulations
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-uts10">[UTS10]
    <dd>Ken Whistler; Markus Scherer. <a href="https://www.unicode.org/reports/tr10/tr10-47.html"><cite>Unicode Collation Algorithm</cite></a>. 26 August 2022. Unicode Technical Standard #10. URL: <a href="https://www.unicode.org/reports/tr10/tr10-47.html">https://www.unicode.org/reports/tr10/tr10-47.html</a>
-   <dt id="biblio-web-animations-1">[WEB-ANIMATIONS-1]
-   <dd>Brian Birtles; et al. <a href="https://drafts.csswg.org/web-animations-1/"><cite>Web Animations</cite></a>. URL: <a href="https://drafts.csswg.org/web-animations-1/">https://drafts.csswg.org/web-animations-1/</a>
    <dt id="biblio-webidl">[WEBIDL]
    <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
   </dl>
@@ -3524,12 +3660,14 @@ manipulations
     one. But maybe in this case we should return the empty string? That way a page can explicitly
     clear directives/highlights by navigating/pushState to '#:~:'. <a class="issue-return" href="#issue-827449be" title="Jump to section">↵</a></div>
    <div class="issue"> What should be set as target if inside a shadow tree? <a href="https://github.com/WICG/scroll-to-text-fragment/issues/190">#190</a> <a class="issue-return" href="#issue-424a4e25" title="Jump to section">↵</a></div>
-   <div class="issue"> These revealing algorithms currently wont work well since <var>target</var> could be an ancestor or even the root document node. Issue <a href="https://github.com/WICG/scroll-to-text-fragment/issues/89">#89</a> proposes restricting matches to <code>contain:style layout</code> blocks which
-    would resolve this problem. <a class="issue-return" href="#issue-10739530" title="Jump to section">↵</a></div>
-   <div class="issue"> <code>force-load-at-top</code> should be checked only when a new
-      document is being loaded. <a href="https://github.com/WICG/scroll-to-text-fragment/issues/186">#186</a> <a class="issue-return" href="#issue-b49aac41" title="Jump to section">↵</a></div>
-   <div class="issue"> Implementation note: Blink doesn’t currently set focus for text
-      fragments, it probably should? TODO: file crbug. <a class="issue-return" href="#issue-e253a983" title="Jump to section">↵</a></div>
+   <div class="issue"> These revealing algorithms currently wont work well since <var>target</var> could be an
+      ancestor or even the root document node. Issue <a href="https://github.com/WICG/scroll-to-text-fragment/issues/89">#89</a> proposes
+      restricting matches to <code>contain:style layout</code> blocks which would resolve this
+      problem. <a class="issue-return" href="#issue-10739530" title="Jump to section">↵</a></div>
+   <div class="issue"> <code>force-load-at-top</code> should be checked only when a new document is being
+      loaded. <a href="https://github.com/WICG/scroll-to-text-fragment/issues/186">#186</a> <a class="issue-return" href="#issue-b49aac41" title="Jump to section">↵</a></div>
+   <div class="issue">Implementation note: Blink doesn’t currently set focus for text
+  fragments, it probably should? TODO: file crbug. <a class="issue-return" href="#issue-e253a983" title="Jump to section">↵</a></div>
    <div class="issue"> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data">data</a> is not
 correct here since that’s the text data as it exists in the DOM. This
 algorithm means to run over the text as rendered (and then convert back
@@ -3540,303 +3678,314 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
    <ul>
     <li><a href="#ref-for-fragment-directive">3.2. Syntax</a>
     <li><a href="#ref-for-fragment-directive①">3.3. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a>
-    <li><a href="#ref-for-fragment-directive③">3.3.1. Processing the fragment directive</a> <a href="#ref-for-fragment-directive④">(2)</a> <a href="#ref-for-fragment-directive⑤">(3)</a> <a href="#ref-for-fragment-directive⑥">(4)</a>
-    <li><a href="#ref-for-fragment-directive⑦">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-fragment-directive⑧">3.6.1. URLs in UA features</a> <a href="#ref-for-fragment-directive⑨">(2)</a> <a href="#ref-for-fragment-directive①⓪">(3)</a>
-    <li><a href="#ref-for-fragment-directive①①">3.6.1.1. Location Bar</a>
-    <li><a href="#ref-for-fragment-directive①②">3.6.1.2. Bookmarks</a> <a href="#ref-for-fragment-directive①③">(2)</a>
-    <li><a href="#ref-for-fragment-directive①④">3.6.1.3. Sharing</a>
+    <li><a href="#ref-for-fragment-directive③">3.3.1. Extracting the fragment directive</a> <a href="#ref-for-fragment-directive④">(2)</a> <a href="#ref-for-fragment-directive⑤">(3)</a> <a href="#ref-for-fragment-directive⑥">(4)</a>
+    <li><a href="#ref-for-fragment-directive⑦">3.3.2. Applying directives to a document</a>
+    <li><a href="#ref-for-fragment-directive⑧">3.7.1. URLs in UA features</a> <a href="#ref-for-fragment-directive⑨">(2)</a> <a href="#ref-for-fragment-directive①⓪">(3)</a>
+    <li><a href="#ref-for-fragment-directive①①">3.7.1.1. Location Bar</a>
+    <li><a href="#ref-for-fragment-directive①②">3.7.1.2. Bookmarks</a> <a href="#ref-for-fragment-directive①③">(2)</a>
+    <li><a href="#ref-for-fragment-directive①④">3.7.1.3. Sharing</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-fragment-directive-delimiter" class="dfn-panel" data-for="fragment-directive-delimiter" id="infopanel-for-fragment-directive-delimiter">
    <span id="infopaneltitle-for-fragment-directive-delimiter" style="display:none">Info about the 'fragment directive delimiter' definition.</span><b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-directive-delimiter">3.3. The Fragment Directive</a>
-    <li><a href="#ref-for-fragment-directive-delimiter①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter②">(2)</a> <a href="#ref-for-fragment-directive-delimiter③">(3)</a> <a href="#ref-for-fragment-directive-delimiter④">(4)</a>
+    <li><a href="#ref-for-fragment-directive-delimiter①">3.3.1. Extracting the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter②">(2)</a> <a href="#ref-for-fragment-directive-delimiter③">(3)</a> <a href="#ref-for-fragment-directive-delimiter④">(4)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-directives" class="dfn-panel" data-for="directives" id="infopanel-for-directives">
    <span id="infopaneltitle-for-directives" style="display:none">Info about the 'directives' definition.</span><b><a href="#directives">#directives</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-directives">3.3.2. Parsing the fragment directive</a>
+    <li><a href="#ref-for-directives">3.4. Text Directives</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-directive-state" class="dfn-panel" data-for="directive-state" id="infopanel-for-directive-state">
    <span id="infopaneltitle-for-directive-state" style="display:none">Info about the 'directive state' definition.</span><b><a href="#directive-state">#directive-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-directive-state">3.3.1. Processing the fragment directive</a> <a href="#ref-for-directive-state①">(2)</a> <a href="#ref-for-directive-state②">(3)</a> <a href="#ref-for-directive-state③">(4)</a> <a href="#ref-for-directive-state④">(5)</a> <a href="#ref-for-directive-state⑤">(6)</a> <a href="#ref-for-directive-state⑥">(7)</a> <a href="#ref-for-directive-state⑦">(8)</a>
+    <li><a href="#ref-for-directive-state">3.3.1. Extracting the fragment directive</a> <a href="#ref-for-directive-state①">(2)</a> <a href="#ref-for-directive-state②">(3)</a> <a href="#ref-for-directive-state③">(4)</a> <a href="#ref-for-directive-state④">(5)</a> <a href="#ref-for-directive-state⑤">(6)</a> <a href="#ref-for-directive-state⑥">(7)</a> <a href="#ref-for-directive-state⑦">(8)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-directive-state-value" class="dfn-panel" data-for="directive-state-value" id="infopanel-for-directive-state-value">
    <span id="infopaneltitle-for-directive-state-value" style="display:none">Info about the 'value' definition.</span><b><a href="#directive-state-value">#directive-state-value</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-directive-state-value">3.3.1. Processing the fragment directive</a> <a href="#ref-for-directive-state-value①">(2)</a> <a href="#ref-for-directive-state-value②">(3)</a> <a href="#ref-for-directive-state-value③">(4)</a>
+    <li><a href="#ref-for-directive-state-value">3.3.1. Extracting the fragment directive</a> <a href="#ref-for-directive-state-value①">(2)</a> <a href="#ref-for-directive-state-value②">(3)</a> <a href="#ref-for-directive-state-value③">(4)</a>
+    <li><a href="#ref-for-directive-state-value④">3.3.2. Applying directives to a document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-she-directive-state" class="dfn-panel" data-for="she-directive-state" id="infopanel-for-she-directive-state">
    <span id="infopaneltitle-for-she-directive-state" style="display:none">Info about the 'directive state' definition.</span><b><a href="#she-directive-state">#she-directive-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-she-directive-state">3.3.1. Processing the fragment directive</a> <a href="#ref-for-she-directive-state①">(2)</a> <a href="#ref-for-she-directive-state②">(3)</a> <a href="#ref-for-she-directive-state③">(4)</a> <a href="#ref-for-she-directive-state④">(5)</a> <a href="#ref-for-she-directive-state⑤">(6)</a> <a href="#ref-for-she-directive-state⑥">(7)</a>
+    <li><a href="#ref-for-she-directive-state">3.3.1. Extracting the fragment directive</a> <a href="#ref-for-she-directive-state①">(2)</a> <a href="#ref-for-she-directive-state②">(3)</a> <a href="#ref-for-she-directive-state③">(4)</a> <a href="#ref-for-she-directive-state④">(5)</a> <a href="#ref-for-she-directive-state⑤">(6)</a> <a href="#ref-for-she-directive-state⑥">(7)</a>
+    <li><a href="#ref-for-she-directive-state⑦">3.3.2. Applying directives to a document</a> <a href="#ref-for-she-directive-state⑧">(2)</a> <a href="#ref-for-she-directive-state⑨">(3)</a> <a href="#ref-for-she-directive-state①⓪">(4)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-remove-the-fragment-directive" class="dfn-panel" data-for="remove-the-fragment-directive" id="infopanel-for-remove-the-fragment-directive">
    <span id="infopaneltitle-for-remove-the-fragment-directive" style="display:none">Info about the 'remove the fragment directive' definition.</span><b><a href="#remove-the-fragment-directive">#remove-the-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-remove-the-fragment-directive">3.3.1. Processing the fragment directive</a> <a href="#ref-for-remove-the-fragment-directive①">(2)</a> <a href="#ref-for-remove-the-fragment-directive②">(3)</a>
+    <li><a href="#ref-for-remove-the-fragment-directive">3.3.1. Extracting the fragment directive</a> <a href="#ref-for-remove-the-fragment-directive①">(2)</a> <a href="#ref-for-remove-the-fragment-directive②">(3)</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-document-uninvoked-directives" class="dfn-panel" data-for="document-uninvoked-directives" id="infopanel-for-document-uninvoked-directives">
+   <span id="infopaneltitle-for-document-uninvoked-directives" style="display:none">Info about the 'uninvoked directives' definition.</span><b><a href="#document-uninvoked-directives">#document-uninvoked-directives</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-document-uninvoked-directives">3.3.2. Applying directives to a document</a>
+    <li><a href="#ref-for-document-uninvoked-directives①">3.4.1. Invoking Text Directives</a> <a href="#ref-for-document-uninvoked-directives②">(2)</a> <a href="#ref-for-document-uninvoked-directives③">(3)</a> <a href="#ref-for-document-uninvoked-directives④">(4)</a> <a href="#ref-for-document-uninvoked-directives⑤">(5)</a> <a href="#ref-for-document-uninvoked-directives⑥">(6)</a> <a href="#ref-for-document-uninvoked-directives⑦">(7)</a> <a href="#ref-for-document-uninvoked-directives⑧">(8)</a> <a href="#ref-for-document-uninvoked-directives⑨">(9)</a> <a href="#ref-for-document-uninvoked-directives①⓪">(10)</a>
+    <li><a href="#ref-for-document-uninvoked-directives①①">3.5.4. Restricting the Text Fragment</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-valid-fragment-directive" class="dfn-panel" data-for="valid-fragment-directive" id="infopanel-for-valid-fragment-directive">
+   <span id="infopaneltitle-for-valid-fragment-directive" style="display:none">Info about the 'valid fragment directive' definition.</span><b><a href="#valid-fragment-directive">#valid-fragment-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-valid-fragment-directive">3.6.1. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-fragmentdirectiveproduction" class="dfn-panel" data-for="fragmentdirectiveproduction" id="infopanel-for-fragmentdirectiveproduction">
+   <span id="infopaneltitle-for-fragmentdirectiveproduction" style="display:none">Info about the 'FragmentDirective' definition.</span><b><a href="#fragmentdirectiveproduction">#fragmentdirectiveproduction</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-fragmentdirectiveproduction">3.3.4. Fragment directive grammar</a> <a href="#ref-for-fragmentdirectiveproduction①">(2)</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-unknowndirective" class="dfn-panel" data-for="unknowndirective" id="infopanel-for-unknowndirective">
+   <span id="infopaneltitle-for-unknowndirective" style="display:none">Info about the 'UnknownDirective' definition.</span><b><a href="#unknowndirective">#unknowndirective</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-unknowndirective">3.3.4. Fragment directive grammar</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-characterstring" class="dfn-panel" data-for="characterstring" id="infopanel-for-characterstring">
+   <span id="infopaneltitle-for-characterstring" style="display:none">Info about the 'CharacterString' definition.</span><b><a href="#characterstring">#characterstring</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-characterstring">3.3.4. Fragment directive grammar</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-explicitchar" class="dfn-panel" data-for="explicitchar" id="infopanel-for-explicitchar">
+   <span id="infopaneltitle-for-explicitchar" style="display:none">Info about the 'ExplicitChar' definition.</span><b><a href="#explicitchar">#explicitchar</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-explicitchar">3.3.4. Fragment directive grammar</a> <a href="#ref-for-explicitchar①">(2)</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-textdirective" class="dfn-panel" data-for="textdirective" id="infopanel-for-textdirective">
+   <span id="infopaneltitle-for-textdirective" style="display:none">Info about the 'TextDirective' definition.</span><b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirective">3.3.4. Fragment directive grammar</a> <a href="#ref-for-textdirective①">(2)</a>
+    <li><a href="#ref-for-textdirective②">3.4. Text Directives</a>
+    <li><a href="#ref-for-textdirective③">3.6.1. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-textdirectiveparameters" class="dfn-panel" data-for="textdirectiveparameters" id="infopanel-for-textdirectiveparameters">
+   <span id="infopaneltitle-for-textdirectiveparameters" style="display:none">Info about the 'TextDirectiveParameters' definition.</span><b><a href="#textdirectiveparameters">#textdirectiveparameters</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirectiveparameters">3.3.4. Fragment directive grammar</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-textdirectiveprefix" class="dfn-panel" data-for="textdirectiveprefix" id="infopanel-for-textdirectiveprefix">
+   <span id="infopaneltitle-for-textdirectiveprefix" style="display:none">Info about the 'TextDirectivePrefix' definition.</span><b><a href="#textdirectiveprefix">#textdirectiveprefix</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirectiveprefix">3.3.4. Fragment directive grammar</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-textdirectivesuffix" class="dfn-panel" data-for="textdirectivesuffix" id="infopanel-for-textdirectivesuffix">
+   <span id="infopaneltitle-for-textdirectivesuffix" style="display:none">Info about the 'TextDirectiveSuffix' definition.</span><b><a href="#textdirectivesuffix">#textdirectivesuffix</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirectivesuffix">3.3.4. Fragment directive grammar</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-textdirectivestring" class="dfn-panel" data-for="textdirectivestring" id="infopanel-for-textdirectivestring">
+   <span id="infopaneltitle-for-textdirectivestring" style="display:none">Info about the 'TextDirectiveString' definition.</span><b><a href="#textdirectivestring">#textdirectivestring</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirectivestring">3.3.4. Fragment directive grammar</a> <a href="#ref-for-textdirectivestring①">(2)</a> <a href="#ref-for-textdirectivestring②">(3)</a> <a href="#ref-for-textdirectivestring③">(4)</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-textdirectiveexplicitchar" class="dfn-panel" data-for="textdirectiveexplicitchar" id="infopanel-for-textdirectiveexplicitchar">
+   <span id="infopaneltitle-for-textdirectiveexplicitchar" style="display:none">Info about the 'TextDirectiveExplicitChar' definition.</span><b><a href="#textdirectiveexplicitchar">#textdirectiveexplicitchar</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-textdirectiveexplicitchar">3.3.4. Fragment directive grammar</a> <a href="#ref-for-textdirectiveexplicitchar①">(2)</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-percentencodedchar" class="dfn-panel" data-for="percentencodedchar" id="infopanel-for-percentencodedchar">
+   <span id="infopaneltitle-for-percentencodedchar" style="display:none">Info about the 'PercentEncodedChar' definition.</span><b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-percentencodedchar">3.3.4. Fragment directive grammar</a> <a href="#ref-for-percentencodedchar①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-text-directive" class="dfn-panel" data-for="text-directive" id="infopanel-for-text-directive">
    <span id="infopaneltitle-for-text-directive" style="display:none">Info about the 'text directive' definition.</span><b><a href="#text-directive">#text-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-directive">3.2. Syntax</a>
-    <li><a href="#ref-for-text-directive①">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-text-directive②">(2)</a>
-    <li><a href="#ref-for-text-directive③">3.4.1. Motivation</a> <a href="#ref-for-text-directive④">(2)</a>
-    <li><a href="#ref-for-text-directive⑤">3.4.3. Search Timing</a>
-    <li><a href="#ref-for-text-directive⑥">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-text-directive⑦">3.5.1. Finding Ranges in a Document</a>
-    <li><a href="#ref-for-text-directive⑧">4. Generating Text Fragment Directives</a>
-    <li><a href="#ref-for-text-directive⑨">4.2. Use Context Only When Necessary</a> <a href="#ref-for-text-directive①⓪">(2)</a> <a href="#ref-for-text-directive①①">(3)</a>
-    <li><a href="#ref-for-text-directive①②">4.3. Determine If Fragment Id Is Needed</a> <a href="#ref-for-text-directive①③">(2)</a>
+    <li><a href="#ref-for-text-directive①">3.4. Text Directives</a> <a href="#ref-for-text-directive②">(2)</a>
+    <li><a href="#ref-for-text-directive③">3.4.1. Invoking Text Directives</a>
+    <li><a href="#ref-for-text-directive④">3.5.1. Motivation</a> <a href="#ref-for-text-directive⑤">(2)</a>
+    <li><a href="#ref-for-text-directive⑥">3.5.3. Search Timing</a>
+    <li><a href="#ref-for-text-directive⑦">3.6. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-text-directive⑧">3.6.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-text-directive⑨">4. Generating Text Fragment Directives</a>
+    <li><a href="#ref-for-text-directive①⓪">4.2. Use Context Only When Necessary</a> <a href="#ref-for-text-directive①①">(2)</a> <a href="#ref-for-text-directive①②">(3)</a>
+    <li><a href="#ref-for-text-directive①③">4.3. Determine If Fragment Id Is Needed</a> <a href="#ref-for-text-directive①④">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-text-directive-start" class="dfn-panel" data-for="text-directive-start" id="infopanel-for-text-directive-start">
    <span id="infopaneltitle-for-text-directive-start" style="display:none">Info about the 'start' definition.</span><b><a href="#text-directive-start">#text-directive-start</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-text-directive-start">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-text-directive-start①">(2)</a>
-    <li><a href="#ref-for-text-directive-start②">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-text-directive-start③">(2)</a> <a href="#ref-for-text-directive-start④">(3)</a> <a href="#ref-for-text-directive-start⑤">(4)</a> <a href="#ref-for-text-directive-start⑥">(5)</a> <a href="#ref-for-text-directive-start⑦">(6)</a>
+    <li><a href="#ref-for-text-directive-start">3.4. Text Directives</a> <a href="#ref-for-text-directive-start①">(2)</a>
+    <li><a href="#ref-for-text-directive-start②">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-text-directive-start③">(2)</a> <a href="#ref-for-text-directive-start④">(3)</a> <a href="#ref-for-text-directive-start⑤">(4)</a> <a href="#ref-for-text-directive-start⑥">(5)</a> <a href="#ref-for-text-directive-start⑦">(6)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-text-directive-end" class="dfn-panel" data-for="text-directive-end" id="infopanel-for-text-directive-end">
    <span id="infopaneltitle-for-text-directive-end" style="display:none">Info about the 'end' definition.</span><b><a href="#text-directive-end">#text-directive-end</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-text-directive-end">3.3.2. Parsing the fragment directive</a>
-    <li><a href="#ref-for-text-directive-end①">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-text-directive-end②">(2)</a> <a href="#ref-for-text-directive-end③">(3)</a> <a href="#ref-for-text-directive-end④">(4)</a> <a href="#ref-for-text-directive-end⑤">(5)</a> <a href="#ref-for-text-directive-end⑥">(6)</a> <a href="#ref-for-text-directive-end⑦">(7)</a> <a href="#ref-for-text-directive-end⑧">(8)</a> <a href="#ref-for-text-directive-end⑨">(9)</a> <a href="#ref-for-text-directive-end①⓪">(10)</a> <a href="#ref-for-text-directive-end①①">(11)</a>
+    <li><a href="#ref-for-text-directive-end">3.4. Text Directives</a>
+    <li><a href="#ref-for-text-directive-end①">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-text-directive-end②">(2)</a> <a href="#ref-for-text-directive-end③">(3)</a> <a href="#ref-for-text-directive-end④">(4)</a> <a href="#ref-for-text-directive-end⑤">(5)</a> <a href="#ref-for-text-directive-end⑥">(6)</a> <a href="#ref-for-text-directive-end⑦">(7)</a> <a href="#ref-for-text-directive-end⑧">(8)</a> <a href="#ref-for-text-directive-end⑨">(9)</a> <a href="#ref-for-text-directive-end①⓪">(10)</a> <a href="#ref-for-text-directive-end①①">(11)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-text-directive-prefix" class="dfn-panel" data-for="text-directive-prefix" id="infopanel-for-text-directive-prefix">
    <span id="infopaneltitle-for-text-directive-prefix" style="display:none">Info about the 'prefix' definition.</span><b><a href="#text-directive-prefix">#text-directive-prefix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-text-directive-prefix">3.3.2. Parsing the fragment directive</a>
-    <li><a href="#ref-for-text-directive-prefix①">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-text-directive-prefix②">(2)</a> <a href="#ref-for-text-directive-prefix③">(3)</a> <a href="#ref-for-text-directive-prefix④">(4)</a> <a href="#ref-for-text-directive-prefix⑤">(5)</a> <a href="#ref-for-text-directive-prefix⑥">(6)</a>
+    <li><a href="#ref-for-text-directive-prefix">3.4. Text Directives</a>
+    <li><a href="#ref-for-text-directive-prefix①">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-text-directive-prefix②">(2)</a> <a href="#ref-for-text-directive-prefix③">(3)</a> <a href="#ref-for-text-directive-prefix④">(4)</a> <a href="#ref-for-text-directive-prefix⑤">(5)</a> <a href="#ref-for-text-directive-prefix⑥">(6)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-text-directive-suffix" class="dfn-panel" data-for="text-directive-suffix" id="infopanel-for-text-directive-suffix">
    <span id="infopaneltitle-for-text-directive-suffix" style="display:none">Info about the 'suffix' definition.</span><b><a href="#text-directive-suffix">#text-directive-suffix</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-text-directive-suffix">3.3.2. Parsing the fragment directive</a>
-    <li><a href="#ref-for-text-directive-suffix①">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-text-directive-suffix②">(2)</a> <a href="#ref-for-text-directive-suffix③">(3)</a> <a href="#ref-for-text-directive-suffix④">(4)</a> <a href="#ref-for-text-directive-suffix⑤">(5)</a> <a href="#ref-for-text-directive-suffix⑥">(6)</a> <a href="#ref-for-text-directive-suffix⑦">(7)</a>
+    <li><a href="#ref-for-text-directive-suffix">3.4. Text Directives</a>
+    <li><a href="#ref-for-text-directive-suffix①">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-text-directive-suffix②">(2)</a> <a href="#ref-for-text-directive-suffix③">(3)</a> <a href="#ref-for-text-directive-suffix④">(4)</a> <a href="#ref-for-text-directive-suffix⑤">(5)</a> <a href="#ref-for-text-directive-suffix⑥">(6)</a> <a href="#ref-for-text-directive-suffix⑦">(7)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-parse-a-text-directive" class="dfn-panel" data-for="parse-a-text-directive" id="infopanel-for-parse-a-text-directive">
    <span id="infopaneltitle-for-parse-a-text-directive" style="display:none">Info about the 'parse a text directive' definition.</span><b><a href="#parse-a-text-directive">#parse-a-text-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-parse-a-text-directive">3.5.1. Finding Ranges in a Document</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-valid-fragment-directive" class="dfn-panel" data-for="valid-fragment-directive" id="infopanel-for-valid-fragment-directive">
-   <span id="infopaneltitle-for-valid-fragment-directive" style="display:none">Info about the 'valid fragment directive' definition.</span><b><a href="#valid-fragment-directive">#valid-fragment-directive</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-valid-fragment-directive">3.5.1. Finding Ranges in a Document</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-fragmentdirectiveproduction" class="dfn-panel" data-for="fragmentdirectiveproduction" id="infopanel-for-fragmentdirectiveproduction">
-   <span id="infopaneltitle-for-fragmentdirectiveproduction" style="display:none">Info about the 'FragmentDirective' definition.</span><b><a href="#fragmentdirectiveproduction">#fragmentdirectiveproduction</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-fragmentdirectiveproduction">3.3.3. Fragment directive grammar</a> <a href="#ref-for-fragmentdirectiveproduction①">(2)</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-unknowndirective" class="dfn-panel" data-for="unknowndirective" id="infopanel-for-unknowndirective">
-   <span id="infopaneltitle-for-unknowndirective" style="display:none">Info about the 'UnknownDirective' definition.</span><b><a href="#unknowndirective">#unknowndirective</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-unknowndirective">3.3.3. Fragment directive grammar</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-characterstring" class="dfn-panel" data-for="characterstring" id="infopanel-for-characterstring">
-   <span id="infopaneltitle-for-characterstring" style="display:none">Info about the 'CharacterString' definition.</span><b><a href="#characterstring">#characterstring</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-characterstring">3.3.3. Fragment directive grammar</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-explicitchar" class="dfn-panel" data-for="explicitchar" id="infopanel-for-explicitchar">
-   <span id="infopaneltitle-for-explicitchar" style="display:none">Info about the 'ExplicitChar' definition.</span><b><a href="#explicitchar">#explicitchar</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-explicitchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-explicitchar①">(2)</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-textdirective" class="dfn-panel" data-for="textdirective" id="infopanel-for-textdirective">
-   <span id="infopaneltitle-for-textdirective" style="display:none">Info about the 'TextDirective' definition.</span><b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-textdirective">3.3.2. Parsing the fragment directive</a>
-    <li><a href="#ref-for-textdirective①">3.3.3. Fragment directive grammar</a> <a href="#ref-for-textdirective②">(2)</a>
-    <li><a href="#ref-for-textdirective③">3.5.1. Finding Ranges in a Document</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-textdirectiveparameters" class="dfn-panel" data-for="textdirectiveparameters" id="infopanel-for-textdirectiveparameters">
-   <span id="infopaneltitle-for-textdirectiveparameters" style="display:none">Info about the 'TextDirectiveParameters' definition.</span><b><a href="#textdirectiveparameters">#textdirectiveparameters</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-textdirectiveparameters">3.3.3. Fragment directive grammar</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-textdirectiveprefix" class="dfn-panel" data-for="textdirectiveprefix" id="infopanel-for-textdirectiveprefix">
-   <span id="infopaneltitle-for-textdirectiveprefix" style="display:none">Info about the 'TextDirectivePrefix' definition.</span><b><a href="#textdirectiveprefix">#textdirectiveprefix</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-textdirectiveprefix">3.3.3. Fragment directive grammar</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-textdirectivesuffix" class="dfn-panel" data-for="textdirectivesuffix" id="infopanel-for-textdirectivesuffix">
-   <span id="infopaneltitle-for-textdirectivesuffix" style="display:none">Info about the 'TextDirectiveSuffix' definition.</span><b><a href="#textdirectivesuffix">#textdirectivesuffix</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-textdirectivesuffix">3.3.3. Fragment directive grammar</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-textdirectivestring" class="dfn-panel" data-for="textdirectivestring" id="infopanel-for-textdirectivestring">
-   <span id="infopaneltitle-for-textdirectivestring" style="display:none">Info about the 'TextDirectiveString' definition.</span><b><a href="#textdirectivestring">#textdirectivestring</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-textdirectivestring">3.3.3. Fragment directive grammar</a> <a href="#ref-for-textdirectivestring①">(2)</a> <a href="#ref-for-textdirectivestring②">(3)</a> <a href="#ref-for-textdirectivestring③">(4)</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-textdirectiveexplicitchar" class="dfn-panel" data-for="textdirectiveexplicitchar" id="infopanel-for-textdirectiveexplicitchar">
-   <span id="infopaneltitle-for-textdirectiveexplicitchar" style="display:none">Info about the 'TextDirectiveExplicitChar' definition.</span><b><a href="#textdirectiveexplicitchar">#textdirectiveexplicitchar</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-textdirectiveexplicitchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-textdirectiveexplicitchar①">(2)</a>
-   </ul>
-  </aside>
-  <aside aria-labelledby="infopaneltitle-for-percentencodedchar" class="dfn-panel" data-for="percentencodedchar" id="infopanel-for-percentencodedchar">
-   <span id="infopaneltitle-for-percentencodedchar" style="display:none">Info about the 'PercentEncodedChar' definition.</span><b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-percentencodedchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-percentencodedchar①">(2)</a>
+    <li><a href="#ref-for-parse-a-text-directive">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-request-text-directive-user-activation" class="dfn-panel" data-for="request-text-directive-user-activation" id="infopanel-for-request-text-directive-user-activation">
    <span id="infopaneltitle-for-request-text-directive-user-activation" style="display:none">Info about the 'text directive user activation' definition.</span><b><a href="#request-text-directive-user-activation">#request-text-directive-user-activation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-request-text-directive-user-activation">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-request-text-directive-user-activation①">(2)</a> <a href="#ref-for-request-text-directive-user-activation②">(3)</a> <a href="#ref-for-request-text-directive-user-activation③">(4)</a> <a href="#ref-for-request-text-directive-user-activation④">(5)</a>
+    <li><a href="#ref-for-request-text-directive-user-activation">3.5.4. Restricting the Text Fragment</a> <a href="#ref-for-request-text-directive-user-activation①">(2)</a> <a href="#ref-for-request-text-directive-user-activation②">(3)</a> <a href="#ref-for-request-text-directive-user-activation③">(4)</a> <a href="#ref-for-request-text-directive-user-activation④">(5)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-document-text-directive-user-activation" class="dfn-panel" data-for="document-text-directive-user-activation" id="infopanel-for-document-text-directive-user-activation">
    <span id="infopaneltitle-for-document-text-directive-user-activation" style="display:none">Info about the 'text directive user activation' definition.</span><b><a href="#document-text-directive-user-activation">#document-text-directive-user-activation</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-text-directive-user-activation">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-text-directive-user-activation①">(2)</a> <a href="#ref-for-document-text-directive-user-activation②">(3)</a> <a href="#ref-for-document-text-directive-user-activation③">(4)</a> <a href="#ref-for-document-text-directive-user-activation④">(5)</a> <a href="#ref-for-document-text-directive-user-activation⑤">(6)</a> <a href="#ref-for-document-text-directive-user-activation⑥">(7)</a> <a href="#ref-for-document-text-directive-user-activation⑦">(8)</a> <a href="#ref-for-document-text-directive-user-activation⑧">(9)</a> <a href="#ref-for-document-text-directive-user-activation⑨">(10)</a> <a href="#ref-for-document-text-directive-user-activation①⓪">(11)</a> <a href="#ref-for-document-text-directive-user-activation①①">(12)</a> <a href="#ref-for-document-text-directive-user-activation①②">(13)</a>
+    <li><a href="#ref-for-document-text-directive-user-activation">3.5.4. Restricting the Text Fragment</a> <a href="#ref-for-document-text-directive-user-activation①">(2)</a> <a href="#ref-for-document-text-directive-user-activation②">(3)</a> <a href="#ref-for-document-text-directive-user-activation③">(4)</a> <a href="#ref-for-document-text-directive-user-activation④">(5)</a> <a href="#ref-for-document-text-directive-user-activation⑤">(6)</a> <a href="#ref-for-document-text-directive-user-activation⑥">(7)</a> <a href="#ref-for-document-text-directive-user-activation⑦">(8)</a> <a href="#ref-for-document-text-directive-user-activation⑧">(9)</a> <a href="#ref-for-document-text-directive-user-activation⑨">(10)</a> <a href="#ref-for-document-text-directive-user-activation①⓪">(11)</a> <a href="#ref-for-document-text-directive-user-activation①①">(12)</a> <a href="#ref-for-document-text-directive-user-activation①②">(13)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-document-allow-text-fragment-scroll" class="dfn-panel" data-for="document-allow-text-fragment-scroll" id="infopanel-for-document-allow-text-fragment-scroll">
    <span id="infopaneltitle-for-document-allow-text-fragment-scroll" style="display:none">Info about the 'allow text fragment scroll' definition.</span><b><a href="#document-allow-text-fragment-scroll">#document-allow-text-fragment-scroll</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-allow-text-fragment-scroll">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allow-text-fragment-scroll①">(2)</a> <a href="#ref-for-document-allow-text-fragment-scroll②">(3)</a> <a href="#ref-for-document-allow-text-fragment-scroll③">(4)</a> <a href="#ref-for-document-allow-text-fragment-scroll④">(5)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑤">(6)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑥">(7)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑦">(8)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑧">(9)</a>
-    <li><a href="#ref-for-document-allow-text-fragment-scroll⑨">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-document-allow-text-fragment-scroll">3.4.1. Invoking Text Directives</a>
+    <li><a href="#ref-for-document-allow-text-fragment-scroll①">3.5.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allow-text-fragment-scroll②">(2)</a> <a href="#ref-for-document-allow-text-fragment-scroll③">(3)</a> <a href="#ref-for-document-allow-text-fragment-scroll④">(4)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑤">(5)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑥">(6)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑦">(7)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑧">(8)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑨">(9)</a> <a href="#ref-for-document-allow-text-fragment-scroll①⓪">(10)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-first-common-ancestor" class="dfn-panel" data-for="first-common-ancestor" id="infopanel-for-first-common-ancestor">
    <span id="infopaneltitle-for-first-common-ancestor" style="display:none">Info about the 'first common ancestor' definition.</span><b><a href="#first-common-ancestor">#first-common-ancestor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-first-common-ancestor">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-first-common-ancestor">3.4.1. Invoking Text Directives</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-shadow-including-parent" class="dfn-panel" data-for="shadow-including-parent" id="infopanel-for-shadow-including-parent">
    <span id="infopaneltitle-for-shadow-including-parent" style="display:none">Info about the 'shadow-including parent' definition.</span><b><a href="#shadow-including-parent">#shadow-including-parent</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-shadow-including-parent">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-shadow-including-parent">3.6. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-process-a-fragment-directive" class="dfn-panel" data-for="process-a-fragment-directive" id="infopanel-for-process-a-fragment-directive">
    <span id="infopaneltitle-for-process-a-fragment-directive" style="display:none">Info about the 'process a fragment directive' definition.</span><b><a href="#process-a-fragment-directive">#process-a-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-process-a-fragment-directive">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-process-a-fragment-directive①">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-process-a-fragment-directive">3.4.1. Invoking Text Directives</a>
+    <li><a href="#ref-for-process-a-fragment-directive①">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-find-a-range-from-a-text-directive" class="dfn-panel" data-for="find-a-range-from-a-text-directive" id="infopanel-for-find-a-range-from-a-text-directive">
    <span id="infopaneltitle-for-find-a-range-from-a-text-directive" style="display:none">Info about the 'find a range from a text directive' definition.</span><b><a href="#find-a-range-from-a-text-directive">#find-a-range-from-a-text-directive</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-find-a-range-from-a-text-directive">3.4.3. Search Timing</a>
-    <li><a href="#ref-for-find-a-range-from-a-text-directive①">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-find-a-range-from-a-text-directive">3.5.3. Search Timing</a>
+    <li><a href="#ref-for-find-a-range-from-a-text-directive①">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-next-non-whitespace-position" class="dfn-panel" data-for="next-non-whitespace-position" id="infopanel-for-next-non-whitespace-position">
    <span id="infopaneltitle-for-next-non-whitespace-position" style="display:none">Info about the 'next
 non-whitespace position' definition.</span><b><a href="#next-non-whitespace-position">#next-non-whitespace-position</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-next-non-whitespace-position">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-next-non-whitespace-position①">(2)</a>
+    <li><a href="#ref-for-next-non-whitespace-position">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-next-non-whitespace-position①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-find-a-string-in-range" class="dfn-panel" data-for="find-a-string-in-range" id="infopanel-for-find-a-string-in-range">
    <span id="infopaneltitle-for-find-a-string-in-range" style="display:none">Info about the 'find a string in range' definition.</span><b><a href="#find-a-string-in-range">#find-a-string-in-range</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-find-a-string-in-range">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-find-a-string-in-range①">(2)</a> <a href="#ref-for-find-a-string-in-range②">(3)</a> <a href="#ref-for-find-a-string-in-range③">(4)</a> <a href="#ref-for-find-a-string-in-range④">(5)</a>
+    <li><a href="#ref-for-find-a-string-in-range">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-find-a-string-in-range①">(2)</a> <a href="#ref-for-find-a-string-in-range②">(3)</a> <a href="#ref-for-find-a-string-in-range③">(4)</a> <a href="#ref-for-find-a-string-in-range④">(5)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-search-invisible" class="dfn-panel" data-for="search-invisible" id="infopanel-for-search-invisible">
    <span id="infopaneltitle-for-search-invisible" style="display:none">Info about the 'search invisible' definition.</span><b><a href="#search-invisible">#search-invisible</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-search-invisible">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-search-invisible①">(2)</a>
+    <li><a href="#ref-for-search-invisible">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-search-invisible①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-non-searchable-subtree" class="dfn-panel" data-for="non-searchable-subtree" id="infopanel-for-non-searchable-subtree">
    <span id="infopaneltitle-for-non-searchable-subtree" style="display:none">Info about the 'non-searchable subtree' definition.</span><b><a href="#non-searchable-subtree">#non-searchable-subtree</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-non-searchable-subtree">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-non-searchable-subtree①">(2)</a>
+    <li><a href="#ref-for-non-searchable-subtree">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-non-searchable-subtree①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-visible-text-node" class="dfn-panel" data-for="visible-text-node" id="infopanel-for-visible-text-node">
    <span id="infopaneltitle-for-visible-text-node" style="display:none">Info about the 'visible text node' definition.</span><b><a href="#visible-text-node">#visible-text-node</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-visible-text-node">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-visible-text-node①">(2)</a> <a href="#ref-for-visible-text-node②">(3)</a>
+    <li><a href="#ref-for-visible-text-node">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-visible-text-node①">(2)</a> <a href="#ref-for-visible-text-node②">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-has-block-level-display" class="dfn-panel" data-for="has-block-level-display" id="infopanel-for-has-block-level-display">
    <span id="infopaneltitle-for-has-block-level-display" style="display:none">Info about the 'has block-level display' definition.</span><b><a href="#has-block-level-display">#has-block-level-display</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-has-block-level-display">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-has-block-level-display①">(2)</a>
+    <li><a href="#ref-for-has-block-level-display">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-has-block-level-display①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-nearest-block-ancestor" class="dfn-panel" data-for="nearest-block-ancestor" id="infopanel-for-nearest-block-ancestor">
    <span id="infopaneltitle-for-nearest-block-ancestor" style="display:none">Info about the 'nearest block ancestor' definition.</span><b><a href="#nearest-block-ancestor">#nearest-block-ancestor</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-nearest-block-ancestor">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-nearest-block-ancestor">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-find-a-range-from-a-node-list" class="dfn-panel" data-for="find-a-range-from-a-node-list" id="infopanel-for-find-a-range-from-a-node-list">
    <span id="infopaneltitle-for-find-a-range-from-a-node-list" style="display:none">Info about the 'find a range from a node list' definition.</span><b><a href="#find-a-range-from-a-node-list">#find-a-range-from-a-node-list</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-find-a-range-from-a-node-list">3.5.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-find-a-range-from-a-node-list">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-get-boundary-point-at-index" class="dfn-panel" data-for="get-boundary-point-at-index" id="infopanel-for-get-boundary-point-at-index">
    <span id="infopaneltitle-for-get-boundary-point-at-index" style="display:none">Info about the 'get boundary point at index' definition.</span><b><a href="#get-boundary-point-at-index">#get-boundary-point-at-index</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-get-boundary-point-at-index">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-get-boundary-point-at-index①">(2)</a>
+    <li><a href="#ref-for-get-boundary-point-at-index">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-get-boundary-point-at-index①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-word-boundary" class="dfn-panel" data-for="word-boundary" id="infopanel-for-word-boundary">
    <span id="infopaneltitle-for-word-boundary" style="display:none">Info about the 'word boundary' definition.</span><b><a href="#word-boundary">#word-boundary</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-word-boundary">3.5.1. Finding Ranges in a Document</a>
-    <li><a href="#ref-for-word-boundary①">3.5.2. Word Boundaries</a>
+    <li><a href="#ref-for-word-boundary">3.6.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-word-boundary①">3.6.2. Word Boundaries</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-locale" class="dfn-panel" data-for="locale" id="infopanel-for-locale">
    <span id="infopaneltitle-for-locale" style="display:none">Info about the 'locale' definition.</span><b><a href="#locale">#locale</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-locale">3.5.2. Word Boundaries</a> <a href="#ref-for-locale①">(2)</a>
+    <li><a href="#ref-for-locale">3.6.2. Word Boundaries</a> <a href="#ref-for-locale①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-word-bounded" class="dfn-panel" data-for="word-bounded" id="infopanel-for-word-bounded">
    <span id="infopaneltitle-for-word-bounded" style="display:none">Info about the 'word bounded' definition.</span><b><a href="#word-bounded">#word-bounded</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-word-bounded">3.5.2. Word Boundaries</a>
+    <li><a href="#ref-for-word-bounded">3.6.2. Word Boundaries</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-is-at-a-word-boundary" class="dfn-panel" data-for="is-at-a-word-boundary" id="infopanel-for-is-at-a-word-boundary">
    <span id="infopaneltitle-for-is-at-a-word-boundary" style="display:none">Info about the 'is at a word boundary' definition.</span><b><a href="#is-at-a-word-boundary">#is-at-a-word-boundary</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-is-at-a-word-boundary">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-is-at-a-word-boundary①">(2)</a>
-    <li><a href="#ref-for-is-at-a-word-boundary②">3.5.2. Word Boundaries</a> <a href="#ref-for-is-at-a-word-boundary③">(2)</a>
+    <li><a href="#ref-for-is-at-a-word-boundary">3.6.1. Finding Ranges in a Document</a> <a href="#ref-for-is-at-a-word-boundary①">(2)</a>
+    <li><a href="#ref-for-is-at-a-word-boundary②">3.6.2. Word Boundaries</a> <a href="#ref-for-is-at-a-word-boundary③">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-fragmentdirective" class="dfn-panel" data-for="fragmentdirective" id="infopanel-for-fragmentdirective">
    <span id="infopaneltitle-for-fragmentdirective" style="display:none">Info about the 'FragmentDirective' definition.</span><b><a href="#fragmentdirective">#fragmentdirective</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-fragmentdirective">3.8. Feature Detectability</a>
+    <li><a href="#ref-for-fragmentdirective">3.9. Feature Detectability</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
   <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version d9bd89757, updated Thu Mar 23 10:06:53 2023 -0700" name="generator">
   <link href="https://wicg.github.io/scroll-to-text-fragment/" rel="canonical">
+<style>
+  .monkeypatch {
+    color: grey;
+  }
+
+  .monkeypatch .diff {
+    color: black;
+  }
+</style>
 <style>/* style-autolinks */
 .css.css, .property.property, .descriptor.descriptor {
     color: var(--a-normal-text);
@@ -735,7 +744,7 @@ dd:not(:last-child) > .wpt-tests-block:not([open]):last-child {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">URL Fragment Text Directives</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2023-03-28">28 March 2023</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2023-04-06">6 April 2023</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -994,131 +1003,307 @@ action. Multiple directives may appear in the fragment directive.</p>
     <a class="self-link" href="#example-9acce0ff"></a> <code>https://example.com#:~:text=foo&amp;text=bar&amp;unknownDirective</code> 
     <p>Contains 2 text directives and one unknown directive.</p>
    </div>
-   <p>To prevent impacting page operation, it is stripped from a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>'s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url">URL</a> to prevent interaction with author script. This also ensures
-future directives can be added without web compatibility risk.</p>
+   <p>To prevent impacting page operation, it is stripped from script-accessible APIs to prevent
+interaction with author script. This also ensures future directives can be added without web
+compatibility risk.</p>
    <h4 class="heading settled" data-level="3.3.1" id="processing-the-fragment-directive"><span class="secno">3.3.1. </span><span class="content">Processing the fragment directive</span><a class="self-link" href="#processing-the-fragment-directive"></a></h4>
-   <p>The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive③">fragment directive</a> is processed and removed from the fragment whenever the
-UA sets the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url①">URL</a> on a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">Document</a>. This is defined with the
-following additions and changes.</p>
-   <p>To the definition of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a>, add:</p>
-   <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-dom" title="DOM Standard">[DOM]</a>:</strong></p>
-    <p><em> Each document has an associated <dfn class="dfn-paneled" data-dfn-for="Document" data-dfn-type="dfn" data-lt="fragment directive" data-noexport id="document-fragment-directive">fragment
-    directive</dfn> which is either null or an ASCII string holding data used
-    by the UA to process the resource. It is initially null. </em></p>
-   </blockquote>
-   <div class="algorithm" data-algorithm="split the fragment from the fragment directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="split-the-fragment-from-the-fragment-directive">split the fragment from the fragment directive</dfn>, given an ASCII string <var>raw fragment</var> and returning a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#tuple" id="ref-for-tuple">tuple</a> consisting of a <code>fragment</code> and a <code>fragment directive</code> (both ASCII strings), run these steps: 
-    <ol class="algorithm">
+   <p>This section describes the mechanism by which the fragment directive is hidden
+from script and how it fits into <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-and-session-history"><cite>HTML</cite> § 7.4 Navigation and session history</a>.</p>
+   <div class="note" role="note">
+     The summarized changes in this section: 
+    <ul>
      <li data-md>
-      <p>Let <var>position</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable">position variable</a> pointing to the first code
-point of the first instance, if one exists, of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive delimiter</a> in <var>raw
-fragment</var>, or past the end of <var>raw fragment</var> otherwise.</p>
+      <p>Session history entries now include a new "directive state" item</p>
      <li data-md>
-      <p>Let <var>fragment</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point-substring-by-positions" id="ref-for-code-point-substring-by-positions">code point substring by positions</a> of <var>raw fragment</var> from the
-start of <var>raw fragment</var> to <var>position</var>.</p>
+      <p>All new entries are created with a directive state with an empty value. If the new URL includes
+  a fragment directive it will be written to the state’s value (otherwise it remains null).</p>
      <li data-md>
-      <p>Let <var>fragmentDirective</var> be an ASCII string, initially empty.</p>
-     <li data-md>
-      <p>Advance <var>position</var> by the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-code-point-length" id="ref-for-string-code-point-length">code point length</a> of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive
-delimiter</a>.</p>
-     <li data-md>
-      <p>If <var>position</var> does not point past the end of <var>raw fragment</var>:</p>
-      <ol>
+      <p>Any time a URL potentially including a fragment directive is written to a session history entry,
+  extract the fragment directive from the URL and store it in a directive state item of the
+  entry. There are three such points where a URL can potentially include a directive:</p>
+      <ul>
        <li data-md>
-        <p>Set <var>fragmentDirective</var> to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point-substring-to-the-end-of-the-string" id="ref-for-code-point-substring-to-the-end-of-the-string">code point substring to the end of the string</a> <var>raw fragment</var> starting from <var>position</var></p>
-      </ol>
+        <p>In the "navigate" steps for typical cross-document navigations</p>
+       <li data-md>
+        <p>In the "navigate to a fragment" steps for fragment based same-document navigations</p>
+       <li data-md>
+        <p>In the "URL and history update steps" for synchronous updates such as
+  pushState/replaceState.</p>
+      </ul>
      <li data-md>
-      <p>Return the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#tuple" id="ref-for-tuple①">tuple</a> (<var>fragment</var>, <var>fragmentDirective</var>).</p>
-    </ol>
+      <p>Same-document navigations that change only the fragment, and the new URL doesn’t specify a
+  directive, will create an entry whose directive state refers to the previous entry’s directive
+  state.</p>
+    </ul>
    </div>
-   <p>Whenever the fragment directive is stripped from the URL, the
-Document’s <a data-link-type="dfn" href="#document-fragment-directive" id="ref-for-document-fragment-directive">fragment directive</a> is set to the content of the fragment directive.</p>
-   <p>Add a series of steps that will process a fragment directive on a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url②">URL</a>:</p>
+   <div class="issue" id="issue-b598ad03"><a class="self-link" href="#issue-b598ad03"></a> The <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching:~:text=Set%20entry%27s%20URL%20to%20currentURL"> create navigation params by fetching</a> steps also write a URL to an entry. As written, that URL always <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching:~:text=Set%20locationURL%20to%20response%27s%20location%20URL%20given%20currentURL%27s%20fragment."> uses the fragment from an existing entry</a> so the directive would already be removed. However,
+    I think that’s wrong. If the redirect URL includes a fragment it should be used, see <a href="https://www.rfc-editor.org/rfc/rfc7231#section-7.1.2">RFC7231</a>. Browsers all <a href="https://wpt.fyi/results/fetch/redirect-navigate/preserve-fragment.html">implement the
+    RFC behavior</a> so it seems like this is a spec bug in HTML. If fixed, this is a fourth place
+    where the directive would have to be removed. </div>
+   <p>In <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-infrastructure"><cite>HTML</cite> § 7.4.1 Session history</a>, define <a data-link-type="dfn" href="#directive-state" id="ref-for-directive-state">directive state</a>:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-dom" title="DOM Standard">[DOM]</a>:</strong></p>
-    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-and-consume-fragment-directive">process and consume fragment directive</dfn> from a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">URL</a> <var>url</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a> <var>document</var>, run these steps:</p>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-infrastructure"><cite>HTML</cite> § 7.4.1 Session history</a>:</strong></p>
+    <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="directive-state">directive state</dfn> holds the value of the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive③">fragment directive</a> at the time the session
+  history entry was created and is used to invoke directives, such as text highlighting, whenever
+  the entry is traversed. It has:</p>
+    <ul>
+     <li data-md>
+      <p><dfn class="dfn-paneled" data-dfn-for="directive state" data-dfn-type="dfn" data-noexport id="directive-state-value">value</dfn>, the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> ASCII string or null,
+  initially null.</p>
+    </ul>
+    <p>A <a data-link-type="dfn" href="#directive-state" id="ref-for-directive-state①">directive state</a> may be shared across contiguous session history entries.</p>
+    <div class="note" role="note">
+     <p>The fragment directive is removed from the URL before the URL is set to the session
+      history entry. It is instead stored in the directive state. This prevents it from being
+      visible to script APIs so that a directive can be specified without interfering with a
+      page’s operation.</p>
+     <p>The fragment directive is stored in the directive state object, rather than a raw string,
+      since the same directive state can be shared across multiple contiguous session history
+      entries. On a traversal, the directive is only processed (i.e. search text and highlight) if
+      the directive state has changed between two entries.</p>
+    </div>
+   </blockquote>
+   <p>To the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-entry">session history entry</a>, add:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-entries"><cite>HTML</cite> § 7.4.1.1 Session history entries</a>:</strong></p>
+    <div class="monkeypatch">
+     A session history entry is a struct with the following items: 
+     <ul>
+      <li data-md>
+       <p>...</p>
+      <li data-md>
+       <p>persisted user state, which is implementation-defined, initially null</p>
+      <li data-md>
+       <p><span class="diff"><dfn class="dfn-paneled" data-dfn-for="she" data-dfn-type="dfn" data-noexport id="she-directive-state">directive state</dfn>, a <a data-link-type="dfn" href="#directive-state" id="ref-for-directive-state②">directive state</a>,
+initially a new <a data-link-type="dfn" href="#directive-state" id="ref-for-directive-state③">directive state</a></span></p>
+     </ul>
+    </div>
+   </blockquote>
+   <p>Add a helper algorithm for removing and returning a fragment directive string from a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url">URL</a>:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
+    <div class="note" role="note"> This algorithm makes a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter①">fragment directive
+    delimiter</a>. The returned <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a> includes all characters that follow the
+    delimiter but does not include the delimiter. </div>
+    <div class="issue" id="issue-827449be"><a class="self-link" href="#issue-827449be"></a> If a URL’s fragment ends with ':~:' (i.e. empty directive), this will return null which is
+    treated as the URL not specifying an explicit directive (and avoids clobbering an existing
+    one. But maybe in this case we should return the empty string? That way a page can explicitly
+    clear directives/highlights by navigating/pushState to '#:~:'. </div>
+    <p>To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="remove-the-fragment-directive">remove the fragment directive</dfn> from a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①">URL</a> <var>url</var>, run these steps:</p>
     <ol>
      <li data-md>
       <p>Let <var>raw fragment</var> be equal to <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment①">fragment</a>.</p>
      <li data-md>
-      <p>If <var>raw fragment</var> is non-null and contains the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter③">fragment directive
-  delimiter</a> as a substring:</p>
+      <p>Let <var>fragment directive</var> be null.</p>
+     <li data-md>
+      <p>If <var>raw fragment</var> is non-null and contains the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter②">fragment directive delimiter</a> as a
+  substring:</p>
       <ol>
        <li data-md>
-        <p>Let <var>components</var> be the result of running <a data-link-type="dfn" href="#split-the-fragment-from-the-fragment-directive" id="ref-for-split-the-fragment-from-the-fragment-directive">split the fragment from the fragment
-  directive</a> on <var>raw fragment</var>.</p>
+        <p>Let <var>position</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-position-variable" id="ref-for-string-position-variable">position variable</a> pointing to the first code
+  point of the first instance, if one exists, of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter③">fragment directive delimiter</a> in <var>raw fragment</var>, or past the end of <var>raw fragment</var> otherwise.</p>
        <li data-md>
-        <p>Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment②">fragment</a> to <var>components</var>’ <code>fragment</code>.</p>
+        <p>Let <var>new fragment</var> be the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point-substring-by-positions" id="ref-for-code-point-substring-by-positions">code point substring by positions</a> of <var>raw fragment</var> from
+  the start of <var>raw fragment</var> to <var>position</var>.</p>
        <li data-md>
-        <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-fragment-directive" id="ref-for-document-fragment-directive①">fragment directive</a> to <var>components</var>’ <code>fragment directive</code>.</p>
-        <div class="note" role="note">This is stored on the document but currently not web-exposed</div>
+        <p>Advance <var>position</var> by the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-code-point-length" id="ref-for-string-code-point-length">code point length</a> of the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter④">fragment directive
+  delimiter</a>.</p>
+       <li data-md>
+        <p>If <var>position</var> does not point past the end of <var>raw fragment</var>:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>fragment directive</var> to the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-point-substring-to-the-end-of-the-string" id="ref-for-code-point-substring-to-the-end-of-the-string">code point substring to the end of the string</a> <var>raw fragment</var> starting from <var>position</var></p>
+        </ol>
+       <li data-md>
+        <p>Set <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-fragment" id="ref-for-concept-url-fragment②">fragment</a> to <var>new fragment</var>.</p>
       </ol>
+     <li data-md>
+      <p>Return <var>fragment directive</var>.</p>
     </ol>
+    <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
+     the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> is the string
+     "text=foo". </div>
    </blockquote>
-   <div class="note" role="note"> These changes make a URL’s fragment end at the <a data-link-type="dfn" href="#fragment-directive-delimiter" id="ref-for-fragment-directive-delimiter④">fragment directive
-  delimiter</a>. The <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive④">fragment directive</a> includes all characters that follow,
-  but not including, the delimiter. </div>
-   <div class="example" id="example-775c8cc2"><a class="self-link" href="#example-775c8cc2"></a> <code>https://example.org/#test:~:text=foo</code> will be parsed such that
-the fragment is the string "test" and the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑤">fragment directive</a> is the string
-"text=foo". </div>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object"> create and initialize a Document object</a> steps to parse and remove the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑥">fragment directive</a> by inserting the following steps right before the
-setting <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url③">URL</a> (<a href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#initialise-the-document-object">currently</a> step 9):</p>
+   <p>The next three monkeypatches modify the creation of a session history entry, where the URL might
+contain a fragment directive, to remove the fragment directive and store it in the <a data-link-type="dfn" href="#directive-state" id="ref-for-directive-state④">directive
+state</a>.</p>
+   <p>In the definition of <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate" id="ref-for-navigate">navigate</a>:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <ol start="9">
-     <li data-md>
-      <p>Run the <a data-link-type="dfn" href="#process-and-consume-fragment-directive" id="ref-for-process-and-consume-fragment-directive">process and consume fragment directive</a> steps on <var>creationURL</var> and <var>document</var>.</p>
-     <li data-md>
-      <p>Set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url④">URL</a> to be <var>creationURL</var>.</p>
-    </ol>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation"><cite>HTML</cite> § 7.4.2.2 Beginning navigation</a>:</strong></p>
+    <div class="monkeypatch">
+     To navigate a navigable navigable to a URL <var>url</var>...: 
+     <ol>
+      <li data-md>
+       <p>...</p>
+      <li value="14">Set navigable’s ongoing navigation to navigationId.
+      <li data-md>
+       <p>If url’s scheme is "javascript", then...</p>
+      <li data-md>
+       <p>In parallel, run these steps:</p>
+       <ol>
+        <li data-md>
+         <p>...</p>
+        <li value="5">If url is about:blank, then set documentState’s origin to documentState’s initiator origin.
+        <li data-md>
+         <p>Otherwise, if url is about:srcdoc, then set documentState’s origin to navigable’s parent’s active document’s origin.</p>
+        <li data-md>
+         <strike>Let historyEntry be a new session history entry, with its URL set to url and
+its document state set to documentState.</strike>
+        <li value="7"><span class="diff">Let <var>fragment directive</var> be the result of running <a data-link-type="dfn" href="#remove-the-fragment-directive" id="ref-for-remove-the-fragment-directive">remove the
+fragment directive</a> on <var>url</var>.</span>
+        <li data-md>
+         <p><span class="diff">Let <var>directive state</var> be a new <a data-link-type="dfn" href="#directive-state" id="ref-for-directive-state⑤">directive
+state</a> with <a data-link-type="dfn" href="#directive-state-value" id="ref-for-directive-state-value">value</a> set to <var>fragment directive</var>.</span></p>
+        <li data-md>
+         <p><span class="diff">Let historyEntry be a new session history entry, with its URL
+set to <var>url</var>, its document state set to documentState, and its <a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state">directive state</a> set to <var>directive state</var>.</span></p>
+        <li data-md>
+         <p>Let navigationParams be null.</p>
+        <li data-md>
+         <p>...</p>
+       </ol>
+     </ol>
+    </div>
    </blockquote>
-   <p>Amend the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history"> traverse the history</a> steps to process the <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a> during a history navigation by inserting steps before setting the <var>newDocument</var>’s URL (<a href="https://html.spec.whatwg.org/commit-snapshots/6ccb1ec8b8e79116880ea7a519d5a96fe8558afc/#traverse-the-history">currently</a> step 6).</p>
+   <p>In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid">navigate to a fragment</a>:</p>
    <blockquote>
-    <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <ol start="6">
-     <li data-md>
-      <p>Let <var>processedURL</var> be a copy of <var>entry</var>’s URL.</p>
-     <li data-md>
-      <p>Run the <a data-link-type="dfn" href="#process-and-consume-fragment-directive" id="ref-for-process-and-consume-fragment-directive①">process and consume fragment directive</a> steps on <var>processedURL</var> and <var>document</var>.</p>
-     <li data-md>
-      <p>Set <var>newDocument</var>’s URL to <var>processedURL</var>.</p>
-    </ol>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid"><cite>HTML</cite> § 7.4.2.3.3 Fragment navigations</a>:</strong></p>
+    <div class="monkeypatch">
+     To navigate to a fragment given navigable <var>navigable</var>, ...: 
+     <ol>
+      <li data-md>
+       <p><span class="diff">Let <var>directive state</var> be navigable’s active session history
+entry’s <a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state①">directive state</a>.</span></p>
+      <li data-md>
+       <p><span class="diff">Let <var>fragment directive</var> be the result of running <a data-link-type="dfn" href="#remove-the-fragment-directive" id="ref-for-remove-the-fragment-directive①">remove the fragment directive</a> on <var>url</var>.</span></p>
+      <li data-md>
+       <p><span class="diff">If <var>url</var> does not equal <var>navigable</var>’s active session history
+entry’s URL with exclude fragments set to true OR <var>fragment directive</var> is not null:</span></p>
+       <div class="note" role="note">Otherwise, when only the fragment has changed and it did not specify
+a directive, the active entry’s directive state is reused. This prevents a fragment
+change from clobbering highlights.</div>
+       <ol>
+        <li data-md>
+         <p><span class="diff">Let <var>directive state</var> be a new <a data-link-type="dfn" href="#directive-state" id="ref-for-directive-state⑥">directive state</a> with <a data-link-type="dfn" href="#directive-state-value" id="ref-for-directive-state-value①">value</a> set to <var>fragment directive</var>.</span></p>
+       </ol>
+      <li data-md>
+       <p>Let historyEntry be a new session history entry, with</p>
+       <ul>
+        <li data-md>
+         <p>URL url</p>
+        <li data-md>
+         <p>document state navigable’s active session history entry’s document state</p>
+        <li data-md>
+         <p>scroll restoration mode navigable’s active session history entry’s scroll restoration
+mode</p>
+        <li data-md>
+         <p><span class="diff"><a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state②">directive state</a> <var>directive state</var></span></p>
+       </ul>
+      <li data-md>
+       <p>Let entryToReplace be navigable’s active session history entry if historyHandling is
+"replace", otherwise null.</p>
+      <li data-md>
+       <p>...</p>
+     </ol>
+    </div>
+   </blockquote>
+   <p>In the definition of <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps">URL and history update steps</a>:</p>
+   <blockquote>
+    <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-non-frag-sync"><cite>HTML</cite> § 7.4.4 Non-fragment synchronous "navigations"</a>:</strong></p>
+    <div class="monkeypatch">
+     The URL and history update steps, given a Document <var>document</var>, ...: 
+     <ol>
+      <li data-md>
+       <p>Let <var>navigable</var> be <var>document</var>’s node navigable.</p>
+      <li data-md>
+       <p>Let <var>activeEntry</var> be <var>navigable</var>’s active session history entry.</p>
+      <li data-md>
+       <p><span class="diff">Let <var>fragment directive</var> be the result of running <a data-link-type="dfn" href="#remove-the-fragment-directive" id="ref-for-remove-the-fragment-directive②">remove the
+fragment directive</a> on <var>newUrl</var>.</span></p>
+      <li data-md>
+       <p>Let <var>historyEntry</var> be a new session history entry, with</p>
+       <ul>
+        <li data-md>
+         <p>URL <var>newUrl</var></p>
+        <li data-md>
+         <p>...</p>
+        <li data-md>
+         <p><span class="diff"><a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state③">directive state</a> <var>activeEntry</var>’s <a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state④">directive
+state</a></span></p>
+       </ul>
+      <li data-md>
+       <p>If <var>document</var>’s is initial about:blank is true, then set historyHandling to "replace".</p>
+      <li data-md>
+       <p>If historyHandling is "push", then:</p>
+       <ol>
+        <li data-md>
+         <p>Increment document’s history object’s index.</p>
+        <li data-md>
+         <p>Set document’s history object’s length to its index + 1.</p>
+        <li data-md>
+         <p><span class="diff">If <var>newUrl</var> does not equal <var>activeEntry</var>’s URL with exclude
+fragments set to true OR <var>fragment directive</var> is not null, then:</span></p>
+         <div class="note" role="note">Otherwise, when only the fragment has changed and it did not specify
+a directive, the active entry’s directive state is reused. This prevents a fragment
+change from clobbering highlights.</div>
+         <ol>
+          <li data-md>
+           <p><span class="diff">Let <var>historyEntry</var>’s <a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state⑤">directive state</a> be a new <a data-link-type="dfn" href="#directive-state" id="ref-for-directive-state⑦">directive state</a> with <a data-link-type="dfn" href="#directive-state-value" id="ref-for-directive-state-value②">value</a> set to <var>fragment
+directive</var>.</span></p>
+         </ol>
+       </ol>
+      <li data-md>
+       <p><span class="diff">Otherwise, if <var>fragment directive</var> is not null, set <var>historyEntry</var>’s <a data-link-type="dfn" href="#she-directive-state" id="ref-for-she-directive-state⑥">directive state</a>'s <a data-link-type="dfn" href="#directive-state-value" id="ref-for-directive-state-value③">value</a> to <var>fragment
+directive</var>.</span></p>
+      <li data-md>
+       <p>If serializedData is not null, then restore the history object state given document and
+newEntry.</p>
+     </ol>
+    </div>
    </blockquote>
    <div class="note" role="note">
-    <p> The changes in this section imply that a URL is only stripped of its fragment
-    directive when it is set on a Document. Notably, since a window’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location" id="ref-for-location">Location</a></code> object is a representation of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url①">URL</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document">active
-    document</a>, all getters on it will show a fragment-directive-stripped
+    <p> Since a Document is populated from a history entry, its <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-url" id="ref-for-concept-document-url">URL</a> will not include the
+    fragment directive. Similarly, since a window’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location" id="ref-for-location">Location</a></code> object is a representation of the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url" id="ref-for-concept-url②">URL</a> of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document" id="ref-for-nav-document">active document</a>, all getters on it will show a fragment-directive-stripped
     version of the URL. </p>
+    <p> Additionally, since the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent" id="ref-for-hashchangeevent">HashChangeEvent</a></code> is <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#updating-the-document"> fired in response to a changed fragment</a> between URLs of session history entries, <code>hashchange</code> will not be fired if a navigation or traversal changes only the fragment
+    directive. </p>
     <p> Some examples are provided to help clarify various edge cases. </p>
    </div>
-   <div class="example" id="example-609a3312">
-    <a class="self-link" href="#example-609a3312"></a> 
-<pre>window.location = 'https://example.com#foo:~:bar';
+   <div class="example" id="example-c4fd5b50">
+    <a class="self-link" href="#example-c4fd5b50"></a> 
+<pre>window.location = "https://example.com#page1:~:hello";
+console.log(window.location.href); // 'https://example.com#page1'
+console.log(window.location.hash); // '#page1'
 </pre>
-    <p>The page loads and when the document’s URL is set the fragment directive is
-  stripped out during the "create and initialize a Document object" steps.</p>
-<pre>console.log(window.location.href); // 'https://example.com#foo'
-console.log(window.location.hash); // '#foo'
+    <p>The initial navigation created a new session history entry. The entry’s URL is stripped of the
+  fragment directive: "https://example.com#page1". The entry’s directive state value is set to
+  "hello". Since the document is populated from the entry, web APIs don’t include the fragment
+  directive in URLs.</p>
+<pre>location.hash = "page2";
+console.log(location.href); // 'https://example.com#page2'
 </pre>
-    <p>Since same document navigations are made by adding a new session history
-  entry and using the "traverse the history" steps, the the fragment directive
-  will be stripped here as well.</p>
-<pre>window.location.hash = 'fizz:~:buzz';
-console.log(window.location.href); // 'https://example.com#fizz'
-console.log(window.location.hash); // '#fizz'
+    <p>A same document navigation changed only the fragment. This adds a new session history entry in the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid">navigate to
+  a fragment</a> steps. However, since only the fragment changed, the new entry’s directive state
+  points to the same state as the first entry, with a value of "bar".</p>
+<pre>onhashchange = () => console.assert(false, "hashchange doesn’t fire.");
+location.hash = "page2:~:world";
+console.log(location.href); // 'https://example.com#page2'
+onhashchange = null;
 </pre>
-    <p>The hashchange event is dispatched when only the fragment directive changes
-  because the comparison for it is done on the URLs in the session history
-  entries, where the fragment directive hasn’t been removed.</p>
-<pre>onhashchange = () => {console.log('HASHCHANGE');};
-window.location.hash = 'fizz:~:zillch'; // 'HASHCHANGE'
-console.log(window.location.href); // 'https://example.com#fizz'
-console.log(window.location.hash); // '#fizz'
+    <p>A same document navigation changes only the fragment but includes a fragment directive. Since an
+  explicit directive was provided, the new entry includes its own directive state with a value of
+  "fizz".</p>
+    <p>The hashchange event is not fired since the page-visible fragment is unchanged; only the fragment
+  directive changed. This is because the comparison for hashchange is done on the URLs in the
+  session history entries, where the fragment directive has been removed.</p>
+<pre>history.pushState("", "", "page3");
+console.log(location.href); // 'https://example.com/page3'
 </pre>
+    <p>pushState creates a new session history entry for the same document. However, since the
+  non-fragment URL has changed, this entry has its own directive state with value currently null.</p>
    </div>
-   <div class="example" id="example-42953739">
-    <a class="self-link" href="#example-42953739"></a> In other cases where a Document’s URL is not set by the UA, there is no
+   <div class="example" id="example-f4d8b076">
+    <a class="self-link" href="#example-f4d8b076"></a> In other cases where a URL is not set to a session history entry, there is no
   fragment directive stripping. 
     <p>For URL objects:</p>
 <pre>let url = new URL('https://example.com#foo:~:bar');
@@ -1137,19 +1322,6 @@ console.log(document.url.hash); // '#foo:~:bar'
   console.log(anchor.hash); // '#foo:~:bar'
 &lt;/script>
 </pre>
-   </div>
-   <div class="example" id="example-c1edb88d">
-    <a class="self-link" href="#example-c1edb88d"></a> History pushState will create a session history entry where the URL’s
-  fragment directive isn’t stripped. However, traversing to the entry will
-  cause it to set its URL on the document which will process the fragment
-  directive before setting it on the Document (but the fragment directive
-  remains on the entry). 
-<pre>history.pushState({}, 'title', 'index.html#foo:~:bar');
-window.location = 'newpage.html';
-// on newpage.html
-history.back();
-</pre>
-    <p>Results in the current document having "bar" as the fragment directive.</p>
    </div>
    <h4 class="heading settled" data-level="3.3.2" id="parsing-the-fragment-directive"><span class="secno">3.3.2. </span><span class="content">Parsing the fragment directive</span><a class="self-link" href="#parsing-the-fragment-directive"></a></h4>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-directive">text directive</dfn> is a kind of <a data-link-type="dfn" href="#directives" id="ref-for-directives">directive</a> representing a range of
@@ -1349,9 +1521,9 @@ has been successfully found</em>.</p>
    <p>This specification does not specify exactly how a UA achieves this as there are
 multiple solutions with differing tradeoffs. For example, a UA <em>may</em> continue to walk the tree even after a match is found in <a data-link-type="dfn" href="#find-a-range-from-a-text-directive" id="ref-for-find-a-range-from-a-text-directive">find a range from a
 text directive</a>.  Alternatively, it <em>may</em> schedule an asynchronous task
-to find and set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a>'s indicated part.</p>
+to find and set the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document">Document</a>'s indicated part.</p>
    <h4 class="heading settled" data-level="3.4.4" id="restricting-the-text-fragment"><span class="secno">3.4.4. </span><span class="content">Restricting the Text Fragment</span><a class="self-link" href="#restricting-the-text-fragment"></a></h4>
-   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a> to include a new
+   <p>Amend the definition of a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> and of a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①">Document</a> to include a new
 boolean <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation">text directive user activation</a> field:</p>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-fetch" title="Fetch Standard">[FETCH]</a>:</strong></p>
@@ -1360,17 +1532,17 @@ boolean <a data-link-type="dfn" href="#document-text-directive-user-activation" 
    </blockquote>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-text-directive-user-activation">text directive user activation</dfn>, which is a boolean,
+    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document②">Document</a> has a <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-text-directive-user-activation">text directive user activation</dfn>, which is a boolean,
   initially false.</p>
     <div class="note" role="note">
       <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation①">text directive user activation</a> provides the necessary user gesture signal to allow
     a single activation of a text fragment. It is set to true during document loading only if the
     navigation occurred as a result of a user activation and is propagated across client-side
     redirects. 
-     <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>'s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation②">text directive user activation</a> isn’t used to activate a text
+     <p>If a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document③">Document</a>'s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation②">text directive user activation</a> isn’t used to activate a text
     fragment, it is instead used to set a new navigation <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">request</a>'s <a data-link-type="dfn" href="#request-text-directive-user-activation" id="ref-for-request-text-directive-user-activation">text directive user activation</a> to true. In this way, a <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation③">text directive user activation</a> can be propagated
-    from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> to another across a navigation.</p>
-     <p>Both <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a>'s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation④">text directive user activation</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-directive-user-activation" id="ref-for-request-text-directive-user-activation①">text directive user activation</a> are always set to false when used, such that a
+    from one <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document④">Document</a> to another across a navigation.</p>
+     <p>Both <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑤">Document</a>'s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation④">text directive user activation</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">request</a>'s <a data-link-type="dfn" href="#request-text-directive-user-activation" id="ref-for-request-text-directive-user-activation①">text directive user activation</a> are always set to false when used, such that a
     single user activation cannot be reused to activate more than one text fragment.</p>
     </div>
    </blockquote>
@@ -1401,7 +1573,7 @@ boolean <a data-link-type="dfn" href="#document-text-directive-user-activation" 
    </div>
    <blockquote>
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
-    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allow-text-fragment-scroll">allow text fragment scroll</dfn>, which is a
+    <p>Each <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑥">Document</a> has an <dfn class="dfn-paneled" data-dfn-for="document" data-dfn-type="dfn" data-noexport id="document-allow-text-fragment-scroll">allow text fragment scroll</dfn>, which is a
   boolean, initially false.</p>
     <div class="note" role="note">
      <p> <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll">allow text fragment scroll</a> is used to determine whether a text fragment will
@@ -1440,11 +1612,9 @@ and initialize a Document object</a> steps by adding the following steps before 
       <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll①">allow text fragment scroll</a> by following these sub-steps:</p>
       <ol>
        <li data-md>
-        <p>If <var>document</var>’s <a data-link-type="dfn" href="#document-fragment-directive" id="ref-for-document-fragment-directive②">fragment directive</a> field is null or empty, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll②">allow text fragment scroll</a> to false and abort these sub-steps.</p>
-       <li data-md>
         <p>Let <var>text directive user activation</var> be the value of <var>document</var>’s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation⑧">text directive user activation</a> and set <var>document</var>’s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation⑨">text directive user activation</a> to false.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll③">allow text fragment scroll</a> to true and abort these sub-steps.</p>
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"none"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll②">allow text fragment scroll</a> to true and abort these sub-steps.</p>
         <div class="note" role="note">
          <p> If a navigation originates from browser UI, it’s always ok to allow it
       since it’ll be user triggered and the page/script isn’t providing the
@@ -1462,19 +1632,19 @@ and initialize a Document object</a> steps by adding the following steps before 
          <p> See <a href="https://w3c.github.io/webappsec-fetch-metadata/#directly-user-initiated">sec-fetch-site</a> in <a data-link-type="biblio" href="#biblio-fetch-metadata" title="Fetch Metadata Request Headers">[FETCH-METADATA]</a> for a more detailed discussion of how this applies. </p>
         </div>
        <li data-md>
-        <p>If <var>text directive user activation</var> is false, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll④">allow text fragment scroll</a> to false and abort these sub-steps.</p>
+        <p>If <var>text directive user activation</var> is false, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll③">allow text fragment scroll</a> to false and abort these sub-steps.</p>
        <li data-md>
-        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑤">allow text fragment scroll</a> to true and abort these
+        <p>If the <var>navigationParam</var>’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">request</a> has a <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">sec-fetch-site</a> header and its value is <code>"same-origin"</code> set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll④">allow text fragment scroll</a> to true and abort these
   sub-steps.</p>
        <li data-md>
         <p>If <var>document</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc" id="ref-for-concept-document-bc">browsing context</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context" id="ref-for-top-level-browsing-context">top-level browsing
-  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑥">allow text fragment scroll</a> to true and abort these sub-steps.</p>
+  context</a> and its <a href="https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group">group</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set" id="ref-for-browsing-context-set">browsing context set</a> has length 1, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑤">allow text fragment scroll</a> to true and abort these sub-steps.</p>
         <div class="note" role="note"> i.e. Only allow navigation from a cross-origin element/script if the
     document is loaded in a noopener context. That is, a new top level
     browsing context group to which the navigator does not have script access
     and which can be placed into a separate process. </div>
        <li data-md>
-        <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑦">allow text fragment scroll</a> to false.</p>
+        <p>Otherwise, set <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑥">allow text fragment scroll</a> to false.</p>
       </ol>
     </ol>
    </blockquote>
@@ -1501,13 +1671,13 @@ steps of the task queued in step 2:</p>
      <li data-md>
       <p>If document has no parser, or its parser has stopped parsing, or the user
   agent has reason to believe the user is no longer interested in scrolling to
-  the fragment, then set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑧">allow text fragment scroll</a> to false and abort these steps.</p>
+  the fragment, then set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑦">allow text fragment scroll</a> to false and abort these steps.</p>
      <li data-md>
       <p>Scroll to the fragment given in document’s URL. If this does not find an
   indicated part, then try to scroll to the fragment for
   document.</p>
      <li data-md>
-      <p>Set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑨">allow text fragment scroll</a> to false.</p>
+      <p>Set <em>document</em>’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑧">allow text fragment scroll</a> to false.</p>
     </ol>
    </blockquote>
    <h3 class="heading settled" data-level="3.5" id="navigating-to-text-fragment"><span class="secno">3.5. </span><span class="content">Navigating to a Text Fragment</span><a class="self-link" href="#navigating-to-text-fragment"></a></h3>
@@ -1558,7 +1728,7 @@ indicated part processing model to return a <a data-link-type="dfn" href="https:
     would resolve this problem. </div>
      <li data-md>
       <p><a href="https://wicg.github.io/document-policy#algo-get-policy-value">Get
-  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">Document</a>. If the result is false:</p>
+  the policy value</a> for <code>force-load-at-top</code> in the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a>. If the result is false:</p>
       <ol>
        <li data-md>
         <p>If <var>range</var> wasn’t produced as a result of a text fragment, or if the
@@ -1584,9 +1754,9 @@ beginning of the processing model for the <a data-link-type="dfn" href="https://
     <p><strong>Monkeypatching <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>:</strong></p>
     <ol>
      <li data-md>
-      <p>Let <var>fragment directive string</var> be the document’s <a data-link-type="dfn" href="#document-fragment-directive" id="ref-for-document-fragment-directive③">fragment directive</a>.</p>
+      <p>Let <var>fragment directive string</var> be the document’s <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry">latest entry</a>’s <a data-link-type="dfn" href="#fragment-directive" id="ref-for-fragment-directive⑦">fragment directive</a>.</p>
      <li data-md>
-      <p>If the document’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll①⓪">allow text fragment scroll</a> is true then:</p>
+      <p>If the document’s <a data-link-type="dfn" href="#document-allow-text-fragment-scroll" id="ref-for-document-allow-text-fragment-scroll⑨">allow text fragment scroll</a> is true then:</p>
       <ol>
        <li data-md>
         <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
@@ -1690,7 +1860,7 @@ text=bar,baz
   list.</p>
    </div>
    <div class="algorithm" data-algorithm="process a fragment directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①②">Document</a> <var>document</var>, run these steps: 
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> <var>document</var>, run these steps: 
     <div class="note" role="note"> This algorithm takes as input a <var>fragment directive input</var>, that is the
   raw text of the fragment directive and the <var>document</var> over which it operates.
   It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①②">ranges</a> that are to be visually
@@ -1725,7 +1895,7 @@ directive</a> steps on <var>directive</var>.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="find a range from a text directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑦">text directive</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①③">Document</a> <var>document</var>, run the
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="find-a-range-from-a-text-directive">find a range from a text directive</dfn>, given a <a data-link-type="dfn" href="#text-directive" id="ref-for-text-directive⑦">text directive</a> <var>parsedValues</var> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑨">Document</a> <var>document</var>, run the
 following steps: 
     <div class="note" role="note">
       This algorithm takes as input a successfully parsed text directive and a
@@ -2318,9 +2488,9 @@ persisted state</a> steps by inserting a new step after 2:</p>
    <ol start="3">
     <li data-md>
      <p><a href="https://wicg.github.io/document-policy#algo-get-policy-value">Get
-the document policy value</a> of the "force-load-at-top" feature for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①④">Document</a>. If
+the document policy value</a> of the "force-load-at-top" feature for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⓪">Document</a>. If
 the result is true, then the user agent should not restore the scroll
-position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①⑤">Document</a> or any of its scrollable regions.</p>
+position for the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document①①">Document</a> or any of its scrollable regions.</p>
    </ol>
    <h3 class="heading settled" data-level="3.8" id="feature-detectability"><span class="secno">3.8. </span><span class="content">Feature Detectability</span><a class="self-link" href="#feature-detectability"></a></h3>
    <p>For feature detectability, we propose adding a new FragmentDirective interface
@@ -2492,18 +2662,19 @@ manipulations
    <li><a href="#document-allow-text-fragment-scroll">allow text fragment scroll</a><span>, in § 3.4.4</span>
    <li><a href="#characterstring">CharacterString</a><span>, in § 3.3.3</span>
    <li><a href="#directives">directives</a><span>, in § 3.3</span>
+   <li>
+    directive state
+    <ul>
+     <li><a href="#directive-state">definition of</a><span>, in § 3.3.1</span>
+     <li><a href="#she-directive-state">dfn for she</a><span>, in § 3.3.1</span>
+    </ul>
    <li><a href="#text-directive-end">end</a><span>, in § 3.3.2</span>
    <li><a href="#explicitchar">ExplicitChar</a><span>, in § 3.3.3</span>
    <li><a href="#find-a-range-from-a-node-list">find a range from a node list</a><span>, in § 3.5.1</span>
    <li><a href="#find-a-range-from-a-text-directive">find a range from a text directive</a><span>, in § 3.5.1</span>
    <li><a href="#find-a-string-in-range">find a string in range</a><span>, in § 3.5.1</span>
    <li><a href="#first-common-ancestor">first common ancestor</a><span>, in § 3.5</span>
-   <li>
-    fragment directive
-    <ul>
-     <li><a href="#fragment-directive">definition of</a><span>, in § 3.3</span>
-     <li><a href="#document-fragment-directive">dfn for Document</a><span>, in § 3.3.1</span>
-    </ul>
+   <li><a href="#fragment-directive">fragment directive</a><span>, in § 3.3</span>
    <li>
     FragmentDirective
     <ul>
@@ -2523,10 +2694,9 @@ manipulations
    <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in § 3.3.3</span>
    <li><a href="#text-directive-prefix">prefix</a><span>, in § 3.3.2</span>
    <li><a href="#process-a-fragment-directive">process a fragment directive</a><span>, in § 3.5.1</span>
-   <li><a href="#process-and-consume-fragment-directive">process and consume fragment directive</a><span>, in § 3.3.1</span>
+   <li><a href="#remove-the-fragment-directive">remove the fragment directive</a><span>, in § 3.3.1</span>
    <li><a href="#search-invisible">search invisible</a><span>, in § 3.5.1</span>
    <li><a href="#shadow-including-parent">shadow-including parent</a><span>, in § 3.5</span>
-   <li><a href="#split-the-fragment-from-the-fragment-directive">split the fragment from the fragment directive</a><span>, in § 3.3.1</span>
    <li><a href="#text-directive-start">start</a><span>, in § 3.3.2</span>
    <li><a href="#text-directive-suffix">suffix</a><span>, in § 3.3.2</span>
    <li><a href="#text-directive">text directive</a><span>, in § 3.3.2</span>
@@ -2544,6 +2714,7 @@ manipulations
     </ul>
    <li><a href="#unknowndirective">UnknownDirective</a><span>, in § 3.3.3</span>
    <li><a href="#valid-fragment-directive">valid fragment directive</a><span>, in § 3.3.3</span>
+   <li><a href="#directive-state-value">value</a><span>, in § 3.3.1</span>
    <li><a href="#visible-text-node">visible text node</a><span>, in § 3.5.1</span>
    <li><a href="#word-boundary">word boundary</a><span>, in § 3.5.2</span>
    <li><a href="#word-bounded">word bounded</a><span>, in § 3.5.2</span>
@@ -2659,13 +2830,11 @@ manipulations
   <aside aria-labelledby="infopaneltitle-for-985c42e2af63b3e74bd3b70d55668fd4" class="dfn-panel" data-for="985c42e2af63b3e74bd3b70d55668fd4" id="infopanel-for-985c42e2af63b3e74bd3b70d55668fd4">
    <span id="infopaneltitle-for-985c42e2af63b3e74bd3b70d55668fd4" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document">3.3. The Fragment Directive</a>
-    <li><a href="#ref-for-concept-document①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a>
-    <li><a href="#ref-for-concept-document④">3.4.3. Search Timing</a>
-    <li><a href="#ref-for-concept-document⑤">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document⑥">(2)</a> <a href="#ref-for-concept-document⑦">(3)</a> <a href="#ref-for-concept-document⑧">(4)</a> <a href="#ref-for-concept-document⑨">(5)</a> <a href="#ref-for-concept-document①⓪">(6)</a>
-    <li><a href="#ref-for-concept-document①①">3.5. Navigating to a Text Fragment</a>
-    <li><a href="#ref-for-concept-document①②">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-document①③">(2)</a>
-    <li><a href="#ref-for-concept-document①④">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①⑤">(2)</a>
+    <li><a href="#ref-for-concept-document">3.4.3. Search Timing</a>
+    <li><a href="#ref-for-concept-document①">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a> <a href="#ref-for-concept-document④">(4)</a> <a href="#ref-for-concept-document⑤">(5)</a> <a href="#ref-for-concept-document⑥">(6)</a>
+    <li><a href="#ref-for-concept-document⑦">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-concept-document⑧">3.5.1. Finding Ranges in a Document</a> <a href="#ref-for-concept-document⑨">(2)</a>
+    <li><a href="#ref-for-concept-document①⓪">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①①">(2)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-6780f5129791c577e5710641ce0e787a" class="dfn-panel" data-for="6780f5129791c577e5710641ce0e787a" id="infopanel-for-6780f5129791c577e5710641ce0e787a">
@@ -2817,8 +2986,7 @@ manipulations
   <aside aria-labelledby="infopaneltitle-for-2fc74f43c6d7f15a4a2fbfbece346388" class="dfn-panel" data-for="2fc74f43c6d7f15a4a2fbfbece346388" id="infopanel-for-2fc74f43c6d7f15a4a2fbfbece346388">
    <span id="infopaneltitle-for-2fc74f43c6d7f15a4a2fbfbece346388" style="display:none">Info about the 'url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-document-url">3.3. The Fragment Directive</a>
-    <li><a href="#ref-for-concept-document-url①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-document-url②">(2)</a> <a href="#ref-for-concept-document-url③">(3)</a> <a href="#ref-for-concept-document-url④">(4)</a>
+    <li><a href="#ref-for-concept-document-url">3.3.1. Processing the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-491791562dd138987138e7051a96c07c" class="dfn-panel" data-for="491791562dd138987138e7051a96c07c" id="infopanel-for-491791562dd138987138e7051a96c07c">
@@ -2887,6 +3055,12 @@ manipulations
     <li><a href="#ref-for-htmlvideoelement">3.5.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
+  <aside aria-labelledby="infopaneltitle-for-e57cf03d5231bf211b6e11747eb511a2" class="dfn-panel" data-for="e57cf03d5231bf211b6e11747eb511a2" id="infopanel-for-e57cf03d5231bf211b6e11747eb511a2">
+   <span id="infopaneltitle-for-e57cf03d5231bf211b6e11747eb511a2" style="display:none">Info about the 'HashChangeEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent">https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-hashchangeevent">3.3.1. Processing the fragment directive</a>
+   </ul>
+  </aside>
   <aside aria-labelledby="infopaneltitle-for-4b63022be77634e01931166ef990401a" class="dfn-panel" data-for="4b63022be77634e01931166ef990401a" id="infopanel-for-4b63022be77634e01931166ef990401a">
    <span id="infopaneltitle-for-4b63022be77634e01931166ef990401a" style="display:none">Info about the 'Location' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
    <ul>
@@ -2928,6 +3102,12 @@ manipulations
    <span id="infopaneltitle-for-b51df82e894ee794ca3f536db97ad537" style="display:none">Info about the 'multiple' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple">https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-select-multiple">3.5.1. Finding Ranges in a Document</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-566b28e53fa11b6a6ff3a9d32626c2c5" class="dfn-panel" data-for="566b28e53fa11b6a6ff3a9d32626c2c5" id="infopanel-for-566b28e53fa11b6a6ff3a9d32626c2c5">
+   <span id="infopaneltitle-for-566b28e53fa11b6a6ff3a9d32626c2c5" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-navigate">3.3.1. Processing the fragment directive</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-7369d61835fa8a54aba2f14b16179bb7" class="dfn-panel" data-for="7369d61835fa8a54aba2f14b16179bb7" id="infopanel-for-7369d61835fa8a54aba2f14b16179bb7">
@@ -3101,12 +3281,6 @@ manipulations
     <li><a href="#ref-for-struct">3.3.2. Parsing the fragment directive</a>
    </ul>
   </aside>
-  <aside aria-labelledby="infopaneltitle-for-decbbd3ee5a73b54e8e8996ce1fddbbc" class="dfn-panel" data-for="decbbd3ee5a73b54e8e8996ce1fddbbc" id="infopanel-for-decbbd3ee5a73b54e8e8996ce1fddbbc">
-   <span id="infopaneltitle-for-decbbd3ee5a73b54e8e8996ce1fddbbc" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-tuple">3.3.1. Processing the fragment directive</a> <a href="#ref-for-tuple①">(2)</a>
-   </ul>
-  </aside>
   <aside aria-labelledby="infopaneltitle-for-60cc34e102fbb39581626f2f37e3179a" class="dfn-panel" data-for="60cc34e102fbb39581626f2f37e3179a" id="infopanel-for-60cc34e102fbb39581626f2f37e3179a">
    <span id="infopaneltitle-for-60cc34e102fbb39581626f2f37e3179a" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
@@ -3123,7 +3297,7 @@ manipulations
   <aside aria-labelledby="infopaneltitle-for-fc05c76e016d3aec6a25a91c066500c8" class="dfn-panel" data-for="fc05c76e016d3aec6a25a91c066500c8" id="infopanel-for-fc05c76e016d3aec6a25a91c066500c8">
    <span id="infopaneltitle-for-fc05c76e016d3aec6a25a91c066500c8" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-url">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-url①">(2)</a>
+    <li><a href="#ref-for-concept-url">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-url①">(2)</a> <a href="#ref-for-concept-url②">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-46bd2da80269c4e9d4491ad1e341a8f5" class="dfn-panel" data-for="46bd2da80269c4e9d4491ad1e341a8f5" id="infopanel-for-46bd2da80269c4e9d4491ad1e341a8f5">
@@ -3229,6 +3403,7 @@ manipulations
      <li><span class="dfn-paneled" id="257c32b9f7676f6cdb079793771ec03b">HTMLScriptElement</span>
      <li><span class="dfn-paneled" id="004ac07b9e7dd26f7341693e2162496d">HTMLStyleElement</span>
      <li><span class="dfn-paneled" id="a958269402aae8e8d7d28d3cb6aacc8d">HTMLVideoElement</span>
+     <li><span class="dfn-paneled" id="e57cf03d5231bf211b6e11747eb511a2">HashChangeEvent</span>
      <li><span class="dfn-paneled" id="4b63022be77634e01931166ef990401a">Location</span>
      <li><span class="dfn-paneled" id="de11cdc07a64c79878f1c3074e81554a">active document</span>
      <li><span class="dfn-paneled" id="004498b212013045422acbba8c92f503">being rendered</span>
@@ -3236,6 +3411,7 @@ manipulations
      <li><span class="dfn-paneled" id="7033f3e77cd84c91db6d5e82613c4d33">browsing context set</span>
      <li><span class="dfn-paneled" id="726a16249061363ef85fbdad67a6e959">language</span>
      <li><span class="dfn-paneled" id="b51df82e894ee794ca3f536db97ad537">multiple</span>
+     <li><span class="dfn-paneled" id="566b28e53fa11b6a6ff3a9d32626c2c5">navigate</span>
      <li><span class="dfn-paneled" id="7369d61835fa8a54aba2f14b16179bb7">restore persisted state</span>
      <li><span class="dfn-paneled" id="0bbe052a00d2d9a1853b94d848e97f83">scroll to the fragment</span>
      <li><span class="dfn-paneled" id="3fff2218abea20e2aebc96a3c4ed942d">select</span>
@@ -3267,7 +3443,6 @@ manipulations
      <li><span class="dfn-paneled" id="adb176cd03e93496f5eaada8f9e4dc0f">strictly split a string</span>
      <li><span class="dfn-paneled" id="40b59bc325bd4d66701dfd8b7f1847c0">string</span>
      <li><span class="dfn-paneled" id="3ee316b93eb2dbe81d01a666cce50f9b">struct</span>
-     <li><span class="dfn-paneled" id="decbbd3ee5a73b54e8e8996ce1fddbbc">tuple</span>
     </ul>
    <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
@@ -3295,7 +3470,7 @@ manipulations
    <dt id="biblio-css-cascade-5">[CSS-CASCADE-5]
    <dd>Elika Etemad; Miriam Suzanne; Tab Atkins Jr.. <a href="https://drafts.csswg.org/css-cascade-5/"><cite>CSS Cascading and Inheritance Level 5</cite></a>. URL: <a href="https://drafts.csswg.org/css-cascade-5/">https://drafts.csswg.org/css-cascade-5/</a>
    <dt id="biblio-css-display-3">[CSS-DISPLAY-3]
-   <dd>Tab Atkins Jr.; Elika Etemad. <a href="https://drafts.csswg.org/css-display/"><cite>CSS Display Module Level 3</cite></a>. URL: <a href="https://drafts.csswg.org/css-display/">https://drafts.csswg.org/css-display/</a>
+   <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://drafts.csswg.org/css-display/"><cite>CSS Display Module Level 3</cite></a>. URL: <a href="https://drafts.csswg.org/css-display/">https://drafts.csswg.org/css-display/</a>
    <dt id="biblio-css-display-4">[CSS-DISPLAY-4]
    <dd>CSS Display Module Level 4 URL: <a href="https://drafts.csswg.org/css-display-4/">https://drafts.csswg.org/css-display-4/</a>
    <dt id="biblio-document-policy">[DOCUMENT-POLICY]
@@ -3340,6 +3515,14 @@ manipulations
 </pre>
   <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
+   <div class="issue"> The <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching:~:text=Set%20entry%27s%20URL%20to%20currentURL"> create navigation params by fetching</a> steps also write a URL to an entry. As written, that URL always <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching:~:text=Set%20locationURL%20to%20response%27s%20location%20URL%20given%20currentURL%27s%20fragment."> uses the fragment from an existing entry</a> so the directive would already be removed. However,
+    I think that’s wrong. If the redirect URL includes a fragment it should be used, see <a href="https://www.rfc-editor.org/rfc/rfc7231#section-7.1.2">RFC7231</a>. Browsers all <a href="https://wpt.fyi/results/fetch/redirect-navigate/preserve-fragment.html">implement the
+    RFC behavior</a> so it seems like this is a spec bug in HTML. If fixed, this is a fourth place
+    where the directive would have to be removed. <a class="issue-return" href="#issue-b598ad03" title="Jump to section">↵</a></div>
+   <div class="issue"> If a URL’s fragment ends with ':~:' (i.e. empty directive), this will return null which is
+    treated as the URL not specifying an explicit directive (and avoids clobbering an existing
+    one. But maybe in this case we should return the empty string? That way a page can explicitly
+    clear directives/highlights by navigating/pushState to '#:~:'. <a class="issue-return" href="#issue-827449be" title="Jump to section">↵</a></div>
    <div class="issue"> What should be set as target if inside a shadow tree? <a href="https://github.com/WICG/scroll-to-text-fragment/issues/190">#190</a> <a class="issue-return" href="#issue-424a4e25" title="Jump to section">↵</a></div>
    <div class="issue"> These revealing algorithms currently wont work well since <var>target</var> could be an ancestor or even the root document node. Issue <a href="https://github.com/WICG/scroll-to-text-fragment/issues/89">#89</a> proposes restricting matches to <code>contain:style layout</code> blocks which
     would resolve this problem. <a class="issue-return" href="#issue-10739530" title="Jump to section">↵</a></div>
@@ -3357,7 +3540,8 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
    <ul>
     <li><a href="#ref-for-fragment-directive">3.2. Syntax</a>
     <li><a href="#ref-for-fragment-directive①">3.3. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a>
-    <li><a href="#ref-for-fragment-directive③">3.3.1. Processing the fragment directive</a> <a href="#ref-for-fragment-directive④">(2)</a> <a href="#ref-for-fragment-directive⑤">(3)</a> <a href="#ref-for-fragment-directive⑥">(4)</a> <a href="#ref-for-fragment-directive⑦">(5)</a>
+    <li><a href="#ref-for-fragment-directive③">3.3.1. Processing the fragment directive</a> <a href="#ref-for-fragment-directive④">(2)</a> <a href="#ref-for-fragment-directive⑤">(3)</a> <a href="#ref-for-fragment-directive⑥">(4)</a>
+    <li><a href="#ref-for-fragment-directive⑦">3.5. Navigating to a Text Fragment</a>
     <li><a href="#ref-for-fragment-directive⑧">3.6.1. URLs in UA features</a> <a href="#ref-for-fragment-directive⑨">(2)</a> <a href="#ref-for-fragment-directive①⓪">(3)</a>
     <li><a href="#ref-for-fragment-directive①①">3.6.1.1. Location Bar</a>
     <li><a href="#ref-for-fragment-directive①②">3.6.1.2. Bookmarks</a> <a href="#ref-for-fragment-directive①③">(2)</a>
@@ -3377,25 +3561,28 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
     <li><a href="#ref-for-directives">3.3.2. Parsing the fragment directive</a>
    </ul>
   </aside>
-  <aside aria-labelledby="infopaneltitle-for-document-fragment-directive" class="dfn-panel" data-for="document-fragment-directive" id="infopanel-for-document-fragment-directive">
-   <span id="infopaneltitle-for-document-fragment-directive" style="display:none">Info about the 'fragment
-    directive' definition.</span><b><a href="#document-fragment-directive">#document-fragment-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-state" class="dfn-panel" data-for="directive-state" id="infopanel-for-directive-state">
+   <span id="infopaneltitle-for-directive-state" style="display:none">Info about the 'directive state' definition.</span><b><a href="#directive-state">#directive-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-fragment-directive">3.3.1. Processing the fragment directive</a> <a href="#ref-for-document-fragment-directive①">(2)</a>
-    <li><a href="#ref-for-document-fragment-directive②">3.4.4. Restricting the Text Fragment</a>
-    <li><a href="#ref-for-document-fragment-directive③">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-directive-state">3.3.1. Processing the fragment directive</a> <a href="#ref-for-directive-state①">(2)</a> <a href="#ref-for-directive-state②">(3)</a> <a href="#ref-for-directive-state③">(4)</a> <a href="#ref-for-directive-state④">(5)</a> <a href="#ref-for-directive-state⑤">(6)</a> <a href="#ref-for-directive-state⑥">(7)</a> <a href="#ref-for-directive-state⑦">(8)</a>
    </ul>
   </aside>
-  <aside aria-labelledby="infopaneltitle-for-split-the-fragment-from-the-fragment-directive" class="dfn-panel" data-for="split-the-fragment-from-the-fragment-directive" id="infopanel-for-split-the-fragment-from-the-fragment-directive">
-   <span id="infopaneltitle-for-split-the-fragment-from-the-fragment-directive" style="display:none">Info about the 'split the fragment from the fragment directive' definition.</span><b><a href="#split-the-fragment-from-the-fragment-directive">#split-the-fragment-from-the-fragment-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-state-value" class="dfn-panel" data-for="directive-state-value" id="infopanel-for-directive-state-value">
+   <span id="infopaneltitle-for-directive-state-value" style="display:none">Info about the 'value' definition.</span><b><a href="#directive-state-value">#directive-state-value</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-split-the-fragment-from-the-fragment-directive">3.3.1. Processing the fragment directive</a>
+    <li><a href="#ref-for-directive-state-value">3.3.1. Processing the fragment directive</a> <a href="#ref-for-directive-state-value①">(2)</a> <a href="#ref-for-directive-state-value②">(3)</a> <a href="#ref-for-directive-state-value③">(4)</a>
    </ul>
   </aside>
-  <aside aria-labelledby="infopaneltitle-for-process-and-consume-fragment-directive" class="dfn-panel" data-for="process-and-consume-fragment-directive" id="infopanel-for-process-and-consume-fragment-directive">
-   <span id="infopaneltitle-for-process-and-consume-fragment-directive" style="display:none">Info about the 'process and consume fragment directive' definition.</span><b><a href="#process-and-consume-fragment-directive">#process-and-consume-fragment-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-she-directive-state" class="dfn-panel" data-for="she-directive-state" id="infopanel-for-she-directive-state">
+   <span id="infopaneltitle-for-she-directive-state" style="display:none">Info about the 'directive state' definition.</span><b><a href="#she-directive-state">#she-directive-state</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-process-and-consume-fragment-directive">3.3.1. Processing the fragment directive</a> <a href="#ref-for-process-and-consume-fragment-directive①">(2)</a>
+    <li><a href="#ref-for-she-directive-state">3.3.1. Processing the fragment directive</a> <a href="#ref-for-she-directive-state①">(2)</a> <a href="#ref-for-she-directive-state②">(3)</a> <a href="#ref-for-she-directive-state③">(4)</a> <a href="#ref-for-she-directive-state④">(5)</a> <a href="#ref-for-she-directive-state⑤">(6)</a> <a href="#ref-for-she-directive-state⑥">(7)</a>
+   </ul>
+  </aside>
+  <aside aria-labelledby="infopaneltitle-for-remove-the-fragment-directive" class="dfn-panel" data-for="remove-the-fragment-directive" id="infopanel-for-remove-the-fragment-directive">
+   <span id="infopaneltitle-for-remove-the-fragment-directive" style="display:none">Info about the 'remove the fragment directive' definition.</span><b><a href="#remove-the-fragment-directive">#remove-the-fragment-directive</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-remove-the-fragment-directive">3.3.1. Processing the fragment directive</a> <a href="#ref-for-remove-the-fragment-directive①">(2)</a> <a href="#ref-for-remove-the-fragment-directive②">(3)</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-text-directive" class="dfn-panel" data-for="text-directive" id="infopanel-for-text-directive">
@@ -3535,8 +3722,8 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
   <aside aria-labelledby="infopaneltitle-for-document-allow-text-fragment-scroll" class="dfn-panel" data-for="document-allow-text-fragment-scroll" id="infopanel-for-document-allow-text-fragment-scroll">
    <span id="infopaneltitle-for-document-allow-text-fragment-scroll" style="display:none">Info about the 'allow text fragment scroll' definition.</span><b><a href="#document-allow-text-fragment-scroll">#document-allow-text-fragment-scroll</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-allow-text-fragment-scroll">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allow-text-fragment-scroll①">(2)</a> <a href="#ref-for-document-allow-text-fragment-scroll②">(3)</a> <a href="#ref-for-document-allow-text-fragment-scroll③">(4)</a> <a href="#ref-for-document-allow-text-fragment-scroll④">(5)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑤">(6)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑥">(7)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑦">(8)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑧">(9)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑨">(10)</a>
-    <li><a href="#ref-for-document-allow-text-fragment-scroll①⓪">3.5. Navigating to a Text Fragment</a>
+    <li><a href="#ref-for-document-allow-text-fragment-scroll">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allow-text-fragment-scroll①">(2)</a> <a href="#ref-for-document-allow-text-fragment-scroll②">(3)</a> <a href="#ref-for-document-allow-text-fragment-scroll③">(4)</a> <a href="#ref-for-document-allow-text-fragment-scroll④">(5)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑤">(6)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑥">(7)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑦">(8)</a> <a href="#ref-for-document-allow-text-fragment-scroll⑧">(9)</a>
+    <li><a href="#ref-for-document-allow-text-fragment-scroll⑨">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-first-common-ancestor" class="dfn-panel" data-for="first-common-ancestor" id="infopanel-for-first-common-ancestor">

--- a/index.html
+++ b/index.html
@@ -1513,7 +1513,7 @@ fragment as a fallback.</p>
        <ol>
         <li data-md>
          <p><span class="diff">Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> that is the result of running
-  the <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive">process a fragment directive</a> steps with <var>directives</var> and the document.</span></p>
+  the <a data-link-type="dfn" href="#invoke-text-directives" id="ref-for-invoke-text-directives">invoke text directives</a> steps with <var>directives</var> and the document.</span></p>
         <li data-md>
          <p><span class="diff">If <var>ranges</var> is non-empty, then:</span></p>
          <ol>
@@ -1985,29 +1985,28 @@ text=bar,baz
   instance of rendered text that matches the restrictions in the directive.
   Each search is independent of any others; that is, the result is the same
   regardless of how many other directives are provided or their match result.</p>
-    <p>If a directive successfully matches to text in the document, it returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⓪">range</a> indicating that match in the document. The <a data-link-type="dfn" href="#process-a-fragment-directive" id="ref-for-process-a-fragment-directive①">process a fragment
-  directive</a> steps are the high level API provided by this section. These
-  return a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①①">ranges</a> that were matched by the
-  individual directive matching steps, in the order the directives were
+    <p>If a directive successfully matches to text in the document, it returns a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①⓪">range</a> indicating that match in the document. The <a data-link-type="dfn" href="#invoke-text-directives" id="ref-for-invoke-text-directives①">invoke text directives</a> steps are the high level API provided by this
+  section. These return a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①①">ranges</a> that were matched
+  by the individual directive matching steps, in the order the directives were
   specified in the fragment directive string.</p>
     <p>If a directive was not matched, it does not add an item to the returned
   list.</p>
    </div>
-   <div class="algorithm" data-algorithm="process a fragment directive">
-     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="process-a-fragment-directive">process a fragment directive</dfn>, given as input an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a> <var>fragment directive input</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> <var>document</var>, run these steps: 
-    <div class="note" role="note"> This algorithm takes as input a <var>fragment directive input</var>, that is the
+   <div class="algorithm" data-algorithm="invoke text directives">
+     To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="invoke-text-directives">invoke text directives</dfn>, given as input an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string②">ASCII string</a> <var>text directives</var> and a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑧">Document</a> <var>document</var>, run these steps: 
+    <div class="note" role="note"> This algorithm takes as input a <var>text directives</var>, that is the
   raw text of the fragment directive and the <var>document</var> over which it operates.
   It returns a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list③">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①②">ranges</a> that are to be visually
   indicated, the first of which will be scrolled into view (if the UA scrolls
   automatically). </div>
     <ol class="algorithm">
      <li data-md>
-      <p>If <var>fragment directive input</var> is not a <a data-link-type="dfn" href="#valid-fragment-directive" id="ref-for-valid-fragment-directive">valid fragment directive</a>, then
+      <p>If <var>text directives</var> is not a <a data-link-type="dfn" href="#valid-fragment-directive" id="ref-for-valid-fragment-directive">valid fragment directive</a>, then
 return an empty <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list④">list</a>.</p>
      <li data-md>
       <p>Let <var>directives</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑤">list</a> of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string" id="ref-for-ascii-string③">ASCII string</a>s
 that is the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#strictly-split" id="ref-for-strictly-split">strictly splitting the
-string</a> <var>fragment directive input</var> on "&amp;".</p>
+string</a> <var>text directives</var> on "&amp;".</p>
      <li data-md>
       <p>Let <var>ranges</var> be a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list⑥">list</a> of <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-range" id="ref-for-concept-range①③">ranges</a>, initially empty.</p>
      <li data-md>
@@ -2819,6 +2818,7 @@ manipulations
    <li><a href="#fragment-directive-delimiter">fragment directive delimiter</a><span>, in § 3.3</span>
    <li><a href="#get-boundary-point-at-index">get boundary point at index</a><span>, in § 3.6.1</span>
    <li><a href="#has-block-level-display">has block-level display</a><span>, in § 3.6.1</span>
+   <li><a href="#invoke-text-directives">invoke text directives</a><span>, in § 3.6.1</span>
    <li><a href="#is-at-a-word-boundary">is at a word boundary</a><span>, in § 3.6.2</span>
    <li><a href="#locale">locale</a><span>, in § 3.6.2</span>
    <li><a href="#nearest-block-ancestor">nearest block ancestor</a><span>, in § 3.6.1</span>
@@ -2827,7 +2827,6 @@ manipulations
    <li><a href="#parse-a-text-directive">parse a text directive</a><span>, in § 3.4</span>
    <li><a href="#percentencodedchar">PercentEncodedChar</a><span>, in § 3.3.4</span>
    <li><a href="#text-directive-prefix">prefix</a><span>, in § 3.4</span>
-   <li><a href="#process-a-fragment-directive">process a fragment directive</a><span>, in § 3.6.1</span>
    <li><a href="#remove-the-fragment-directive">remove the fragment directive</a><span>, in § 3.3.1</span>
    <li><a href="#search-invisible">search invisible</a><span>, in § 3.6.1</span>
    <li><a href="#shadow-including-parent">shadow-including parent</a><span>, in § 3.6</span>
@@ -3887,11 +3886,11 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
     <li><a href="#ref-for-shadow-including-parent">3.6. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside aria-labelledby="infopaneltitle-for-process-a-fragment-directive" class="dfn-panel" data-for="process-a-fragment-directive" id="infopanel-for-process-a-fragment-directive">
-   <span id="infopaneltitle-for-process-a-fragment-directive" style="display:none">Info about the 'process a fragment directive' definition.</span><b><a href="#process-a-fragment-directive">#process-a-fragment-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invoke-text-directives" class="dfn-panel" data-for="invoke-text-directives" id="infopanel-for-invoke-text-directives">
+   <span id="infopaneltitle-for-invoke-text-directives" style="display:none">Info about the 'invoke text directives' definition.</span><b><a href="#invoke-text-directives">#invoke-text-directives</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-process-a-fragment-directive">3.4.1. Invoking Text Directives</a>
-    <li><a href="#ref-for-process-a-fragment-directive①">3.6.1. Finding Ranges in a Document</a>
+    <li><a href="#ref-for-invoke-text-directives">3.4.1. Invoking Text Directives</a>
+    <li><a href="#ref-for-invoke-text-directives①">3.6.1. Finding Ranges in a Document</a>
    </ul>
   </aside>
   <aside aria-labelledby="infopaneltitle-for-find-a-range-from-a-text-directive" class="dfn-panel" data-for="find-a-range-from-a-text-directive" id="infopanel-for-find-a-range-from-a-text-directive">


### PR DESCRIPTION
This PR makes it so that the fragment directive is stripped from the URL whenever it is set to a history entry. Instead, the history entry keeps it in a separate `directive state`.

The `directive state` is shared between contiguous history entries where the only difference is the non-directive portion of the fragment.

Moving between session history entries will cause the `directive state`, if it differs from the current entry, to be set into an `uninvoked directives` member on the Document. The "scroll to the fragment" steps will read directives from this member and attempt to perform the text search.

When the fragment search ends, `uninvoked directives` is always cleared.