### PR TITLE
Restrict text directives to text/html and text/plain

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1242,6 +1242,22 @@ user activation=] flag:
 >
 > </div>
 
+A <dfn>text directive allowing MIME type</dfn> is a [=MIME type=] whose [=MIME type/essence=] is
+"<code>text/html</code>" or "<code>text/plain</code>".
+
+Note: As noted in <a
+href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scrolling-to-a-fragment">scrolling
+to a fragment, fragment processing is defined individually by each MIME type. As such, the
+<a spec=HTML>scroll to the fragment</a> steps where text directives are scrolled should only apply
+to text/html media types. However, in practice, web browsers tend to apply HTML fragment processing
+to other types, such as text/plain (e.g. add an element with an id to a text/plain document,
+navigating to the fragment-id causes scrolling). While this is the case, enabling text directives in
+text/plain documents is useful. Other types are explicitly disallowed to prevent the possibility of
+XS-Search attacks on potentially sensitive application data (e.g. text/css, application/json,
+application/javascript, etc.).
+
+Issue: Is this valid to say in the HTML spec?
+
 <div algorithm="check if a text directive can be scrolled">
   To <dfn>check if a text directive can be scrolled</dfn>; given a [=/Document=] |document|, an
   [=/origin=]-or-null |initiator origin|, and <a spec=HTML>user navigation involvement</a>-or-null
@@ -1253,6 +1269,8 @@ user activation=] flag:
         true, or |user involvement| is one of "<code>activation</code>" or "<code>browser
         UI</code>"; false otherwise.
     1. Set |document|'s [=document/text directive user activation=] to false.
+    1. If |document|'s [=Document/content type=] is not a [=text directive allowing MIME type=],
+        return false.
     1. If |user involvement| is "<code>browser UI</code>", return true.
         <div class="note">
           <p>

--- a/index.html
+++ b/index.html
@@ -813,7 +813,7 @@ dd:not(:last-child) > .wpt-tests-block:not([open]):last-child {
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">URL Fragment Text Directives</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2023-11-28">28 November 2023</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2023-12-13">13 December 2023</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2067,6 +2067,17 @@ conditions hold, false otherwise:
      </ol>
     </div>
    </blockquote>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="text-directive-allowing-mime-type">text directive allowing MIME type</dfn> is a <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#mime-type" id="ref-for-mime-type">MIME type</a> whose <a data-link-type="dfn" href="https://mimesniff.spec.whatwg.org/#mime-type-essence" id="ref-for-mime-type-essence">essence</a> is
+"<code>text/html</code>" or "<code>text/plain</code>".</p>
+   <p class="note" role="note"><span class="marker">Note:</span> As noted in <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scrolling-to-a-fragment">scrolling
+to a fragment, fragment processing is defined individually by each MIME type. As such, the </a><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier②">scroll to the fragment</a> steps where text directives are scrolled should only apply
+to text/html media types. However, in practice, web browsers tend to apply HTML fragment processing
+to other types, such as text/plain (e.g. add an element with an id to a text/plain document,
+navigating to the fragment-id causes scrolling). While this is the case, enabling text directives in
+text/plain documents is useful. Other types are explicitly disallowed to prevent the possibility of
+XS-Search attacks on potentially sensitive application data (e.g. text/css, application/json,
+application/javascript, etc.).</p>
+   <p class="issue" id="issue-0e1d8eda"><a class="self-link" href="#issue-0e1d8eda"></a> Is this valid to say in the HTML spec?</p>
    <div class="algorithm" data-algorithm="check if a text directive can be scrolled">
      To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="check-if-a-text-directive-can-be-scrolled">check if a text directive can be scrolled</dfn>; given a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document" id="ref-for-concept-document⑦">Document</a> <var>document</var>, an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin" id="ref-for-concept-origin">origin</a>-or-null <var>initiator origin</var>, and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#user-navigation-involvement" id="ref-for-user-navigation-involvement②">user navigation involvement</a>-or-null <var>user involvement</var>, follow these steps: 
     <ol class="algorithm">
@@ -2078,6 +2089,9 @@ true, or <var>user involvement</var> is one of "<code>activation</code>" or "<co
 UI</code>"; false otherwise.</p>
      <li data-md>
       <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-text-directive-user-activation" id="ref-for-document-text-directive-user-activation①③">text directive user activation</a> to false.</p>
+     <li data-md>
+      <p>If <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-content-type" id="ref-for-concept-document-content-type">content type</a> is not a <a data-link-type="dfn" href="#text-directive-allowing-mime-type" id="ref-for-text-directive-allowing-mime-type">text directive allowing MIME type</a>,
+return false.</p>
      <li data-md>
       <p>If <var>user involvement</var> is "<code>browser UI</code>", return true.</p>
       <div class="note" role="note">
@@ -2108,7 +2122,7 @@ UI</code>"; false otherwise.</p>
       <p>Otherwise, return false.</p>
     </ol>
    </div>
-   <p>Amend (the already amended, in <a href="#invoking-text-directives">§ 3.4.1 Invoking Text Directives</a>) <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier②">scroll to the
+   <p>Amend (the already amended, in <a href="#invoking-text-directives">§ 3.4.1 Invoking Text Directives</a>) <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier③">scroll to the
 fragment</a> steps to add a new parameter, a boolean <var>allow text directive scroll</var>:</p>
    <blockquote>
     <p><strong>Monkeypatching <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scrolling-to-a-fragment"><cite>HTML</cite> § 7.4.6.3 Scrolling to a fragment</a>:</strong></p>
@@ -3116,7 +3130,7 @@ been dismissed.</p>
   indicated part and set as the document’s target element. However, "foo"
   will not be scrolled into view.</p>
    </div>
-   <p>Fragment-based scroll blocking from this policy is specified in an amendment to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier③">scroll to the fragment</a> algorithm in the <a href="#navigating-to-text-fragment">§ 3.6 Navigating to a Text Fragment</a> section of this document.</p>
+   <p>Fragment-based scroll blocking from this policy is specified in an amendment to the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier" id="ref-for-scroll-to-the-fragment-identifier④">scroll to the fragment</a> algorithm in the <a href="#navigating-to-text-fragment">§ 3.6 Navigating to a Text Fragment</a> section of this document.</p>
    <p>History scroll restoration is blocked by amending the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state" id="ref-for-restore-persisted-state①">restore
 persisted state</a> steps by inserting a new step after 2:</p>
    <ol start="3">
@@ -3321,6 +3335,7 @@ manipulations
    <li><a href="#text-directive-suffix">suffix</a><span>, in § 3.4</span>
    <li><a href="#text-directive">text directive</a><span>, in § 3.4</span>
    <li><a href="#textdirective">TextDirective</a><span>, in § 3.3.4</span>
+   <li><a href="#text-directive-allowing-mime-type">text directive allowing MIME type</a><span>, in § 3.5.4</span>
    <li><a href="#textdirectiveexplicitchar">TextDirectiveExplicitChar</a><span>, in § 3.3.4</span>
    <li><a href="#textdirectiveparameters">TextDirectiveParameters</a><span>, in § 3.3.4</span>
    <li><a href="#textdirectiveprefix">TextDirectivePrefix</a><span>, in § 3.3.4</span>
@@ -3379,6 +3394,7 @@ manipulations
      <li><span class="dfn-paneled" id="4fef809c">after</span>
      <li><span class="dfn-paneled" id="8a3e6de2">boundary point</span>
      <li><span class="dfn-paneled" id="8aac8409">collapsed</span>
+     <li><span class="dfn-paneled" id="3f23ec71">content type</span>
      <li><span class="dfn-paneled" id="212ee1f7">data</span>
      <li><span class="dfn-paneled" id="cefd9ec1">doctype</span>
      <li><span class="dfn-paneled" id="a973e0fe">document</span>
@@ -3481,6 +3497,12 @@ manipulations
      <li><span class="dfn-paneled" id="984221ca">struct</span>
     </ul>
    <li>
+    <a data-link-type="biblio">[MIMESNIFF]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="7c195f8b">essence</span>
+     <li><span class="dfn-paneled" id="16785ec4">mime type</span>
+    </ul>
+   <li>
     <a data-link-type="biblio">[URL]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="ed948033">fragment</span>
@@ -3516,6 +3538,8 @@ manipulations
    <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dt id="biblio-mimesniff">[MIMESNIFF]
+   <dd>Gordon P. Hemsley. <a href="https://mimesniff.spec.whatwg.org/"><cite>MIME Sniffing Standard</cite></a>. Living Standard. URL: <a href="https://mimesniff.spec.whatwg.org/">https://mimesniff.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-uax29">[UAX29]
@@ -3560,6 +3584,7 @@ manipulations
    <div class="issue"> This isn’t strictly true, Chrome
 allows this for same-origin initiators. Need to update the spec on this
 point. <a href="https://github.com/WICG/scroll-to-text-fragment/issues/240">[Issue #WICG/scroll-to-text-fragment#240]</a> <a class="issue-return" href="#issue-35f490f0" title="Jump to section">↵</a></div>
+   <div class="issue"> Is this valid to say in the HTML spec? <a class="issue-return" href="#issue-0e1d8eda" title="Jump to section">↵</a></div>
    <div class="issue"> Need to decide how <code>force-load-at-top</code> interacts with the Navigation API. <a href="https://github.com/WICG/scroll-to-text-fragment/issues/242">[Issue #WICG/scroll-to-text-fragment#242]</a> <a class="issue-return" href="#issue-de0fed9d" title="Jump to section">↵</a></div>
    <div class="issue"> <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-cd-data">data</a> is not
 correct here since that’s the text data as it exists in the DOM. This
@@ -3891,6 +3916,7 @@ window.dfnpanelData['597088f0'] = {"dfnID": "597088f0", "url": "https://dom.spec
 window.dfnpanelData['4fef809c'] = {"dfnID": "4fef809c", "url": "https://dom.spec.whatwg.org/#concept-range-bp-after", "dfnText": "after", "refSections": [{"refs": [{"id": "ref-for-concept-range-bp-after"}, {"id": "ref-for-concept-range-bp-after\u2460"}, {"id": "ref-for-concept-range-bp-after\u2461"}], "title": "3.6.1. Finding Ranges in a Document"}], "external": true};
 window.dfnpanelData['8a3e6de2'] = {"dfnID": "8a3e6de2", "url": "https://dom.spec.whatwg.org/#concept-range-bp", "dfnText": "boundary point", "refSections": [{"refs": [{"id": "ref-for-concept-range-bp"}, {"id": "ref-for-concept-range-bp\u2460"}, {"id": "ref-for-concept-range-bp\u2461"}, {"id": "ref-for-concept-range-bp\u2462"}, {"id": "ref-for-concept-range-bp\u2463"}, {"id": "ref-for-concept-range-bp\u2464"}, {"id": "ref-for-concept-range-bp\u2465"}, {"id": "ref-for-concept-range-bp\u2466"}, {"id": "ref-for-concept-range-bp\u2467"}], "title": "3.6.1. Finding Ranges in a Document"}], "external": true};
 window.dfnpanelData['8aac8409'] = {"dfnID": "8aac8409", "url": "https://dom.spec.whatwg.org/#range-collapsed", "dfnText": "collapsed", "refSections": [{"refs": [{"id": "ref-for-range-collapsed"}, {"id": "ref-for-range-collapsed\u2460"}, {"id": "ref-for-range-collapsed\u2461"}, {"id": "ref-for-range-collapsed\u2462"}, {"id": "ref-for-range-collapsed\u2463"}, {"id": "ref-for-range-collapsed\u2464"}], "title": "3.6.1. Finding Ranges in a Document"}], "external": true};
+window.dfnpanelData['3f23ec71'] = {"dfnID": "3f23ec71", "url": "https://dom.spec.whatwg.org/#concept-document-content-type", "dfnText": "content type", "refSections": [{"refs": [{"id": "ref-for-concept-document-content-type"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": true};
 window.dfnpanelData['212ee1f7'] = {"dfnID": "212ee1f7", "url": "https://dom.spec.whatwg.org/#concept-cd-data", "dfnText": "data", "refSections": [{"refs": [{"id": "ref-for-concept-cd-data"}, {"id": "ref-for-concept-cd-data\u2460"}, {"id": "ref-for-concept-cd-data\u2461"}], "title": "3.6.1. Finding Ranges in a Document"}], "external": true};
 window.dfnpanelData['cefd9ec1'] = {"dfnID": "cefd9ec1", "url": "https://dom.spec.whatwg.org/#concept-doctype", "dfnText": "doctype", "refSections": [{"refs": [{"id": "ref-for-concept-doctype"}], "title": "3.6.1. Finding Ranges in a Document"}], "external": true};
 window.dfnpanelData['a973e0fe'] = {"dfnID": "a973e0fe", "url": "https://dom.spec.whatwg.org/#concept-document", "dfnText": "document", "refSections": [{"refs": [{"id": "ref-for-concept-document"}], "title": "3.3.2. Applying directives to a document"}, {"refs": [{"id": "ref-for-concept-document\u2460"}], "title": "3.5.3. Search Timing"}, {"refs": [{"id": "ref-for-concept-document\u2461"}, {"id": "ref-for-concept-document\u2462"}, {"id": "ref-for-concept-document\u2463"}, {"id": "ref-for-concept-document\u2464"}, {"id": "ref-for-concept-document\u2465"}, {"id": "ref-for-concept-document\u2466"}], "title": "3.5.4. Restricting the Text Fragment"}, {"refs": [{"id": "ref-for-concept-document\u2467"}, {"id": "ref-for-concept-document\u2468"}], "title": "3.6.1. Finding Ranges in a Document"}, {"refs": [{"id": "ref-for-concept-document\u2460\u24ea"}, {"id": "ref-for-concept-document\u2460\u2460"}], "title": "3.8. Document Policy Integration"}], "external": true};
@@ -3952,7 +3978,7 @@ window.dfnpanelData['086e3aff'] = {"dfnID": "086e3aff", "url": "https://html.spe
 window.dfnpanelData['1bba3db7'] = {"dfnID": "1bba3db7", "url": "https://html.spec.whatwg.org/multipage/document-sequences.html#nav-parent", "dfnText": "parent", "refSections": [{"refs": [{"id": "ref-for-nav-parent"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": true};
 window.dfnpanelData['8b87b428'] = {"dfnID": "8b87b428", "url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state", "dfnText": "restore persisted state", "refSections": [{"refs": [{"id": "ref-for-restore-persisted-state"}], "title": "3.5.5. Restricting Scroll on Load"}, {"refs": [{"id": "ref-for-restore-persisted-state\u2460"}], "title": "3.8. Document Policy Integration"}], "external": true};
 window.dfnpanelData['7393da89'] = {"dfnID": "7393da89", "url": "https://html.spec.whatwg.org/multipage/browsers.html#same-origin", "dfnText": "same origin", "refSections": [{"refs": [{"id": "ref-for-same-origin"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": true};
-window.dfnpanelData['3f2e859c'] = {"dfnID": "3f2e859c", "url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier", "dfnText": "scroll to the fragment", "refSections": [{"refs": [{"id": "ref-for-scroll-to-the-fragment-identifier"}, {"id": "ref-for-scroll-to-the-fragment-identifier\u2460"}], "title": "3.4.1. Invoking Text Directives"}, {"refs": [{"id": "ref-for-scroll-to-the-fragment-identifier\u2461"}], "title": "3.5.4. Restricting the Text Fragment"}, {"refs": [{"id": "ref-for-scroll-to-the-fragment-identifier\u2462"}], "title": "3.8. Document Policy Integration"}], "external": true};
+window.dfnpanelData['3f2e859c'] = {"dfnID": "3f2e859c", "url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier", "dfnText": "scroll to the fragment", "refSections": [{"refs": [{"id": "ref-for-scroll-to-the-fragment-identifier"}, {"id": "ref-for-scroll-to-the-fragment-identifier\u2460"}], "title": "3.4.1. Invoking Text Directives"}, {"refs": [{"id": "ref-for-scroll-to-the-fragment-identifier\u2461"}, {"id": "ref-for-scroll-to-the-fragment-identifier\u2462"}], "title": "3.5.4. Restricting the Text Fragment"}, {"refs": [{"id": "ref-for-scroll-to-the-fragment-identifier\u2463"}], "title": "3.8. Document Policy Integration"}], "external": true};
 window.dfnpanelData['85188fb3'] = {"dfnID": "85188fb3", "url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element", "dfnText": "select", "refSections": [{"refs": [{"id": "ref-for-the-select-element"}], "title": "3.6.1. Finding Ranges in a Document"}], "external": true};
 window.dfnpanelData['c3ae9e6a'] = {"dfnID": "c3ae9e6a", "url": "https://html.spec.whatwg.org/multipage/parsing.html#serializes-as-void", "dfnText": "serializes as void", "refSections": [{"refs": [{"id": "ref-for-serializes-as-void"}], "title": "3.6.1. Finding Ranges in a Document"}], "external": true};
 window.dfnpanelData['8a051c9f'] = {"dfnID": "8a051c9f", "url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment", "dfnText": "try to scroll to the fragment", "refSections": [{"refs": [{"id": "44bd3acf0"}], "title": "3.4.1. Invoking Text Directives"}, {"refs": [{"id": "ref-for-try-to-scroll-to-the-fragment"}], "title": "3.5.4. Restricting the Text Fragment"}, {"refs": [{"id": "ref-for-try-to-scroll-to-the-fragment\u2460"}], "title": "3.7. Indicating The Text Match"}], "external": true};
@@ -3979,6 +4005,8 @@ window.dfnpanelData['0437147c'] = {"dfnID": "0437147c", "url": "https://infra.sp
 window.dfnpanelData['7a3dbdb1'] = {"dfnID": "7a3dbdb1", "url": "https://infra.spec.whatwg.org/#strictly-split", "dfnText": "strictly split a string", "refSections": [{"refs": [{"id": "ref-for-strictly-split"}], "title": "3.6.1. Finding Ranges in a Document"}], "external": true};
 window.dfnpanelData['0698d556'] = {"dfnID": "0698d556", "url": "https://infra.spec.whatwg.org/#string", "dfnText": "string", "refSections": [{"refs": [{"id": "ref-for-string"}], "title": "3.6.1. Finding Ranges in a Document"}, {"refs": [{"id": "ref-for-string\u2460"}, {"id": "ref-for-string\u2461"}, {"id": "ref-for-string\u2462"}], "title": "3.6.2. Word Boundaries"}], "external": true};
 window.dfnpanelData['984221ca'] = {"dfnID": "984221ca", "url": "https://infra.spec.whatwg.org/#struct", "dfnText": "struct", "refSections": [{"refs": [{"id": "ref-for-struct"}], "title": "3.4. Text Directives"}], "external": true};
+window.dfnpanelData['7c195f8b'] = {"dfnID": "7c195f8b", "url": "https://mimesniff.spec.whatwg.org/#mime-type-essence", "dfnText": "essence", "refSections": [{"refs": [{"id": "ref-for-mime-type-essence"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": true};
+window.dfnpanelData['16785ec4'] = {"dfnID": "16785ec4", "url": "https://mimesniff.spec.whatwg.org/#mime-type", "dfnText": "mime type", "refSections": [{"refs": [{"id": "ref-for-mime-type"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": true};
 window.dfnpanelData['ed948033'] = {"dfnID": "ed948033", "url": "https://url.spec.whatwg.org/#concept-url-fragment", "dfnText": "fragment", "refSections": [{"refs": [{"id": "ref-for-concept-url-fragment"}], "title": "3.3. The Fragment Directive"}, {"refs": [{"id": "ref-for-concept-url-fragment\u2460"}, {"id": "ref-for-concept-url-fragment\u2461"}], "title": "3.3.1. Extracting the fragment directive"}], "external": true};
 window.dfnpanelData['8f69ce41'] = {"dfnID": "8f69ce41", "url": "https://url.spec.whatwg.org/#string-percent-decode", "dfnText": "percent-decode", "refSections": [{"refs": [{"id": "ref-for-string-percent-decode"}, {"id": "ref-for-string-percent-decode\u2460"}, {"id": "ref-for-string-percent-decode\u2461"}, {"id": "ref-for-string-percent-decode\u2462"}], "title": "3.4. Text Directives"}], "external": true};
 window.dfnpanelData['dcffbccd'] = {"dfnID": "dcffbccd", "url": "https://url.spec.whatwg.org/#concept-url", "dfnText": "url", "refSections": [{"refs": [{"id": "ref-for-concept-url"}, {"id": "ref-for-concept-url\u2460"}, {"id": "ref-for-concept-url\u2461"}], "title": "3.3.1. Extracting the fragment directive"}], "external": true};
@@ -4014,6 +4042,7 @@ window.dfnpanelData['parse-a-text-directive'] = {"dfnID": "parse-a-text-directiv
 window.dfnpanelData['request-text-directive-user-activation'] = {"dfnID": "request-text-directive-user-activation", "url": "#request-text-directive-user-activation", "dfnText": "text directive user activation", "refSections": [{"refs": [{"id": "ref-for-request-text-directive-user-activation"}, {"id": "ref-for-request-text-directive-user-activation\u2460"}, {"id": "ref-for-request-text-directive-user-activation\u2461"}, {"id": "ref-for-request-text-directive-user-activation\u2462"}, {"id": "ref-for-request-text-directive-user-activation\u2463"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": false};
 window.dfnpanelData['document-text-directive-user-activation'] = {"dfnID": "document-text-directive-user-activation", "url": "#document-text-directive-user-activation", "dfnText": "text directive user activation", "refSections": [{"refs": [{"id": "ref-for-document-text-directive-user-activation"}, {"id": "ref-for-document-text-directive-user-activation\u2460"}, {"id": "ref-for-document-text-directive-user-activation\u2461"}, {"id": "ref-for-document-text-directive-user-activation\u2462"}, {"id": "ref-for-document-text-directive-user-activation\u2463"}, {"id": "ref-for-document-text-directive-user-activation\u2464"}, {"id": "ref-for-document-text-directive-user-activation\u2465"}, {"id": "ref-for-document-text-directive-user-activation\u2466"}, {"id": "ref-for-document-text-directive-user-activation\u2467"}, {"id": "ref-for-document-text-directive-user-activation\u2468"}, {"id": "ref-for-document-text-directive-user-activation\u2460\u24ea"}, {"id": "ref-for-document-text-directive-user-activation\u2460\u2460"}, {"id": "ref-for-document-text-directive-user-activation\u2460\u2461"}, {"id": "ref-for-document-text-directive-user-activation\u2460\u2462"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": false};
 window.dfnpanelData['navigation-params-user-involvement'] = {"dfnID": "navigation-params-user-involvement", "url": "#navigation-params-user-involvement", "dfnText": "user involvement", "refSections": [{"refs": [{"id": "ref-for-navigation-params-user-involvement"}, {"id": "ref-for-navigation-params-user-involvement\u2460"}, {"id": "ref-for-navigation-params-user-involvement\u2461"}, {"id": "ref-for-navigation-params-user-involvement\u2462"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": false};
+window.dfnpanelData['text-directive-allowing-mime-type'] = {"dfnID": "text-directive-allowing-mime-type", "url": "#text-directive-allowing-mime-type", "dfnText": "text directive allowing MIME type", "refSections": [{"refs": [{"id": "ref-for-text-directive-allowing-mime-type"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": false};
 window.dfnpanelData['check-if-a-text-directive-can-be-scrolled'] = {"dfnID": "check-if-a-text-directive-can-be-scrolled", "url": "#check-if-a-text-directive-can-be-scrolled", "dfnText": "check if a text directive can be scrolled", "refSections": [{"refs": [{"id": "ref-for-check-if-a-text-directive-can-be-scrolled"}, {"id": "ref-for-check-if-a-text-directive-can-be-scrolled\u2460"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": false};
 window.dfnpanelData['first-common-ancestor'] = {"dfnID": "first-common-ancestor", "url": "#first-common-ancestor", "dfnText": "first common ancestor", "refSections": [{"refs": [{"id": "ref-for-first-common-ancestor"}], "title": "3.4.1. Invoking Text Directives"}, {"refs": [{"id": "ref-for-first-common-ancestor\u2460"}], "title": "3.5.4. Restricting the Text Fragment"}], "external": false};
 window.dfnpanelData['shadow-including-parent'] = {"dfnID": "shadow-including-parent", "url": "#shadow-including-parent", "dfnText": "shadow-including parent", "refSections": [{"refs": [{"id": "ref-for-shadow-including-parent"}], "title": "3.6. Navigating to a Text Fragment"}], "external": false};


### PR DESCRIPTION
Technically, HTML fragment indication and scrolling is defined only for HTML documents. However, in practice, browsers use it for other types as well.  Safari invokes text directives for multiple text-based media types while Chrome restricts itself to text/html and text/plain, avoiding other types for security reasons (see
https://crbug.com/1270469).

Make this explicit in the spec, though perhaps this should be made explicit elsewhere (e.g. [RFC
5147](https://datatracker.ietf.org/doc/html/rfc5147) defines fragment identifiers for text/plain).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bokand/ScrollToTextFragment/pull/246.html" title="Last updated on Dec 13, 2023, 8:51 PM UTC (1db2bda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/scroll-to-text-fragment/246/05cc693...bokand:1db2bda.html" title="Last updated on Dec 13, 2023, 8:51 PM UTC (1db2bda)">Diff</a>