### PR TITLE
Update README.md to fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ view. However, all matched directives will be visually indicated on the page.
 For example:
 
 ```
-example.com#:~:text=foo&text=bar&text=bas
+example.com#:~:text=foo&text=bar&text=baz
 ```
 
 will target each of “foo”, “bar”, and “baz” and use the “foo” result as the


### PR DESCRIPTION
The example in the text refers to the word `baz` but the URL contains `bas`. This fixes the typo in the URL so that it matches what's in the text.